### PR TITLE
[14.0][IMP] cetmix_tower_server

### DIFF
--- a/cetmix_tower_server/data/ir_actions_server.xml
+++ b/cetmix_tower_server/data/ir_actions_server.xml
@@ -12,7 +12,7 @@
     </record>
 
     <record id="action_execute_cx_tower_plan" model="ir.actions.server">
-        <field name="name">Execute Flightplan</field>
+        <field name="name">Execute Flight Plan</field>
         <field name="type">ir.actions.server</field>
         <field name="model_id" ref="model_cx_tower_server" />
         <field name="binding_model_id" ref="model_cx_tower_server" />

--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -137,7 +137,7 @@
         <field name="code">cd {{ test_path }} &amp;&amp; ls -l</field>
     </record>
 
-    <!-- Flightplans -->
+    <!-- Flight Plans -->
     <record id="plan_test_1" model="cx.tower.plan">
         <field name="name">Test #1</field>
         <field name="note">Create directory and list its content</field>

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -12,7 +12,7 @@ class CxTowerPlan(models.Model):
     """A sequence of commands running based on the pre-defined flow"""
 
     _name = "cx.tower.plan"
-    _description = "Cetmix Tower Flightplan"
+    _description = "Cetmix Tower Flight Plan"
 
     active = fields.Boolean(default=True)
     name = fields.Char(required=True)
@@ -66,7 +66,7 @@ class CxTowerPlan(models.Model):
                 plan._execute_single(server, **kwargs)
 
     def _execute_single(self, server, **kwargs):
-        """Execute Flightplan
+        """Execute Flight Plan
 
         Args:
             server (cx.tower.server()): Server object
@@ -97,7 +97,7 @@ class CxTowerPlan(models.Model):
             if running_count > 0:
                 return ANOTHER_PLAN_RUNNING
 
-        # Start Flightplan log
+        # Start Flight Plan log
         plan_log_obj.start(server, self, fields.Datetime.now(), **kwargs)
 
     def _get_next_action_values(self, command_log):

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -6,12 +6,12 @@ from odoo import fields, models
 class CxTowerPlanLine(models.Model):
     _name = "cx.tower.plan.line"
     _order = "sequence, plan_id"
-    _description = "Cetmix Tower Flightplan Line"
+    _description = "Cetmix Tower Flight Plan Line"
 
     sequence = fields.Integer(default=10)
     name = fields.Char(related="command_id.name", readonly=True)
     plan_id = fields.Many2one(
-        string="Flightplan", comodel_name="cx.tower.plan", auto_join=True
+        string="Flight Plan", comodel_name="cx.tower.plan", auto_join=True
     )
     command_id = fields.Many2one(comodel_name="cx.tower.command", required=True)
     use_sudo = fields.Boolean(
@@ -29,7 +29,7 @@ class CxTowerPlanLine(models.Model):
     command_code = fields.Text(related="command_id.code", readonly=True)
 
     def _execute(self, server, plan_log_record, **kwargs):
-        """Execute command from the Flightplan line
+        """Execute command from the Flight Plan line
 
         Args:
             server (cx.tower.server()): Server object

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -5,7 +5,7 @@ from odoo import _, api, fields, models
 
 class CxTowerPlanLineAction(models.Model):
     _name = "cx.tower.plan.line.action"
-    _description = "Cetmix Tower Flightplan Line Action"
+    _description = "Cetmix Tower Flight Plan Line Action"
 
     active = fields.Boolean(default=True)
     name = fields.Char(compute="_compute_name")

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -678,7 +678,7 @@ class CxTowerServer(models.Model):
         )
         return {
             "type": "ir.actions.act_window",
-            "name": _("Execute Flightplan"),
+            "name": _("Execute Flight Plan"),
             "res_model": "cx.tower.plan.execute.wizard",
             "view_mode": "form",
             "view_type": "form",

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -70,6 +70,7 @@ class TestTowerPlan(TestTowerCommon):
         command_log = self.CommandLog.create(
             {
                 "plan_log_id": plan_log.id,
+                "server_id": self.server_test_1.id,
                 "command_id": plan_line_1.command_id.id,
                 "command_response": "Ok",
                 "command_status": 0,  # Error code

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -6,6 +6,23 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Running"
+                        bg_color="bg-info"
+                        attrs="{'invisible': [('is_running', '=', False)]}"
+                    />
+                    <widget
+                        name="web_ribbon"
+                        title="Finished"
+                        attrs="{'invisible': ['|', ('is_running', '=', True), '&amp;', ('is_running', '=', False), ('command_status', '!=', 0)]}"
+                    />
+                    <widget
+                        name="web_ribbon"
+                        title="Failed"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': ['|', ('is_running', '=', True), '&amp;', ('is_running', '=', False), ('command_status', '=', 0)]}"
+                    />
                     <group>
                         <group>
                             <field name="create_uid" />

--- a/cetmix_tower_server/views/cx_tower_plan_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_log_view.xml
@@ -6,6 +6,23 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Running"
+                        bg_color="bg-info"
+                        attrs="{'invisible': [('is_running', '=', False)]}"
+                    />
+                    <widget
+                        name="web_ribbon"
+                        title="Finished"
+                        attrs="{'invisible': ['|', ('is_running', '=', True), '&amp;', ('is_running', '=', False), ('plan_status', '!=', 0)]}"
+                    />
+                    <widget
+                        name="web_ribbon"
+                        title="Failed"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': ['|', ('is_running', '=', True), '&amp;', ('is_running', '=', False), ('plan_status', '=', 0)]}"
+                    />
                     <group>
                         <group>
                             <field name="create_uid" />
@@ -76,7 +93,7 @@
         <field name="name">cx.tower.plan.log.view.search</field>
         <field name="model">cx.tower.plan.log</field>
         <field name="arch" type="xml">
-            <search string="Search Flightplan Log">
+            <search string="Search Flight Plan Log">
                 <field name="label" />
                 <field name="server_id" />
                 <field name="plan_id" />
@@ -109,7 +126,7 @@
                         context="{'group_by': 'server_id'}"
                     />
                     <filter
-                        string="Flightplan"
+                        string="Flight Plan"
                         name="group_plan"
                         domain="[]"
                         context="{'group_by': 'plan_id'}"
@@ -132,7 +149,7 @@
     </record>
 
     <record id="action_cx_tower_plan_log" model="ir.actions.act_window">
-        <field name="name">Flightplan Log</field>
+        <field name="name">Flight Plan Log</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">cx.tower.plan.log</field>
         <field name="view_mode">tree,form</field>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -75,7 +75,7 @@
         <field name="name">cx.tower.plan.view.search</field>
         <field name="model">cx.tower.plan</field>
         <field name="arch" type="xml">
-            <search string="Search Flightplans">
+            <search string="Search Flight Plans">
                 <field name="name" />
                 <field name="server_ids" />
                 <field name="tag_ids" />
@@ -106,7 +106,7 @@
     </record>
 
     <record id="action_cx_tower_plan" model="ir.actions.act_window">
-        <field name="name">Flightplan</field>
+        <field name="name">Flight Plan</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">cx.tower.plan</field>
         <field name="view_mode">tree,form</field>

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -49,7 +49,7 @@
                         <button
                             name="action_open_plan_logs"
                             type="object"
-                            string="Flightplan Logs"
+                            string="Flight Plan Logs"
                             class="oe_stat_button"
                             icon="fa-bars"
                         />

--- a/cetmix_tower_server/views/menuitems.xml
+++ b/cetmix_tower_server/views/menuitems.xml
@@ -40,7 +40,7 @@
     />
     <menuitem
         id="menu_cx_tower_plan"
-        name="Flightplans"
+        name="Flight Plans"
         action="action_cx_tower_plan"
         parent="menu_cx_tower_command_root"
         sequence="7"
@@ -54,7 +54,7 @@
     />
     <menuitem
         id="menu_cx_tower_plan_log"
-        name="Flightplan Log"
+        name="Flight Plan Log"
         action="action_cx_tower_plan_log"
         parent="menu_cx_tower_command_root"
         sequence="72"

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
@@ -7,7 +7,7 @@ from ..models.tools import generate_random_id
 
 class CxTowerPlanExecuteWizard(models.TransientModel):
     _name = "cx.tower.plan.execute.wizard"
-    _description = "Execute Flightplan in Wizard"
+    _description = "Execute Flight Plan in Wizard"
 
     server_ids = fields.Many2many(
         "cx.tower.server",


### PR DESCRIPTION
Renamed "Flightplan" into "Flight Plan"

cx.tower.command.log: "name" and "duration" are computed stored fields now
cx.tower.command.log: "server_id" and "command_id" are required and indexed fields now
cx.tower.plan.log: "name" and "duration" are computed stored fields now
cx.tower.plan.log: "server_id" and "plan_id" are required and indexed fields now

Tests are updated to comply with these changes.

Command Log and Flight Plan Log: badges added on form view to improve UX