### PR TITLE
[14.0][IMP] cetmix_tower_server

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -401,7 +401,7 @@ class CxTowerServer(models.Model):
         Returns:
             Char: SSH command
         """
-        command = "uname -ar"
+        command = "whoami"
         return command
 
     def _connect(self, raise_on_error=True):
@@ -440,7 +440,7 @@ class CxTowerServer(models.Model):
             raise ValidationError(
                 _(
                     "Cannot execute command\n. CODE: {}. RESULT: {}. ERROR: {}".format(
-                        status, response, ", ".joint(error)
+                        status, response, ", ".join(error)
                     )
                 )
             )

--- a/cetmix_tower_server/tests/test_file.py
+++ b/cetmix_tower_server/tests/test_file.py
@@ -32,7 +32,7 @@ class TestTowerCommand(TestTowerCommon):
 
         with patch.object(cx_tower_server_obj, "upload_file", upload_file):
             file.action_push_to_server()
-            self.assertEqual(file.sync_code, "ok")
+            self.assertEqual(file.server_response, "ok")
 
     def test_download_file(self):
         """
@@ -85,7 +85,7 @@ class TestTowerCommand(TestTowerCommon):
 
         with patch.object(cx_tower_server_obj, "upload_file", upload_file):
             file.action_push_to_server()
-            self.assertEqual(file.sync_code, "ok")
+            self.assertEqual(file.server_response, "ok")
 
         def download_file(this, remote_path):
             if remote_path == "/var/tmp/test.txt":

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -170,17 +170,17 @@
                 <filter
                     string="Synced"
                     name="filter_is_synced"
-                    domain="[('sync_code', '=', 'ok')]"
+                    domain="[('server_response', '=', 'ok')]"
                 />
                 <filter
                     string="No Synced"
                     name="filter_is_no_synced"
-                    domain="[('sync_code', '=', False)]"
+                    domain="[('server_response', '=', False)]"
                 />
                 <filter
                     string="Sync Error"
                     name="filter_is_error_synced"
-                    domain="[('sync_code', 'not in', ['ok', False])]"
+                    domain="[('server_response', 'not in', ['ok', False])]"
                 />
                 <group expand="0" string="Group By">
                     <filter


### PR DESCRIPTION
cx.tower.file
-------------
Reverted to the `onchange` method for file fields. Because compute method doesn't work well for file auto-update mechanism.

cx.tower.server
---------------
* Fixed error message composition string.
* `whoami` is now used as connection test command.

Check individual commit messages for more details.