### PR TITLE
[14.0][IMP] cetmix_tower_server Command duration

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -66,11 +66,10 @@ class CxTowerPlanLog(models.Model):
         """Shows relative time between now() and start time for running plans,
         and computed duration for finished ones.
         """
+        now = fields.Datetime.now()
         for plan_log in self:
             if plan_log.is_running:
-                plan_log.duration_current = (
-                    fields.Datetime.now() - plan_log.start_date
-                ).total_seconds()
+                plan_log.duration_current = (now - plan_log.start_date).total_seconds()
             else:
                 plan_log.duration_current = plan_log.duration
 

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -45,7 +45,7 @@
                             />
                             <field name="start_date" />
                             <field name="finish_date" />
-                            <field name="duration" />
+                            <field name="duration_current" />
                         </group>
                     </group>
                     <notebook>
@@ -78,7 +78,7 @@
             >
                 <field name="start_date" />
                 <field name="finish_date" optional="hide" />
-                <field name="duration" optional="show" />
+                <field name="duration_current" optional="show" />
                 <field name="server_id" optional="show" />
                 <field name="command_id" optional="show" />
                 <field name="command_status" optional="show" />

--- a/cetmix_tower_server/views/cx_tower_plan_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_log_view.xml
@@ -59,7 +59,7 @@
                             <field name="command_id" optional="show" />
                             <field name="start_date" optional="hide" />
                             <field name="finish_date" optional="hide" />
-                            <field name="duration" optional="show" />
+                            <field name="duration_current" optional="show" />
                             <field name="command_status" optional="show" />
                             <field name="is_running" optional="hide" />
                             </tree>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -10,6 +10,7 @@
                     <group>
                         <group>
                             <field name="name" />
+                            <field name="allow_parallel_run" />
                             <label for="on_error_action" />
                             <div class="o_row">
                                 <field name="on_error_action" />


### PR DESCRIPTION
Before
------
Command duration was computed once the a command has finished. So it was shown as '0' as long as a command was running.

Now
---
If a command is still duration is computed as a difference between command start time and current time. For finished commands duration is show as a total consumed.