### PR TITLE
[14.0][IMP] add  add variable values access rules

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -21,6 +21,7 @@
         "security/cetmix_tower_server_groups.xml",
         "security/cx_tower_server_security.xml",
         "security/cx_tower_command_security.xml",
+        "security/cx_tower_variable_value_security.xml",
         "security/ir.model.access.csv",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",

--- a/cetmix_tower_server/security/cx_tower_variable_value_security.xml
+++ b/cetmix_tower_server/security/cx_tower_variable_value_security.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="cx_tower_variable_value_rule_group_manager_access" model="ir.rule">
+        <field name="name">Tower variable value: manager access rule</field>
+        <field name="model_id" ref="model_cx_tower_variable_value" />
+        <field name="domain_force">['|', ('is_global', '=', True),
+            ('server_id.message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field
+            name="groups"
+            eval="[(4, ref('cetmix_tower_server.group_user')), (4, ref('cetmix_tower_server.group_manager'))]"
+        />
+
+    </record>
+
+
+    <record id="cx_tower_variable_value_rule_group_root_access" model="ir.rule">
+        <field name="name">Tower variable value: root access rule</field>
+        <field name="model_id" ref="model_cx_tower_variable_value" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('cetmix_tower_server.group_root'))]" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
Variable Access Rights

Users should see only variable values that are either global or related to their server. 

They shouldn’t be able to view local variables from another servers.

Rights to read and write variables will not be modified for now.