### PR TITLE
[14.0][REF] cetmix_tower_server

### DIFF
--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -102,20 +102,17 @@
     <!-- Variable values -->
     <record id="server_2_value_path" model="cx.tower.variable.value">
         <field name="variable_id" ref="variable_path" />
-        <field name="model">cx.tower.server</field>
-        <field name="res_id" ref="server_test_2" />
+        <field name="server_id" ref="server_test_2" />
         <field name="value_char">/opt/cetmix-tower</field>
     </record>
     <record id="server_2_value_url" model="cx.tower.variable.value">
         <field name="variable_id" ref="variable_url" />
-        <field name="model">cx.tower.server</field>
-        <field name="res_id" ref="server_test_2" />
+        <field name="server_id" ref="server_test_2" />
         <field name="value_char">https://cetmix.com</field>
     </record>
     <record id="server_2_value_branch" model="cx.tower.variable.value">
         <field name="variable_id" ref="variable_branch" />
-        <field name="model">cx.tower.server</field>
-        <field name="res_id" ref="server_test_2" />
+        <field name="server_id" ref="server_test_2" />
         <field name="value_char">staging</field>
     </record>
     <record id="global_value_branch" model="cx.tower.variable.value">
@@ -162,7 +159,7 @@
     <record id="plan_test_1_line_1_action_2" model="cx.tower.plan.line.action">
         <field name="line_id" ref="plan_test_1_line_1" />
         <field name="sequence">2</field>
-        <field name="condition">></field>
+        <field name="condition">&gt;</field>
         <field name="value_char">0</field>
         <field name="action">ec</field>
         <field name="custom_exit_code">255</field>
@@ -185,7 +182,7 @@
     <record id="plan_test_1_line_2_action_2" model="cx.tower.plan.line.action">
         <field name="line_id" ref="plan_test_1_line_2" />
         <field name="sequence">2</field>
-        <field name="condition">>=</field>
+        <field name="condition">&gt;=</field>
         <field name="value_char">3</field>
         <field name="action">n</field>
     </record>

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -244,6 +244,10 @@ class CxTowerServer(models.Model):
         selection=[("n", "Without password"), ("p", "With password")],
         help="Run commands using 'sudo'",
     )
+    # ---- Variables
+    variable_value_ids = fields.One2many(
+        inverse_name="server_id"  # Other field properties are defined in mixin
+    )
 
     # ---- Keys
     secret_ids = fields.One2many(

--- a/cetmix_tower_server/models/cx_tower_variable_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_variable_mixin.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class TowerValueMixin(models.AbstractModel):
@@ -14,80 +14,9 @@ class TowerValueMixin(models.AbstractModel):
     variable_value_ids = fields.One2many(
         string="Variable Values",
         comodel_name="cx.tower.variable.value",
-        compute="_compute_variable_value_ids",
-        inverse="_inverse_variable_value_ids",
+        auto_join=True,
         help="Variable values for selected record",
     )
-
-    def _compute_variable_value_ids(self):
-        """Compute variable values"""
-        # Pre-fetch all values to avoid multiple queries
-        values = self.env["cx.tower.variable.value"].search(
-            [("model", "=", self._name), ("res_id", "in", self.ids)]
-        )
-        for rec in self:
-            rec.variable_value_ids = values.filtered(
-                lambda v, rec=rec: v.res_id == rec.id
-            )
-
-    def _inverse_variable_value_ids(self):
-        """Store variable values for selected record"""
-        current_values = self.env["cx.tower.variable.value"].search(
-            [
-                ("model", "=", self._name),
-                ("res_id", "in", self.ids),
-            ]
-        )
-        new_vals = []
-
-        # All values are deleted
-        if not self.variable_value_ids and current_values:
-            current_values.unlink()
-        elif not current_values:
-            # Store new values only
-            new_vals = [
-                {
-                    "model": self._name,
-                    "res_id": self.id,
-                    "variable_id": line.variable_id.id,
-                    "value_char": line.value_char,
-                }
-                for line in self.variable_value_ids
-            ]
-        else:
-            # Store new values
-            new_vals = [
-                {
-                    "model": self._name,
-                    "res_id": self.id,
-                    "variable_id": line.variable_id.id,
-                    "value_char": line.value_char,
-                }
-                for line in self.variable_value_ids
-                if line.id not in current_values.ids
-            ]
-            vals_to_delete = current_values.filtered(
-                lambda v: v.id not in self.variable_value_ids.ids
-            )
-            if vals_to_delete:
-                vals_to_delete.unlink()
-
-        # Create new variable values
-        if new_vals:
-            self.env["cx.tower.variable.value"].create(new_vals)
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        # Force field recompute on creation
-        res = super().create(vals_list)
-        res.invalidate_cache(fnames=["variable_value_ids"], ids=res.ids)
-        return res
-
-    def unlink(self):
-        # Unlink variable values that belong to deleted records
-        variable_value_ids = self.variable_value_ids
-        super().unlink()
-        variable_value_ids.sudo().unlink()
 
     def get_variable_values(self, variable_names):
         """Get variable values for selected records
@@ -100,40 +29,29 @@ class TowerValueMixin(models.AbstractModel):
         """
         res = {}
 
+        # Get global values first
         if variable_names:
-            # Get fallback values
             global_values = self.get_global_variable_values(variable_names)
 
-            # In onchange some computed fields of the related models
-            #  may be not initialized yet.
-            # For this we get data directly
-            values = self.env["cx.tower.variable.value"].search(
-                [
-                    ("model", "=", self._name),
-                    ("res_id", "in", self.ids),
-                    ("variable_name", "in", variable_names),
-                ]
-            )
-            if values:
-                for rec in self:
-                    res_vars = global_values.get(
-                        rec.id, {}
-                    )  # set global values as defaults
-                    for variable_name in variable_names:
-                        value = values.filtered(
-                            lambda v, rec=rec, variable_name=variable_name: v.res_id
-                            == rec.ids[0]  # id might be not be valid in onchange
-                            and v.variable_name == variable_name
-                        )
-                        if value:
-                            res_vars.update({variable_name: value.value_char})
+            # Get record wise values
+            for rec in self:
+                res_vars = global_values.get(
+                    rec.id, {}
+                )  # set global values as defaults
+                for variable_name in variable_names:
+                    value = rec.variable_value_ids.filtered(
+                        lambda v, variable_name=variable_name: v.variable_name
+                        == variable_name
+                    )
+                    if value:
+                        res_vars.update({variable_name: value.value_char})
 
-                    res.update({rec.id: res_vars})
-            else:
-                res = global_values
-        # Render templates in values
-        for key in res:
-            self._render_variable_values(res[key])
+                res.update({rec.id: res_vars})
+
+            # Render templates in values
+            for variables in res.values():
+                self._render_variable_values(variables)
+
         return res
 
     def get_global_variable_values(self, variable_names):
@@ -175,7 +93,7 @@ class TowerValueMixin(models.AbstractModel):
             domain
         """
         domain = [
-            ("model", "=", False),
+            ("is_global", "=", True),
             ("variable_name", "in", variable_names),
         ]
         return domain

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class TowerVariableValue(models.Model):
@@ -11,59 +12,124 @@ class TowerVariableValue(models.Model):
 
     variable_id = fields.Many2one(string="Variable", comodel_name="cx.tower.variable")
     variable_name = fields.Char(related="variable_id.name", store=True, index=True)
-    model = fields.Char(string="Related Model", index=True)
-    res_id = fields.Integer(string="Record ID")
-    record_ref = fields.Reference(
-        string="Record",
-        selection="_referable_models",
-        compute="_compute_record_ref",
-        inverse="_inverse_record_ref",
-    )
     is_global = fields.Boolean(
-        string="Global", compute="_compute_is_global", inverse="_inverse_is_global"
+        string="Global",
+        compute="_compute_is_global",
+        inverse="_inverse_is_global",
+        store=True,
     )
+
     value_char = fields.Char(string="Value", required=True)
     note = fields.Text(related="variable_id.note", readonly=True)
+
+    # Direct model relations.
+    # Following functions should be updated when a new m2o field is added:
+    #   -  `_used_in_models()`
+    #   -  `_compute_is_global()`: add you field to 'depends'
+    # Define a `unique` constraint for new model too.
+    server_id = fields.Many2one(
+        comodel_name="cx.tower.server", index=True, ondelete="cascade"
+    )
 
     _sql_constraints = [
         (
             "tower_variable_value_uniq",
-            "unique (variable_id,model,res_id)",
+            "unique (variable_id,server_id,is_global)",
             "Variable can be declared only once for the same record!",
         )
     ]
 
-    def _compute_is_global(self):
-        """If variable is global"""
+    @api.constrains("is_global", "value_char")
+    def _constraint_global_unique(self):
+        """Ensure that there is only one global value exist for the same variable
+
+        Hint to devs:
+            `unique nulls not distinct (variable_id,server_id,global_id)`
+            can be used instead in PG 15.0+
+        """
         for rec in self:
-            if rec.model:
-                rec.is_global = False
-            else:
-                rec.is_global = True
+            if rec.is_global:
+                val_count = self.search_count(
+                    [("variable_id", "=", rec.variable_id.id), ("is_global", "=", True)]
+                )
+                if val_count > 1:
+                    # NB: there is a value check in tests for this message.
+                    # Update `test_variable_value_toggle_global`
+                    # if you modify this message in your code.
+                    raise ValidationError(
+                        _(
+                            "Only one global value can be defined"
+                            " for variable '%(var)s'",
+                            var=rec.variable_id.name,
+                        )
+                    )
+
+    def _used_in_models(self):
+        """Returns information about models which use this mixin.
+
+        Returns:
+            dict(): of the following format:
+                {"model.name": ("m2o_field_name", "model_description")}
+            Eg:
+                {"my.custom.model": ("much_model_id", "Much Model")}
+        """
+        return {"cx.tower.server": ("server_id", "Server")}
+
+    def _check_is_global(self):
+        """
+        This is a helper function used to define
+         which variables are considered 'Global'
+        Override it to implement your custom logic.
+
+        Returns:
+            bool:  True if global else False
+        """
+
+        self.ensure_one()
+        is_global = True
+
+        # Get m2o field values for all models that use variables.
+        # If none of them is set such value is considered 'global'.
+        for related_model_info in self._used_in_models().values():
+            m2o_field = related_model_info[0]
+            if self[m2o_field]:
+                is_global = False
+                break
+        return is_global
+
+    @api.depends("server_id")
+    def _compute_is_global(self):
+        """
+        If variable considered `global` when it's not linked to any record.
+        """
+        for rec in self:
+            rec.is_global = rec._check_is_global()
 
     def _inverse_is_global(self):
-        if self.is_global:
-            self.update({"model": None, "res_id": None})
+        """Triggered when `is_global` is updated"""
+        global_values = self.filtered("is_global")
+        if global_values:
+            values_to_set = {}
 
-    @api.model
-    def _referable_models(self):
-        """Models that can have variable values"""
-        return [("cx.tower.server", "Server")]
+            # Set m2o fields related to variable using models to 'False'
+            for related_model_info in self._used_in_models().values():
+                m2o_field = related_model_info[0]
+                values_to_set.update({m2o_field: False})
+            global_values.write(values_to_set)
 
-    @api.depends("model", "res_id")
-    def _compute_record_ref(self):
-        """Compose record reference"""
-        for rec in self:
-            if rec.model and rec.res_id:
-                res = self.env[rec.model].sudo().search([("id", "=", rec.res_id)])
-                if res:
-                    rec.record_ref = res
-                else:
-                    rec.record_ref = None
-            else:
-                rec.record_ref = None
-
-    def _inverse_record_ref(self):
-        """Set model and res id based on reference"""
-        if self.record_ref:
-            self.write({"model": self.record_ref._name, "res_id": self.record_ref.id})
+        # Check if we are trying to remove 'global' from value
+        #  that doesn't belong to any record.
+        record_related_values = self - global_values
+        for record in record_related_values:
+            if record._check_is_global():
+                # NB: there is a value check in tests for this message.
+                # Update `test_variable_value_toggle_global` if you modify this message.
+                raise ValidationError(
+                    _(
+                        "Cannot change 'global' status for "
+                        "'%(var)s' with value '%(val)s'."
+                        "\nTry to assigns it to a record instead.",
+                        var=record.variable_id.name,
+                        val=record.value_char,
+                    )
+                )

--- a/cetmix_tower_server/views/cx_tower_variable_value_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_value_view.xml
@@ -5,11 +5,10 @@
         <field name="name">cx.tower.variable.value.view.tree</field>
         <field name="model">cx.tower.variable.value</field>
         <field name="arch" type="xml">
-            <tree editable="top" decoration-bf="model==False">
-                <field name="variable_id" invisible="0" readonly="1" />
-                <field name="model" invisible="1" />
+            <tree editable="top" decoration-bf="is_global==True">
+                <field name="variable_id" />
                 <field name="is_global" widget="boolean_toggle" />
-                <field name="record_ref" />
+                <field name="server_id" />
                 <field name="value_char" />
             </tree>
         </field>
@@ -22,20 +21,16 @@
             <search string="Search Values">
                 <field name="variable_id" string="Variable" />
                 <field name="value_char" string="Value" />
-                <filter string="Local" name="local" domain="[('model', '!=', False)]" />
+                <filter
+                    string="Local"
+                    name="local"
+                    domain="[('is_global', '=', False)]"
+                />
                 <filter
                     string="Global"
                     name="global"
-                    domain="[('model', '=', False)]"
+                    domain="[('is_global', '=', True)]"
                 />
-                <group expand="0" string="Group By">
-                    <filter
-                        string="Model"
-                        name="group_by_model"
-                        domain="[]"
-                        context="{'group_by': 'model'}"
-                    />
-                </group>
              </search>
         </field>
     </record>

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -29,23 +29,23 @@
                             <field name="note" />
                         </group>
                         <field name="value_ids">
-                            <tree editable="top" decoration-bf="model==False">
+                            <tree editable="top" decoration-bf="is_global==True">
                                 <field name="variable_id" invisible="1" />
-                                <field name="model" invisible="1" />
+                                <field name="server_id" invisible="1" />
                                 <field name="is_global" widget="boolean_toggle" />
-                                <field name="record_ref" />
+                                <field name="server_id" />
                                 <field name="value_char" />
                             </tree>
                             <form>
                                 <group>
-                                    <field name="model" invisible="1" />
+                                    <field name="server_id" invisible="1" />
                                     <field
                                         name="is_global"
-                                        attrs="{'invisible':[('model', '!=', False)]}"
+                                        attrs="{'invisible':[('is_global', '=', False)]}"
                                     />
                                     <field
-                                        name="record_ref"
-                                        attrs="{'invisible':[('model', '=', False)]}"
+                                        name="server_id"
+                                        attrs="{'invisible':[('is_global', '=', True)]}"
                                     />
                                     <field name="value_char" />
                                 </group>


### PR DESCRIPTION
Refactoring the way variable values are connected with records.

Before
------

`model` and `res_id` field were used to allow flexible connection of variable values to any model that inherits a mixin. This allowed greater flexibility however caused excessive complications especially with access rules. However potential number of such models is limited which makes such approach an overkill.

Now
---
Each model relation adds its own m2o field to `cx.tower.variable.value` model. Also you need to add `variable_value_ids` field explicitly when inheriting from `cx.tower.variable.mixin` to add the `inverse_name` parameter. Currently only `cx.tower.server` uses variables so `server_id` field is added.