### PR TITLE
[14.0] [IMP]  cetmix_tower_server: command log access

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -813,8 +813,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -974,9 +974,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -984,7 +984,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -999,6 +999,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -29,6 +29,7 @@
         "security/cx_tower_plan_line_action_security.xml",
         "security/cx_tower_plan_log_security.xml",
         "security/cx_tower_server_log_security.xml",
+        "security/cx_tower_command_log_security.xml",
         "security/cx_tower_server_template_security.xml",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -49,6 +49,11 @@ class CxTowerCommandLog(models.Model):
     is_skipped = fields.Boolean(
         readonly=True,
     )
+    access_level = fields.Selection(
+        related="command_id.access_level",
+        readonly=True,
+        store=True,
+    )
 
     # -- Flight Plan
     plan_log_id = fields.Many2one(comodel_name="cx.tower.plan.log", ondelete="cascade")

--- a/cetmix_tower_server/security/cx_tower_command_log_security.xml
+++ b/cetmix_tower_server/security/cx_tower_command_log_security.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+
+    <record id="cx_tower_command_log_rule_group_user_access" model="ir.rule">
+        <field name="name">Tower command log: user access rule</field>
+        <field name="model_id" ref="model_cx_tower_command_log" />
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
+        <field name="domain_force">[
+            "|",
+            ('create_uid', '=', user.id),
+            "&amp;",
+            ('server_id.message_partner_ids', 'in', [user.partner_id.id]),
+            ('access_level', '=', '1')]
+        </field>
+    </record>
+
+    <record id="cx_tower_command_log_rule_group_manager_access" model="ir.rule">
+        <field name="name">Tower command log: manager access rule</field>
+        <field name="model_id" ref="model_cx_tower_command_log" />
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="domain_force">[
+            "|",
+            ('create_uid', '=', user.id),
+            "&amp;",
+            ('server_id.message_partner_ids', 'in', [user.partner_id.id]),
+            ('access_level', '&lt;=', '2')]
+        </field>
+    </record>
+
+
+    <record id="cx_tower_command_log_rule_group_root_access" model="ir.rule">
+        <field name="name">Tower command log: root access rule</field>
+        <field name="model_id" ref="model_cx_tower_command_log" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('cetmix_tower_server.group_root'))]" />
+    </record>
+
+
+</odoo>

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:e059c41aedcdb5fbbe7d7ad526a449b0f06ef71ddbe63bf9cbbad8d6558c5827
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -474,7 +473,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting/Users &amp; Companies/Users</tt> and open a user whom you would like
 to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In <tt class="docutils literal">Other</tt> section find the <tt class="docutils literal">Cetmix Tower</tt> field and select one of
 the following options:</p>
 <ul class="simple">
@@ -1008,7 +1007,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1143,7 +1142,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1239,14 +1238,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
 the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
 order to refresh all logs at once. Log output will be displayed in
 the HTML field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1263,7 +1262,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1276,7 +1275,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_server_template
 from . import test_reference_mixin
 from . import test_cetmix_tower
 from . import test_update_related_variable_names
+from . import test_command_log

--- a/cetmix_tower_server/tests/test_command_log.py
+++ b/cetmix_tower_server/tests/test_command_log.py
@@ -1,0 +1,128 @@
+from odoo.exceptions import AccessError
+
+from .common import TestTowerCommon
+
+
+class TestTowerCommandlog(TestTowerCommon):
+    def test_user_access_rule(self):
+        """Test user access rule"""
+        # Create the test command
+        test_command_log = self.CommandLog.create(
+            {
+                "server_id": self.server_test_1.id,
+                "command_id": self.command_create_dir.id,
+            }
+        )
+        # Remove bob from all cxtower_server groups
+        self.remove_from_group(
+            self.user_bob,
+            [
+                "cetmix_tower_server.group_user",
+                "cetmix_tower_server.group_manager",
+                "cetmix_tower_server.group_root",
+            ],
+        )
+        # Ensure that regular user cannot access the command log
+        test_command_log_as_bob = test_command_log.with_user(self.user_bob)
+        with self.assertRaises(AccessError):
+            command_log_read_result = test_command_log_as_bob.read([])
+
+        # Add user_bob to group user
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+        # Ensure that user still doesn't have access to command log he did't create
+        with self.assertRaises(AccessError):
+            command_log_read_result = test_command_log_as_bob.read([])
+        # Add user_bob to group manager
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        # Ensure that manager doesn't have access to command belongs to server
+        #  he did't subscribed to
+        with self.assertRaises(AccessError):
+            command_log_read_result = test_command_log_as_bob.read([])
+        # Subscribe manager to server and test again
+        self.server_test_1.message_subscribe([self.user_bob.partner_id.id])
+        command_log_read_result = test_command_log_as_bob.read([])
+        self.assertEqual(
+            command_log_read_result[0]["name"],
+            test_command_log_as_bob.name,
+            "Command name should be same",
+        )
+
+        # Check if user Bob can unlink command_log entry as member of group_manager
+        with self.assertRaises(
+            AccessError,
+            msg="member of group_manager should \
+                                not be able to unlink log entries",
+        ):
+            test_command_log_as_bob.unlink()
+
+        # Create a new command
+        test_command_1 = self.Command.create(
+            {
+                "name": "Test",
+                "code": "ls",
+                "access_level": "3",
+            }
+        )
+
+        # Create a new command log as user_bob
+        test_command_log_1 = self.CommandLog.create(
+            {
+                "server_id": self.server_test_1.id,
+                "command_id": test_command_1.id,
+                "create_uid": self.user_bob.id,
+            }
+        )
+
+        # Test if Manager can read command log of a command with "Root" access level
+        test_command_log_1_read_result = test_command_log_1.with_user(
+            self.user_bob
+        ).read([])
+        self.assertEqual(
+            test_command_log_1_read_result[0]["name"],
+            test_command_log_1.name,
+            "Command name should be same",
+        )
+        test_command_log_1_command_id = test_command_log_1.with_user(
+            self.user_bob
+        ).read(["command_id"])
+        self.assertEqual(
+            test_command_log_1_command_id[0]["command_id"][0],
+            test_command_log_1.command_id.id,
+            "Command name should be same",
+        )
+        # Remove user_bob from group_manager
+        self.remove_from_group(
+            self.user_bob,
+            [
+                "cetmix_tower_server.group_manager",
+            ],
+        )
+
+        # Update test_command access_level to "1"
+        self.write_and_invalidate(test_command_1, **{"access_level": "1"})
+
+        # Ensure that user_bob has access to test_command_log_1
+        test_command_log_1_as_bob = test_command_log_1.with_user(self.user_bob)
+        self.assertEqual(
+            test_command_log_1_as_bob.access_level,
+            test_command_1.access_level,
+            "Access  should be same",
+        )
+        test_command_log_1_read_result = test_command_log_1_as_bob.read([])
+        self.assertEqual(
+            test_command_log_1_read_result[0]["name"],
+            test_command_log_1.name,
+            "Command name should be same",
+        )
+        # Update test_command access_level to "2"
+        self.write_and_invalidate(test_command_1, **{"access_level": "2"})
+        # Remove Bob from server followers
+        self.server_test_1.message_unsubscribe([self.user_bob.partner_id.id])
+
+        # Bob must have access because he is a log creator
+        test_command_log_1_read_result = test_command_log_1_as_bob.read([])
+        self.assertEqual(
+            test_command_log_1_read_result[0]["name"],
+            test_command_log_1.name,
+            "Command name should be same",
+        )


### PR DESCRIPTION
Restrict access to command log:
User: can see only log records he created.
Manager: + can see all log records for servers he has access to.
Root: can see all records.