### PR TITLE
[14.0][IMP] cetmix_tower_server Command execution path

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -98,12 +98,12 @@ Configure a Server
 
 Go to the ``Cetmix Tower/Servers/Servers`` menu and click ``Create``.
 
-Enter the server name fill the values it the tabs below.
+Enter the server name and fill the values it the tabs below:
 
 General Settings
 ~~~~~~~~~~~~~~~~
 
--  **Partner**: This is a partner this server belongs to
+-  **Partner**: Partner this server belongs to
 -  **Operating System**: Operating system that runs on the server
 -  **IPv4 Address**
 -  **IPv6 Address**: Will be used if no IPv4 address is specified
@@ -337,9 +337,14 @@ and put values in the fields:
 
    -  ``Execute shell command``: Execute a shell command using ssh
       connection on remote server.
-   -  ``Push file``: Cerate or update a file using selected file
+   -  ``Push file``: Create or update a file using selected file
       template and push it to remote server. If the file already exists
       on server it will be overwritten.
+
+-  **Default Path**: Specify path where command will be executed. This
+   field supports `Variables <#configure-variables>`__. Important:
+   ensure ssh user has access to the location even if executing command
+   using sudo.
 
 -  **Code**: Command code as it will be executed by remote shell. This
    field supports `Variables <#configure-variables>`__.
@@ -377,6 +382,9 @@ values in the fields:
    -  **Sequence**: Order this command is executed. Lower value = higher
       priority.
    -  **Command**: `Command <#configure-a-command>`__ to be executed.
+   -  **Path**: Specify path where command will be executed. Overrides
+      ``Default Path`` of the command. This field supports
+      `Variables <#configure-variables>`__.
    -  **Use Sudo**: Use ``sudo`` if required to run this command.
    -  **Actions**: List of condition based actions to be triggered after
       the command is executed. Each of the actions has the following
@@ -394,6 +402,73 @@ values in the fields:
             execution and return the custom code configured in the field
             next to this one.
          -  ``Run next command``. Will continue flight plan execution.
+
+Configuration best practices
+----------------------------
+
+Use simple commands
+~~~~~~~~~~~~~~~~~~~
+
+Try to avoid using ``&&`` or ``;`` joined commands unless this is really
+needed. Use flight plans instead.
+
+**Why?**
+
+-  Simple commands are easier to reuse across multiple flight plans.
+-  Commands run with ``sudo`` with password are be split and executed
+   one by one anyway.
+
+**Not recommended:**
+
+.. code:: bash
+
+   apt-get update && apt-get upgrade -y && apt-get install doge-meme-generator
+
+**Way to go:**
+
+.. code:: bash
+
+   apt-get update
+
+.. code:: bash
+
+   apt-get upgrade -y
+
+.. code:: bash
+
+   apt-get install doge-meme-generator
+
+Do not change directory using shell commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Do not use ``cd`` or ``chdir`` commands. Use ``Default Path`` field in
+command or ``Path`` field in flight plan line.
+
+**Why?**
+
+-  Tower will automatically adjust the command to ensure it is properly
+   executed in the specified location.
+
+**Do not do this:**
+
+.. code:: bash
+
+   cd /home/{{ tower.server.username }}/memes && cat my_doge_memes.txt
+
+**Way to go:**
+
+-  Add the following value in the ``Default Path`` command field or
+   ``Path`` field of a flight plan line:
+
+.. code:: bash
+
+   /home/{{ tower.server.username }}/memes
+
+-  Leave the command code as follows:
+
+.. code:: bash
+
+   cat my_doge_memes.txt
 
 Usage
 =====
@@ -414,6 +489,9 @@ To run a command:
    -  **Show shared**: By default only commands available for the
       selected server(s) are selectable. Activate this checkbox to
       select any command
+   -  **Path**: Directory where command will be executed. Important:
+      this field does not support variables! Ensure that user has access
+      to this location even if you run command using sudo.
    -  **Code**: Raw command code
    -  **Preview**: Command code rendered using server variables.
       **IMPORTANT:** If several servers are selected preview will be
@@ -465,7 +543,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -480,6 +558,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -125,13 +125,19 @@
     </record>
 
     <!-- Commands -->
+    <record id="command_update_upgrade" model="cx.tower.command">
+        <field name="name">Update packages</field>
+        <field name="code">apt-get update &amp;&amp; apt-get upgrade -y</field>
+    </record>
     <record id="command_create_dir" model="cx.tower.command">
         <field name="name">Create directory</field>
-        <field name="code">cd {{ test_path }} &amp;&amp; mkdir {{ dir }}</field>
+        <field name="path">/home/{{ tower.server.username }}</field>
+        <field name="code">mkdir {{ dir }}</field>
     </record>
     <record id="command_list_dir" model="cx.tower.command">
         <field name="name">List files in directory</field>
-        <field name="code">cd {{ test_path }} &amp;&amp; ls -l</field>
+        <field name="path">/home/{{ tower.server.username }}</field>
+        <field name="code">ls -l</field>
     </record>
 
     <!-- Flight Plans -->
@@ -148,6 +154,7 @@
         <field name="sequence">5</field>
         <field name="plan_id" ref="plan_test_1" />
         <field name="command_id" ref="command_create_dir" />
+        <field name="path">/such/much/{{ test_path }}</field>
     </record>
     <!-- Actions -->
     <record id="plan_test_1_line_1_action_1" model="cx.tower.plan.line.action">

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -58,6 +58,11 @@ class CxTowerCommand(models.Model):
         required=True,
         default=lambda self: self._selection_action()[0][0],
     )
+    path = fields.Char(
+        string="Default Path",
+        help="Location where command will be executed. "
+        "You can use {{ variables }} in path",
+    )
     file_template_id = fields.Many2one(
         comodel_name="cx.tower.file.template",
         help="This template will be used to create or update the pushed file",

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -33,6 +33,7 @@ class CxTowerCommandLog(models.Model):
     command_id = fields.Many2one(
         comodel_name="cx.tower.command", required=True, index=True, ondelete="restrict"
     )
+    path = fields.Char(string="Execution Path", help="Where command was executed")
     code = fields.Text(string="Command Code")
     command_status = fields.Integer(string="Exit Code")
     command_response = fields.Text(string="Response")

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -15,6 +15,11 @@ class CxTowerPlanLine(models.Model):
         string="Flight Plan", comodel_name="cx.tower.plan", auto_join=True
     )
     command_id = fields.Many2one(comodel_name="cx.tower.command", required=True)
+    path = fields.Char(
+        help="Location where command will be executed. Overrides command default path. "
+        "You can use {{ variables }} in path",
+    )
+
     use_sudo = fields.Boolean(
         help="Will use sudo based on server settings."
         "If no sudo is configured will run without sudo"
@@ -63,4 +68,7 @@ class CxTowerPlanLine(models.Model):
         # Use sudo to bypass access rules for execute command with higher access level
         command_id = self.sudo().command_id
 
-        server.execute_command(command_id, use_sudo, **kwargs)
+        # Set path
+        path = self.path or self.command_id.path
+
+        server.execute_command(command_id, path, sudo=use_sudo, **kwargs)

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -4,11 +4,11 @@ Please ensure that you have read and understood the documentation before running
 
 Go to the `Cetmix Tower/Servers/Servers` menu and click `Create`.
 
-Enter the server name fill the values it the tabs below.
+Enter the server name and fill the values it the tabs below:
 
 ### General Settings
 
-- **Partner**: This is a partner this server belongs to
+- **Partner**: Partner this server belongs to
 - **Operating System**: Operating system that runs on the server
 - **IPv4 Address**
 - **IPv6 Address**: Will be used if no IPv4 address is specified
@@ -159,8 +159,9 @@ To create a new command go to `Cetmix Tower/Commands/Commands` click `Create` an
 - **Tags**: Make usage as search more convenient.
 - **Action**: Action executed by the command. Possible options:
   - `Execute shell command`: Execute a shell command using ssh connection on remote server.
-  - `Push file`: Cerate or update a file using selected file template and push it to remote server. If the file already exists on server it will be overwritten.
+  - `Push file`: Create or update a file using selected file template and push it to remote server. If the file already exists on server it will be overwritten.
 
+- **Default Path**: Specify path where command will be executed. This field supports [Variables](#configure-variables). Important: ensure ssh user has access to the location even if executing command using sudo.
 - **Code**: Command code as it will be executed by remote shell. This field supports [Variables](#configure-variables).
 - **File Template**: File template that will be used to create or update file. Check [File Templates](#file-templates) for more details.
 
@@ -180,6 +181,7 @@ To create a new flight plan go to `Cetmix Tower/Commands/Flight Plans` click `Cr
 - **Code**: List of commands to execute. Each of the commands has the following fields:
   - **Sequence**: Order this command is executed. Lower value = higher priority.
   - **Command**: [Command](#configure-a-command) to be executed.
+  - **Path**: Specify path where command will be executed. Overrides `Default Path` of the command. This field supports [Variables](#configure-variables).
   - **Use Sudo**: Use `sudo` if required to run this command.
   - **Actions**: List of condition based actions to be triggered after the command is executed. Each of the actions has the following fields:
     - **Sequence**: Order this actions is triggered. Lower value = higher priority.
@@ -189,3 +191,63 @@ To create a new flight plan go to `Cetmix Tower/Commands/Flight Plans` click `Cr
       - `Exit with custom code`. Will terminate the flight plan execution and return the custom code configured in the field next to this one.
       - `Run next command`. Will continue flight plan execution.
 
+## Configuration best practices
+
+### Use simple commands
+
+Try to avoid using `&&` or `;` joined commands unless this is really needed.
+Use flight plans instead.
+
+**Why?**
+
+- Simple commands are easier to reuse across multiple flight plans.
+- Commands run with `sudo` with password are be split and executed one by one anyway.
+
+**Not recommended:**
+
+```bash
+apt-get update && apt-get upgrade -y && apt-get install doge-meme-generator
+```
+
+**Way to go:**
+
+```bash
+apt-get update
+```
+
+```bash
+apt-get upgrade -y
+```
+
+```bash
+apt-get install doge-meme-generator
+```
+
+### Do not change directory using shell commands
+
+Do not use `cd` or `chdir` commands.
+Use `Default Path` field in command or `Path` field in flight plan line.
+
+**Why?**
+
+- Tower will automatically adjust the command to ensure it is properly executed in the specified location.
+
+**Do not do this:**
+
+```bash
+cd /home/{{ tower.server.username }}/memes && cat my_doge_memes.txt
+```
+
+**Way to go:**
+
+- Add the following value in the `Default Path` command field or `Path` field of a flight plan line: 
+
+```bash
+/home/{{ tower.server.username }}/memes
+```
+
+- Leave the command code as follows:
+
+```bash
+cat my_doge_memes.txt
+```

--- a/cetmix_tower_server/readme/USAGE.md
+++ b/cetmix_tower_server/readme/USAGE.md
@@ -11,6 +11,7 @@ To run a command:
   - **Sudo**: `sudo` option for running this command
   - **Command**: Command to execute
   - **Show shared**: By default only commands available for the selected server(s) are selectable. Activate this checkbox to select any command
+  - **Path**: Directory where command will be executed. Important: this field does not support variables! Ensure that user has access to this location even if you run command using sudo.
   - **Code**: Raw command code
   - **Preview**: Command code rendered using server variables.
   **IMPORTANT:** If several servers are selected preview will be rendered for the first one. However during the command execution command code will be rendered for each server separately.

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -368,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:1aaaab92f7b9b28080bcbcb6c53cb1ab52aeccb14d88d150a086b0c5c38af692
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>Cetmix Tower offers a streamlined solution for managing remote servers
 via SSH directly from Odoo. This module is designed for versatility
 across different operating systems and software environments, providing
@@ -454,17 +454,22 @@ questions that arise.</li>
 </li>
 <li><a class="reference internal" href="#configure-a-command" id="toc-entry-14">Configure a Command</a></li>
 <li><a class="reference internal" href="#configure-a-flight-plan" id="toc-entry-15">Configure a Flight Plan</a></li>
+<li><a class="reference internal" href="#configuration-best-practices" id="toc-entry-16">Configuration best practices</a><ul>
+<li><a class="reference internal" href="#use-simple-commands" id="toc-entry-17">Use simple commands</a></li>
+<li><a class="reference internal" href="#do-not-change-directory-using-shell-commands" id="toc-entry-18">Do not change directory using shell commands</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="toc-entry-16">Usage</a><ul>
-<li><a class="reference internal" href="#running-a-command" id="toc-entry-17">Running a Command</a></li>
-<li><a class="reference internal" href="#running-a-flight-plan" id="toc-entry-18">Running a Flight Plan</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-19">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-20">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-21">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-22">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-19">Usage</a><ul>
+<li><a class="reference internal" href="#running-a-command" id="toc-entry-20">Running a Command</a></li>
+<li><a class="reference internal" href="#running-a-flight-plan" id="toc-entry-21">Running a Flight Plan</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-22">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-23">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-24">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-25">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -476,11 +481,11 @@ running <strong>Cetmix Tower</strong> in the production environment.</p>
 <div class="section" id="configure-a-server">
 <h2><a class="toc-backref" href="#toc-entry-2">Configure a Server</a></h2>
 <p>Go to the <tt class="docutils literal">Cetmix Tower/Servers/Servers</tt> menu and click <tt class="docutils literal">Create</tt>.</p>
-<p>Enter the server name fill the values it the tabs below.</p>
+<p>Enter the server name and fill the values it the tabs below:</p>
 <div class="section" id="general-settings">
 <h3><a class="toc-backref" href="#toc-entry-3">General Settings</a></h3>
 <ul class="simple">
-<li><strong>Partner</strong>: This is a partner this server belongs to</li>
+<li><strong>Partner</strong>: Partner this server belongs to</li>
 <li><strong>Operating System</strong>: Operating system that runs on the server</li>
 <li><strong>IPv4 Address</strong></li>
 <li><strong>IPv6 Address</strong>: Will be used if no IPv4 address is specified</li>
@@ -698,11 +703,15 @@ this field blank to make the command available for all OSes.</li>
 <li><strong>Action</strong>: Action executed by the command. Possible options:<ul>
 <li><tt class="docutils literal">Execute shell command</tt>: Execute a shell command using ssh
 connection on remote server.</li>
-<li><tt class="docutils literal">Push file</tt>: Cerate or update a file using selected file
+<li><tt class="docutils literal">Push file</tt>: Create or update a file using selected file
 template and push it to remote server. If the file already exists
 on server it will be overwritten.</li>
 </ul>
 </li>
+<li><strong>Default Path</strong>: Specify path where command will be executed. This
+field supports <a class="reference external" href="#configure-variables">Variables</a>. Important:
+ensure ssh user has access to the location even if executing command
+using sudo.</li>
 <li><strong>Code</strong>: Command code as it will be executed by remote shell. This
 field supports <a class="reference external" href="#configure-variables">Variables</a>.</li>
 <li><strong>File Template</strong>: File template that will be used to create or
@@ -737,6 +746,9 @@ following fields:<ul>
 <li><strong>Sequence</strong>: Order this command is executed. Lower value = higher
 priority.</li>
 <li><strong>Command</strong>: <a class="reference external" href="#configure-a-command">Command</a> to be executed.</li>
+<li><strong>Path</strong>: Specify path where command will be executed. Overrides
+<tt class="docutils literal">Default Path</tt> of the command. This field supports
+<a class="reference external" href="#configure-variables">Variables</a>.</li>
 <li><strong>Use Sudo</strong>: Use <tt class="docutils literal">sudo</tt> if required to run this command.</li>
 <li><strong>Actions</strong>: List of condition based actions to be triggered after
 the command is executed. Each of the actions has the following
@@ -760,11 +772,67 @@ next to this one.</li>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration-best-practices">
+<h2><a class="toc-backref" href="#toc-entry-16">Configuration best practices</a></h2>
+<div class="section" id="use-simple-commands">
+<h3><a class="toc-backref" href="#toc-entry-17">Use simple commands</a></h3>
+<p>Try to avoid using <tt class="docutils literal">&amp;&amp;</tt> or <tt class="docutils literal">;</tt> joined commands unless this is really
+needed. Use flight plans instead.</p>
+<p><strong>Why?</strong></p>
+<ul class="simple">
+<li>Simple commands are easier to reuse across multiple flight plans.</li>
+<li>Commands run with <tt class="docutils literal">sudo</tt> with password are be split and executed
+one by one anyway.</li>
+</ul>
+<p><strong>Not recommended:</strong></p>
+<pre class="code bash literal-block">
+apt-get<span class="w"> </span>update<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>apt-get<span class="w"> </span>upgrade<span class="w"> </span>-y<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>apt-get<span class="w"> </span>install<span class="w"> </span>doge-meme-generator
+</pre>
+<p><strong>Way to go:</strong></p>
+<pre class="code bash literal-block">
+apt-get<span class="w"> </span>update
+</pre>
+<pre class="code bash literal-block">
+apt-get<span class="w"> </span>upgrade<span class="w"> </span>-y
+</pre>
+<pre class="code bash literal-block">
+apt-get<span class="w"> </span>install<span class="w"> </span>doge-meme-generator
+</pre>
+</div>
+<div class="section" id="do-not-change-directory-using-shell-commands">
+<h3><a class="toc-backref" href="#toc-entry-18">Do not change directory using shell commands</a></h3>
+<p>Do not use <tt class="docutils literal">cd</tt> or <tt class="docutils literal">chdir</tt> commands. Use <tt class="docutils literal">Default Path</tt> field in
+command or <tt class="docutils literal">Path</tt> field in flight plan line.</p>
+<p><strong>Why?</strong></p>
+<ul class="simple">
+<li>Tower will automatically adjust the command to ensure it is properly
+executed in the specified location.</li>
+</ul>
+<p><strong>Do not do this:</strong></p>
+<pre class="code bash literal-block">
+<span class="nb">cd</span><span class="w"> </span>/home/<span class="o">{{</span><span class="w"> </span>tower.server.username<span class="w"> </span><span class="o">}}</span>/memes<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>cat<span class="w"> </span>my_doge_memes.txt
+</pre>
+<p><strong>Way to go:</strong></p>
+<ul class="simple">
+<li>Add the following value in the <tt class="docutils literal">Default Path</tt> command field or
+<tt class="docutils literal">Path</tt> field of a flight plan line:</li>
+</ul>
+<pre class="code bash literal-block">
+/home/<span class="o">{{</span><span class="w"> </span>tower.server.username<span class="w"> </span><span class="o">}}</span>/memes
+</pre>
+<ul class="simple">
+<li>Leave the command code as follows:</li>
+</ul>
+<pre class="code bash literal-block">
+cat<span class="w"> </span>my_doge_memes.txt
+</pre>
+</div>
+</div>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-16">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-19">Usage</a></h1>
 <div class="section" id="running-a-command">
-<h2><a class="toc-backref" href="#toc-entry-17">Running a Command</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-20">Running a Command</a></h2>
 <p>To run a command:</p>
 <ul class="simple">
 <li>Select a server in the list view or open a server form view</li>
@@ -777,6 +845,9 @@ next to this one.</li>
 <li><strong>Show shared</strong>: By default only commands available for the
 selected server(s) are selectable. Activate this checkbox to
 select any command</li>
+<li><strong>Path</strong>: Directory where command will be executed. Important:
+this field does not support variables! Ensure that user has access
+to this location even if you run command using sudo.</li>
 <li><strong>Code</strong>: Raw command code</li>
 <li><strong>Preview</strong>: Command code rendered using server variables.
 <strong>IMPORTANT:</strong> If several servers are selected preview will be
@@ -798,7 +869,7 @@ delete a command you need to delete all its logs manually before doing
 that.</p>
 </div>
 <div class="section" id="running-a-flight-plan">
-<h2><a class="toc-backref" href="#toc-entry-18">Running a Flight Plan</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Running a Flight Plan</a></h2>
 <p>To run a flight plan:</p>
 <ul>
 <li><p class="first">Select a server in the list view or open a server form view</p>
@@ -826,24 +897,24 @@ before doing that.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-19">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-22">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-20">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-23">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-21">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-24">Authors</a></h2>
 <ul class="simple">
 <li>Cetmix</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-22">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<h2><a class="toc-backref" href="#toc-entry-25">Maintainers</a></h2>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_key
 from . import test_plan
 from . import test_file
 from . import test_plan_log
+from . import test_command_wizard

--- a/cetmix_tower_server/tests/test_command_wizard.py
+++ b/cetmix_tower_server/tests/test_command_wizard.py
@@ -1,0 +1,48 @@
+from odoo.exceptions import AccessError
+
+from .common import TestTowerCommon
+
+
+class TestTowerCommandWizard(TestTowerCommon):
+    def test_user_access_rules(self):
+        """Test user access rules"""
+
+        # Add Bob to `root` group in order to create a wizard
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_root")
+
+        # Create new wizard
+        test_wizard = (
+            self.env["cx.tower.command.execute.wizard"]
+            .with_user(self.user_bob)
+            .create(
+                {
+                    "server_ids": [self.server_test_1.id],
+                    "command_id": self.command_create_dir.id,
+                }
+            )
+        ).with_user(self.user_bob)
+
+        # Force rendered code computation
+        test_wizard._compute_rendered_code()
+
+        # Remove bob from all cxtower_server groups
+        self.remove_from_group(
+            self.user_bob,
+            [
+                "cetmix_tower_server.group_user",
+                "cetmix_tower_server.group_manager",
+                "cetmix_tower_server.group_root",
+            ],
+        )
+        # Ensure that regular user cannot execute command in wizard
+        with self.assertRaises(AccessError):
+            test_wizard.execute_command_in_wizard()
+
+        # Add bob back to `user` group and try again
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+        with self.assertRaises(AccessError):
+            test_wizard.execute_command_in_wizard()
+
+        # Now promote bob to `manager` group and try again
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        test_wizard.execute_command_in_wizard()

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -182,7 +182,7 @@ class TestTowerPlan(TestTowerCommon):
         self.assertEqual(
             len(plan_log_rec.command_log_ids),
             expected_command_count,
-            msg="Must run {} commands".format(expected_command_count),
+            msg=f"Must run {expected_command_count} commands",
         )
 
         # Check plan status
@@ -190,7 +190,7 @@ class TestTowerPlan(TestTowerCommon):
         self.assertEqual(
             plan_log_rec.plan_status,
             expected_plan_status,
-            msg="Plan status must be equal to {}".format(expected_plan_status),
+            msg=f"Plan status must be equal to {expected_plan_status}",
         )
 
         # ************************
@@ -215,7 +215,7 @@ class TestTowerPlan(TestTowerCommon):
         self.assertEqual(
             len(plan_log_rec.command_log_ids),
             expected_command_count,
-            msg="Must run {} commands".format(expected_command_count),
+            msg=f"Must run {expected_command_count} commands",
         )
 
         # Check plan status
@@ -223,7 +223,14 @@ class TestTowerPlan(TestTowerCommon):
         self.assertEqual(
             plan_log_rec.plan_status,
             expected_plan_status,
-            msg="Plan status must be equal to {}".format(expected_plan_status),
+            msg=f"Plan status must be equal to {expected_plan_status}",
+        )
+
+        # Ensure 'path' was substituted with the plan line custom 'path'
+        self.assertEqual(
+            self.plan_line_1.path,
+            plan_log_rec.command_log_ids.path,
+            "Path in command log must be the same as in the flight plan line",
         )
 
     def test_plan_user_access_rule(self):

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -29,6 +29,10 @@
                             <field name="server_id" />
                             <field name="command_id" />
                             <field
+                                name="path"
+                                attrs="{'invisible': [('path', '=', False)]}"
+                            />
+                            <field
                                 name="is_running"
                                 attrs="{'invisible': [('is_running', '=', False)]}"
                             />

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -15,6 +15,10 @@
                                 name="file_template_id"
                                 attrs="{'invisible': [('action', '!=', 'file_using_template')],'required': [('action', '=', 'file_using_template')],}"
                             />
+                            <field
+                                name="path"
+                                placeholder="optional, eg /home/{{ tower.server.username }}"
+                            />
                             <field name="allow_parallel_run" />
                             <field name="note" />
                         </group>
@@ -62,6 +66,7 @@
                     options="{'color_field': 'color'}"
                     optional="show"
                 />
+                <field name="path" optional="show" />
                 <field
                     name="tag_ids"
                     widget="many2many_tags"

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -15,6 +15,10 @@
                                 context="{'command_show_server_names': True}"
                             />
                             <field name="use_sudo" />
+                            <field
+                                name="path"
+                                placeholder="e.g. /such/much/{{ path }}, overrides command path"
+                            />
                         </group>
                         </group>
                     <notebook>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -59,8 +59,9 @@
                             <field name="line_ids">
                                 <tree>
                                     <field name="sequence" widget="handle" />
-                                    <field name="command_id" />
+                                    <field name="name" />
                                     <field name="use_sudo" />
+                                    <field name="path" optional="show" />
                                 </tree>
                             </field>
                         </page>

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -27,6 +27,10 @@
                         <span>show shared</span>
                         <field name="any_server" />
                     </div>
+                    <field
+                        name="path"
+                        placeholder="e.g. /home/user This field does NOT support variables"
+                    />
                 </group>
                     <field
                     name="result"
@@ -57,7 +61,7 @@
                         attrs="{'invisible': [('result', '!=', False)]}"
                     />
                     <button
-                        name="execute_command"
+                        name="execute_command_in_wizard"
                         type="object"
                         string="Run in wizard"
                         help="Run code as it appears in 'Rendered code' in wizard and return to wizard. Result will not be logged"

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -7,8 +7,19 @@ class CxTowerServer(models.Model):
     _inherit = "cx.tower.server"
 
     def _command_runner_wrapper(
-        self, command, log_record, rendered_command_code, ssh_connection=None
+        self,
+        command,
+        log_record,
+        rendered_command_code,
+        rendered_command_path=None,
+        ssh_connection=None,
+        **kwargs,
     ):
         self.with_delay()._command_runner(
-            command, log_record, rendered_command_code, ssh_connection
+            command,
+            log_record,
+            rendered_command_code,
+            rendered_command_path,
+            ssh_connection,
+            **kwargs,
         )


### PR DESCRIPTION
Allow to execute commands at specified locations (directories). 
Command execution path supports variables and can be defined:
- In command
- In flight plan line. Will override the one defined in command
- In wizard. Will override the one defined in command. NB: path in wizard does NOT support variables!
- Code:  command path can provided as an optional parameter to the `execute_command` function.