### PR TITLE
[14.0][IMP] cetmix_tower_server: 'sudo' improvements

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -66,16 +66,16 @@ class SSH(object):
         Returns:
             Char: password ready to be used for connection parameters
         """
-        ssh_key = RSAKey.from_private_key(io.StringIO(self.ssh_key))
+        ssh_key = RSAKey.from_private_key(io.StringIO(self.ssh_key))  # type: ignore
         return ssh_key
 
     def _connect(self):
         """
         Connect to remote host
         """
-        self._ssh = SSHClient()
+        self._ssh = SSHClient()  # type: ignore
         self._ssh.load_system_host_keys()
-        self._ssh.set_missing_host_key_policy(AutoAddPolicy())
+        self._ssh.set_missing_host_key_policy(AutoAddPolicy())  # type: ignore
         kwargs = {
             "hostname": self.host,
             "port": self.port,
@@ -110,7 +110,7 @@ class SSH(object):
         """
         Open SFTP connection to remote host.
         """
-        self._sftp = SFTPClient.from_transport(self.connection.get_transport())
+        self._sftp = SFTPClient.from_transport(self.connection.get_transport())  # type: ignore
         return self._sftp
 
     def disconnect(self):
@@ -138,18 +138,27 @@ class SSH(object):
         Returns:
             status, response, error
         """
-        # TODO: check this
+        # Check this
         # https://stackoverflow.com/questions/22587855/running-sudo-command-with-paramiko
-        if sudo and self.username != "root":
-            command = "sudo -S -p '' %s" % command
 
-        stdin, stdout, stderr = self.connection.exec_command(command)
-        if sudo == "p":
+        sudo_with_password = sudo == "p" and self.username != "root"
+        if sudo_with_password:
+            # Return error if password is not set
             if not self.password:
                 error_message = [_("sudo password was not provided!")]
                 return 255, [], error_message
-            stdin.write(self.password + "\n")
+
+            # prepend command with `sudo`
+            command = f"sudo -S -p '' {command}"
+
+        stdin, stdout, stderr = self.connection.exec_command(command)
+
+        # Send password to stdin
+        if sudo_with_password:
+            stdin.write(self.password + "\n")  # type: ignore
             stdin.flush()
+            # TODO: add password error check
+
         status = stdout.channel.recv_exit_status()
         response = stdout.readlines()
         error = stderr.readlines()
@@ -413,7 +422,7 @@ class CxTowerServer(models.Model):
         Returns:
             Char: SSH command
         """
-        command = "whoami"
+        command = "uname -a"
         return command
 
     def _connect(self, raise_on_error=True):
@@ -455,7 +464,7 @@ class CxTowerServer(models.Model):
                     "RESULT: %(res)s. ERROR: %(err)s",
                     status=status,
                     res=response,
-                    err=", ".join(error),
+                    err=", ".join(error),  # type: ignore
                 )
             )
 
@@ -483,7 +492,7 @@ class CxTowerServer(models.Model):
             raise ValidationError(
                 _(
                     "Cannot execute command\n. CODE: %(status)s. ERROR: %(err)s",
-                    err=", ".join(err),
+                    err=", ".join(err),  # type: ignore
                     status=st,
                 )
             )
@@ -493,7 +502,9 @@ class CxTowerServer(models.Model):
             "tag": "display_notification",
             "params": {
                 "title": _("Success"),
-                "message": _("Connection test passed! \n%(res)s", res=response),
+                "message": _(
+                    "Connection test passed! \n%(res)s", res=response[0].rstrip()
+                ),
                 "sticky": False,
             },
         }
@@ -659,14 +670,19 @@ class CxTowerServer(models.Model):
                 status = []
                 response = []
                 error = []
-                for cmd in self._prepare_command_for_sudo(command):
+                commands = self._prepare_command_for_sudo(command, mode=sudo)
+
+                if isinstance(commands, str):
+                    return client.exec_command(commands, sudo=sudo)
+
+                for cmd in commands:
                     st, resp, err = client.exec_command(cmd, sudo=sudo)
                     status.append(st)
                     response += resp
                     error += err
                 return self._parse_sudo_command_results(status, response, error)
             else:
-                result = client.exec_command(command, sudo=sudo)
+                return client.exec_command(command)
         except Exception as e:
             if raise_on_error:
                 raise ValidationError(
@@ -674,9 +690,8 @@ class CxTowerServer(models.Model):
                 ) from e
             else:
                 return -1, [], [e]
-        return result
 
-    def _prepare_command_for_sudo(self, command):
+    def _prepare_command_for_sudo(self, command, mode=None):
         """Prepare command to be executed with sudo
         IMPORTANT:
         Commands executed with sudo will be run separately one after another
@@ -688,20 +703,32 @@ class CxTowerServer(models.Model):
 
         Args:
             command (text): initial command
+            mode (str, optional): sudo mode (n, p)
+                n - sudo without password
+                p - sudo with password
 
         Returns:
-            command (list): command splitted into separate commands
+            command (list|str): command splitted into separate commands
+                (for sudo with password mode ('p')) or composed command
+                from its parts for sudo without password mode ('n'))
 
         """
         # Detect command separator
+        # TODO: refactor this method to allow mix of different separators in one string
         if "&&" in command:
             separator = "&&"
         elif ";" in command:
             separator = ";"
         else:
+            if mode == "n":
+                return f"sudo -S -p '' {command}"
             return [command]
 
-        return command.replace("\\", "").replace("\n", "").split(separator)
+        result = command.replace("\\", "").replace("\n", "").split(separator)
+        result = [cmd.strip() for cmd in result]
+        if mode == "n":
+            result = f" {separator} ".join([f"sudo -S -p '' {cmd}" for cmd in result])
+        return result
 
     def _parse_sudo_command_results(self, status_list, response_list, error_list):
         """Parse results of the command executed with sudo

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -5,6 +5,63 @@ from .common import TestTowerCommon
 
 
 class TestTowerCommand(TestTowerCommon):
+    def test_sudo_command_prepare_method(self):
+        """Test sudo command preparing in different modes"""
+
+        server = self.server_test_1
+
+        single_command = "ls -a /tmp"
+        multiple_commands = "ls -a /tmp && mkdir /tmp/test"
+
+        sudo_mode = "p"
+        # Prepare single command for sudo with password
+        cmd = server._prepare_command_for_sudo(single_command, sudo_mode)
+        self.assertEqual(
+            cmd,
+            [single_command],
+            msg=(
+                "Single command for sudo with password should be "
+                "equal to list with the original command"
+                "as an only element"
+            ),
+        )
+        # Prepare multiple commands for sudo with password
+        cmd = server._prepare_command_for_sudo(multiple_commands, sudo_mode)
+        self.assertEqual(
+            cmd,
+            [
+                "ls -a /tmp",
+                "mkdir /tmp/test",
+            ],
+            msg=(
+                "Multiple commands with sudo with password should be "
+                "a list of separated commands from original line"
+            ),
+        )
+
+        sudo_mode = "n"
+        # Prepare single command for sudo without password
+        cmd = server._prepare_command_for_sudo(single_command, sudo_mode)
+        self.assertEqual(
+            cmd,
+            f"sudo -S -p '' {single_command}",
+            msg=(
+                "Single command with sudo without password should be "
+                "equal to the original command prefixed with \"sudo -S -p ''\""
+            ),
+        )
+        # Prepare multiple commands for sudo without password
+        cmd = server._prepare_command_for_sudo(multiple_commands, sudo_mode)
+        self.assertEqual(
+            cmd,
+            "sudo -S -p '' ls -a /tmp && sudo -S -p '' mkdir /tmp/test",
+            msg=(
+                "Multiple commands with sudo with password should be "
+                "a re-joined string from list of separated original "
+                "each prefixed with \"sudo -S -p ''\""
+            ),
+        )
+
     def test_render_code(self):
         """Test code template rendering"""
 


### PR DESCRIPTION
Before this commit
------------------
Commands that use sudo without password were split and executed one by one same ways as commands with sudo with password.

After this commit
-----------------
Commands that are using sudo without password are rejoined back and executed as a single command. This allows to use such commands as "chdir" without loosing their context.

Supersedes #52 