### PR TITLE
[14.0][IMP] cetmix_tower_server SSH command execution refactoring

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -317,18 +317,36 @@ Command is a shell command that is executed on remote server. To create
 a new command go to ``Cetmix Tower/Commands/Commands`` click ``Create``
 and put values in the fields:
 
--  **Name**: Command readable name
+-  **Name**: Command readable name.
+
 -  **Allow Parallel Run**: If disabled only one copy of this command can
    be run on the same server at the same time. Otherwise the same
    command can be run in parallel.
--  **Note**: Comments or user notes
+
+-  **Note**: Comments or user notes.
+
 -  **Servers**: List of servers this command can be run on. Leave this
    field blank to make the command available to all servers.
+
 -  **OSes**: List of operating systems this command is available. Leave
    this field blank to make the command available for all OSes.
--  **Tags**: Make usage as search more convenient
+
+-  **Tags**: Make usage as search more convenient.
+
+-  **Action**: Action executed by the command. Possible options:
+
+   -  ``Execute shell command``: Execute a shell command using ssh
+      connection on remote server.
+   -  ``Push file``: Cerate or update a file using selected file
+      template and push it to remote server. If the file already exists
+      on server it will be overwritten.
+
 -  **Code**: Command code as it will be executed by remote shell. This
    field supports `Variables <#configure-variables>`__.
+
+-  **File Template**: File template that will be used to create or
+   update file. Check `File Templates <#file-templates>`__ for more
+   details.
 
 Configure a Flight Plan
 -----------------------
@@ -343,39 +361,39 @@ values in the fields:
    the flight plan execution. Possible options:
 
    -  ``Exit with command code``. Will terminate the flight plan
-      execution and return an exit code of the failed command
+      execution and return an exit code of the failed command.
    -  ``Exit with custom code``. Will terminate the flight plan
       execution and return the custom code configured in the field next
-      to this one
-   -  ``Run next command``. Will continue flight plan execution
+      to this one.
+   -  ``Run next command``. Will continue flight plan execution.
 
--  **Note**: Comments or user notes
+-  **Note**: Comments or user notes.
 -  **Servers**: List of servers this command can be run on. Leave this
    field blank to make the command available to all servers.
--  **Tags**: Make usage as search more convenient
+-  **Tags**: Make usage as search more convenient.
 -  **Code**: List of commands to execute. Each of the commands has the
    following fields:
 
    -  **Sequence**: Order this command is executed. Lower value = higher
-      priority
-   -  **Command**: `Command <#configure-a-command>`__ to be executed
-   -  **Use Sudo**: Use ``sudo`` if required to run this command
+      priority.
+   -  **Command**: `Command <#configure-a-command>`__ to be executed.
+   -  **Use Sudo**: Use ``sudo`` if required to run this command.
    -  **Actions**: List of condition based actions to be triggered after
       the command is executed. Each of the actions has the following
       fields:
 
       -  **Sequence**: Order this actions is triggered. Lower value =
-         higher priority
-      -  **Condition**: Uses command exit code
+         higher priority.
+      -  **Condition**: Uses command exit code.
       -  **Action**: Action to execute if condition is met. Possible
          options:
 
          -  ``Exit with command code``. Will terminate the flight plan
-            execution and return an exit code of the failed command
+            execution and return an exit code of the failed command.
          -  ``Exit with custom code``. Will terminate the flight plan
             execution and return the custom code configured in the field
-            next to this one
-         -  ``Run next command``. Will continue flight plan execution
+            next to this one.
+         -  ``Run next command``. Will continue flight plan execution.
 
 Usage
 =====
@@ -447,7 +465,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -462,6 +480,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/models/constants.py
+++ b/cetmix_tower_server/models/constants.py
@@ -2,13 +2,16 @@
 # This file is used to define commonly used constants
 # ***
 
-# Returned when trying to execute another instance of a flightplan on the same server
-# and this flightplan doesn't allow parallel run
-ANOTHER_PLAN_RUNNING = -7
-
 # Returned when trying to execute another instance of a command on the same server
 # and this command doesn't allow parallel run
 ANOTHER_COMMAND_RUNNING = -5
+
+# Returned when no runner is found for command action
+NO_COMMAND_RUNNER_FOUND = -6
+
+# Returned when trying to execute another instance of a flightplan on the same server
+# and this flightplan doesn't allow parallel run
+ANOTHER_PLAN_RUNNING = -7
 
 # Returned when a plan tries to parse a command log record which doesn't have
 # a valid plan reference in it

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -9,6 +9,17 @@ class CxTowerCommand(models.Model):
     _description = "Cetmix Tower Command"
     _order = "name"
 
+    def _selection_action(self):
+        """Actions that can be run by a command.
+
+        Returns:
+            List of tuples: available options.
+        """
+        return [
+            ("ssh_command", "SSH command"),
+            ("file_using_template", "Push file using template"),
+        ]
+
     active = fields.Boolean(default=True)
     name = fields.Char()
     allow_parallel_run = fields.Boolean(
@@ -53,12 +64,21 @@ class CxTowerCommand(models.Model):
         groups="cetmix_tower_server.group_root,cetmix_tower_server.group_manager",
         required=True,
     )
+    action = fields.Selection(
+        selection=lambda self: self._selection_action(),
+        required=True,
+        default=lambda self: self._selection_action()[0][0],
+    )
+    file_template_id = fields.Many2one(
+        comodel_name="cx.tower.file.template",
+        help="This template will be used to create or update the pushed file",
+    )
 
     @api.returns("self", lambda value: value.id)
     def copy(self, default=None):
         default = default or {}
         default["name"] = _("%(cmd)s (copy)", cmd=self.name)
-        return super(CxTowerCommand, self).copy(default=default)
+        return super().copy(default=default)
 
     def name_get(self):
         # Add 'command_show_server_names' context key

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -90,22 +90,6 @@ class CxTowerCommandLog(models.Model):
         """
         now = fields.Datetime.now()
 
-        # Compose response message
-        command_response = ""
-        if response:
-            response_vals = [r for r in response]
-            command_response = (
-                "".join(response_vals) if len(response_vals) > 1 else response_vals[0]
-            )
-
-        # Compose error message
-        command_error = ""
-        if error:
-            error_vals = [e for e in error]
-            command_error = (
-                "".join(error_vals) if len(error_vals) > 1 else error_vals[0]
-            )
-
         for rec in self.sudo():
             # Duration
             date_finish = finish_date if finish_date else now
@@ -114,8 +98,8 @@ class CxTowerCommandLog(models.Model):
                 "is_running": False,
                 "finish_date": date_finish,
                 "command_status": -1 if status is None else status,
-                "command_response": command_response,
-                "command_error": command_error,
+                "command_response": response,
+                "command_error": error,
             }
             # Apply kwargs and write
             vals.update(kwargs)
@@ -150,22 +134,6 @@ class CxTowerCommandLog(models.Model):
             (cx.tower.command.log()) new command log record
         """
 
-        # Compose response message
-        command_response = ""
-        if response:
-            response_vals = [r for r in response]
-            command_response = (
-                "".join(response_vals) if len(response_vals) > 1 else response_vals[0]
-            )
-
-        # Compose error message
-        command_error = ""
-        if error:
-            error_vals = [e for e in error]
-            command_error = (
-                "".join(error_vals) if len(error_vals) > 1 else error_vals[0]
-            )
-
         vals = kwargs or {}
         vals.update(
             {
@@ -174,8 +142,8 @@ class CxTowerCommandLog(models.Model):
                 "start_date": start_date,
                 "finish_date": finish_date,
                 "command_status": status,
-                "command_response": command_response,
-                "command_error": command_error,
+                "command_response": response,
+                "command_error": error,
             }
         )
         rec = self.sudo().create(vals)

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -8,6 +8,7 @@ class CxTowerPlanLine(models.Model):
     _order = "sequence, plan_id"
     _description = "Cetmix Tower Flight Plan Line"
 
+    active = fields.Boolean(related="plan_id.active", readonly=True)
     sequence = fields.Integer(default=10)
     name = fields.Char(related="command_id.name", readonly=True)
     plan_id = fields.Many2one(
@@ -37,7 +38,7 @@ class CxTowerPlanLine(models.Model):
             kwargs (dict): Optional arguments
                 Following are supported but not limited to:
                     - "plan_log": {values passed to flightplan logger}
-                    - "log": {values passed to logger}
+                    - "log": {values passed to command logger}
                     - "key": {values passed to key parser}
 
         """
@@ -54,4 +55,4 @@ class CxTowerPlanLine(models.Model):
         # Set 'sudo' value
         use_sudo = self.use_sudo and server.use_sudo
 
-        server.execute_commands(self.command_id, use_sudo, **kwargs)
+        server.execute_command(self.command_id, use_sudo, **kwargs)

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -151,13 +151,18 @@ To create a new file template go to `Cetmix Tower/Files/Templates` click `Create
 Command is a shell command that is executed on remote server.
 To create a new command go to `Cetmix Tower/Commands/Commands` click `Create` and put values in the fields:
 
-- **Name**: Command readable name
+- **Name**: Command readable name.
 - **Allow Parallel Run**: If disabled only one copy of this command can be run on the same server at the same time. Otherwise the same command can be run in parallel.
-- **Note**: Comments or user notes
+- **Note**: Comments or user notes.
 - **Servers**: List of servers this command can be run on. Leave this field blank to make the command available to all servers.
 - **OSes**: List of operating systems this command is available. Leave this field blank to make the command available for all OSes.
-- **Tags**: Make usage as search more convenient
+- **Tags**: Make usage as search more convenient.
+- **Action**: Action executed by the command. Possible options:
+  - `Execute shell command`: Execute a shell command using ssh connection on remote server.
+  - `Push file`: Cerate or update a file using selected file template and push it to remote server. If the file already exists on server it will be overwritten.
+
 - **Code**: Command code as it will be executed by remote shell. This field supports [Variables](#configure-variables).
+- **File Template**: File template that will be used to create or update file. Check [File Templates](#file-templates) for more details.
 
 ## Configure a Flight Plan
 
@@ -166,21 +171,21 @@ To create a new flight plan go to `Cetmix Tower/Commands/Flight Plans` click `Cr
 
 - **Name**: Flight Plan name
 - **On Error**: Default action to execute when an error happens during the flight plan execution. Possible options:
-  - `Exit with command code`. Will terminate the flight plan execution and return an exit code of the failed command
-  - `Exit with custom code`. Will terminate the flight plan execution and return the custom code configured in the field next to this one
-  - `Run next command`. Will continue flight plan execution
-- **Note**: Comments or user notes
+  - `Exit with command code`. Will terminate the flight plan execution and return an exit code of the failed command.
+  - `Exit with custom code`. Will terminate the flight plan execution and return the custom code configured in the field next to this one.
+  - `Run next command`. Will continue flight plan execution.
+- **Note**: Comments or user notes.
 - **Servers**: List of servers this command can be run on. Leave this field blank to make the command available to all servers.
-- **Tags**: Make usage as search more convenient
+- **Tags**: Make usage as search more convenient.
 - **Code**: List of commands to execute. Each of the commands has the following fields:
-  - **Sequence**: Order this command is executed. Lower value = higher priority
-  - **Command**: [Command](#configure-a-command) to be executed
-  - **Use Sudo**: Use `sudo` if required to run this command
+  - **Sequence**: Order this command is executed. Lower value = higher priority.
+  - **Command**: [Command](#configure-a-command) to be executed.
+  - **Use Sudo**: Use `sudo` if required to run this command.
   - **Actions**: List of condition based actions to be triggered after the command is executed. Each of the actions has the following fields:
-    - **Sequence**: Order this actions is triggered. Lower value = higher priority
-    - **Condition**: Uses command exit code
+    - **Sequence**: Order this actions is triggered. Lower value = higher priority.
+    - **Condition**: Uses command exit code.
     - **Action**: Action to execute if condition is met. Possible options:
-      - `Exit with command code`. Will terminate the flight plan execution and return an exit code of the failed command
-      - `Exit with custom code`. Will terminate the flight plan execution and return the custom code configured in the field next to this one
-      - `Run next command`. Will continue flight plan execution
+      - `Exit with command code`. Will terminate the flight plan execution and return an exit code of the failed command.
+      - `Exit with custom code`. Will terminate the flight plan execution and return the custom code configured in the field next to this one.
+      - `Run next command`. Will continue flight plan execution.
 

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -368,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:d50668a3e59b82d6a6016864e33cc87f53fedf28cf4905146567cc44a195f4e7
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>Cetmix Tower offers a streamlined solution for managing remote servers
 via SSH directly from Odoo. This module is designed for versatility
 across different operating systems and software environments, providing
@@ -685,18 +685,29 @@ value from the <tt class="docutils literal">Template</tt> field before saving it
 a new command go to <tt class="docutils literal">Cetmix Tower/Commands/Commands</tt> click <tt class="docutils literal">Create</tt>
 and put values in the fields:</p>
 <ul class="simple">
-<li><strong>Name</strong>: Command readable name</li>
+<li><strong>Name</strong>: Command readable name.</li>
 <li><strong>Allow Parallel Run</strong>: If disabled only one copy of this command can
 be run on the same server at the same time. Otherwise the same
 command can be run in parallel.</li>
-<li><strong>Note</strong>: Comments or user notes</li>
+<li><strong>Note</strong>: Comments or user notes.</li>
 <li><strong>Servers</strong>: List of servers this command can be run on. Leave this
 field blank to make the command available to all servers.</li>
 <li><strong>OSes</strong>: List of operating systems this command is available. Leave
 this field blank to make the command available for all OSes.</li>
-<li><strong>Tags</strong>: Make usage as search more convenient</li>
+<li><strong>Tags</strong>: Make usage as search more convenient.</li>
+<li><strong>Action</strong>: Action executed by the command. Possible options:<ul>
+<li><tt class="docutils literal">Execute shell command</tt>: Execute a shell command using ssh
+connection on remote server.</li>
+<li><tt class="docutils literal">Push file</tt>: Cerate or update a file using selected file
+template and push it to remote server. If the file already exists
+on server it will be overwritten.</li>
+</ul>
+</li>
 <li><strong>Code</strong>: Command code as it will be executed by remote shell. This
 field supports <a class="reference external" href="#configure-variables">Variables</a>.</li>
+<li><strong>File Template</strong>: File template that will be used to create or
+update file. Check <a class="reference external" href="#file-templates">File Templates</a> for more
+details.</li>
 </ul>
 </div>
 <div class="section" id="configure-a-flight-plan">
@@ -710,37 +721,37 @@ values in the fields:</p>
 <li><strong>On Error</strong>: Default action to execute when an error happens during
 the flight plan execution. Possible options:<ul>
 <li><tt class="docutils literal">Exit with command code</tt>. Will terminate the flight plan
-execution and return an exit code of the failed command</li>
+execution and return an exit code of the failed command.</li>
 <li><tt class="docutils literal">Exit with custom code</tt>. Will terminate the flight plan
 execution and return the custom code configured in the field next
-to this one</li>
-<li><tt class="docutils literal">Run next command</tt>. Will continue flight plan execution</li>
+to this one.</li>
+<li><tt class="docutils literal">Run next command</tt>. Will continue flight plan execution.</li>
 </ul>
 </li>
-<li><strong>Note</strong>: Comments or user notes</li>
+<li><strong>Note</strong>: Comments or user notes.</li>
 <li><strong>Servers</strong>: List of servers this command can be run on. Leave this
 field blank to make the command available to all servers.</li>
-<li><strong>Tags</strong>: Make usage as search more convenient</li>
+<li><strong>Tags</strong>: Make usage as search more convenient.</li>
 <li><strong>Code</strong>: List of commands to execute. Each of the commands has the
 following fields:<ul>
 <li><strong>Sequence</strong>: Order this command is executed. Lower value = higher
-priority</li>
-<li><strong>Command</strong>: <a class="reference external" href="#configure-a-command">Command</a> to be executed</li>
-<li><strong>Use Sudo</strong>: Use <tt class="docutils literal">sudo</tt> if required to run this command</li>
+priority.</li>
+<li><strong>Command</strong>: <a class="reference external" href="#configure-a-command">Command</a> to be executed.</li>
+<li><strong>Use Sudo</strong>: Use <tt class="docutils literal">sudo</tt> if required to run this command.</li>
 <li><strong>Actions</strong>: List of condition based actions to be triggered after
 the command is executed. Each of the actions has the following
 fields:<ul>
 <li><strong>Sequence</strong>: Order this actions is triggered. Lower value =
-higher priority</li>
-<li><strong>Condition</strong>: Uses command exit code</li>
+higher priority.</li>
+<li><strong>Condition</strong>: Uses command exit code.</li>
 <li><strong>Action</strong>: Action to execute if condition is met. Possible
 options:<ul>
 <li><tt class="docutils literal">Exit with command code</tt>. Will terminate the flight plan
-execution and return an exit code of the failed command</li>
+execution and return an exit code of the failed command.</li>
 <li><tt class="docutils literal">Exit with custom code</tt>. Will terminate the flight plan
 execution and return the custom code configured in the field
-next to this one</li>
-<li><tt class="docutils literal">Run next command</tt>. Will continue flight plan execution</li>
+next to this one.</li>
+<li><tt class="docutils literal">Run next command</tt>. Will continue flight plan execution.</li>
 </ul>
 </li>
 </ul>
@@ -819,7 +830,7 @@ before doing that.</p>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -832,7 +843,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-22">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -179,7 +179,7 @@ class TestTowerCommon(TransactionCase):
                 if raise_on_error:
                     raise ValidationError(_("SSH execute command error"))
                 else:
-                    return -1, [], error
+                    result = self._parse_ssh_command_results(-1, [], error)
 
             command = self.env["cx.tower.key"].parse_code(
                 command, **kwargs.get("key", {})
@@ -193,20 +193,20 @@ class TestTowerCommon(TransactionCase):
                     status_list.append(status)
                     response_list += response
                     error_list += error
-                return self._parse_sudo_command_results(
+                result = self._parse_ssh_command_results(
                     status_list, response_list, error_list
                 )
             else:
-                result = status, response, error
+                result = self._parse_ssh_command_results(status, response, error)
             return result
 
         self.Server._patch_method("_connect", _connect_patch)
-        self.Server._patch_method("_execute_command", _execute_command_patch)
+        self.Server._patch_method("_execute_command_using_ssh", _execute_command_patch)
 
     def tearDown(self):
         # Remove the monkey patches
         self.Server._revert_method("_connect")
-        self.Server._revert_method("_execute_command")
+        self.Server._revert_method("_execute_command_using_ssh")
         super(TestTowerCommon, self).tearDown()
 
     def add_to_group(self, user, group_refs):

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -104,7 +104,7 @@ class TestTowerCommand(TestTowerCommon):
         custom_values = {"log": {"label": command_label}}
 
         # Execute command for Server 1
-        self.server_test_1.execute_commands(self.command_create_dir, **custom_values)
+        self.server_test_1.execute_command(self.command_create_dir, **custom_values)
 
         # Expected rendered command code
         rendered_code_expected = "cd /opt/tower && mkdir test-odoo-1"
@@ -173,7 +173,7 @@ class TestTowerCommand(TestTowerCommon):
         custom_values = {"log": {"label": command_label}}
 
         # Execute command for Server 1
-        self.server_test_1.execute_commands(command_with_keys, **custom_values)
+        self.server_test_1.execute_command(command_with_keys, **custom_values)
 
         # Expected rendered command code
         rendered_code_expected = "cd /opt/tower && mkdir #!cxtower.secret.FOLDER"

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -10,6 +10,11 @@
                     <group>
                         <group>
                             <field name="name" />
+                            <field name="action" />
+                            <field
+                                name="file_template_id"
+                                attrs="{'invisible': [('action', '!=', 'file_using_template')],'required': [('action', '=', 'file_using_template')],}"
+                            />
                             <field name="allow_parallel_run" />
                             <field name="note" />
                         </group>
@@ -31,13 +36,14 @@
                             />
                             <field name="access_level" />
                         </group>
+                        <!-- TODO: use 'ace' widget with ace mode dependent on the command language -->
+                        <field
+                            name="code"
+                            placeholder="Type shell command here..."
+                            nolabel="1"
+                            attrs="{'invisible': [('action', '!=', 'ssh_command')],'required': [('action', '=', 'ssh_command')]}"
+                        />
                     </group>
-                    <notebook>
-                        <page name="code" string="Code">
-                            <!-- TODO: use 'ace' widget with ace mode dependent on the command language -->
-                            <field name="code" nolabel="1" />
-                        </page>
-                    </notebook>
                 </sheet>
             </form>
         </field>
@@ -49,6 +55,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="action" />
                 <field
                     name="server_ids"
                     widget="many2many_tags"
@@ -91,10 +98,22 @@
                     name="filter_global"
                     domain="[('server_ids', '!=', False)]"
                 />
+                <separator />
                 <filter
                     string="Allow Parallel Run"
                     name="filter_run_parallel"
                     domain="[('allow_parallel_run', '=', True)]"
+                />
+                <separator />
+                <filter
+                    string="Run shell command"
+                    name="filter_run_command"
+                    domain="[('action', '=', 'ssh_command')]"
+                />
+                <filter
+                    string="Push file (template)"
+                    name="file_from_template"
+                    domain="[('action', '=', 'file_using_template')]"
                 />
                 <separator />
                 <filter


### PR DESCRIPTION
What's changed:

- `execute_commands` is replaced with `execute_command` that is run for a single server.
Why: we don't need to run commands in series, we have flight plans for that.
- Added support for different command action types. Currently SSH commands only are supported.
- Command type specific `runner` functions for ease of inheritance and extension.
- SSH command execution results are now parsed with a dedicated function.
- Improved `sudo` support: adjust `sudo` usage in commands based on server settings.
