### PR TITLE
[14.0] [IMP] cetmix_tower_server: flight plan log access

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -25,6 +25,7 @@
         "security/cx_tower_plan_security.xml",
         "security/cx_tower_plan_line_security.xml",
         "security/cx_tower_plan_line_action_security.xml",
+        "security/cx_tower_plan_log_security.xml",
         "security/ir.model.access.csv",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",

--- a/cetmix_tower_server/security/cx_tower_plan_log_security.xml
+++ b/cetmix_tower_server/security/cx_tower_plan_log_security.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+
+    <record id="cx_tower_plan_log_rule_group_user_access" model="ir.rule">
+        <field name="name">Tower plan log: user access rule</field>
+        <field name="model_id" ref="model_cx_tower_plan_log" />
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
+        <field name="domain_force">[('create_uid', '=', user.id)]</field>
+    </record>
+
+    <record id="cx_tower_plan_log_rule_group_manager_access" model="ir.rule">
+        <field name="name">Tower plan log: manager access rule</field>
+        <field name="model_id" ref="model_cx_tower_plan_log" />
+        <field name="domain_force">[
+            ('server_id.message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+    </record>
+
+
+    <record id="cx_tower_plan_log_rule_group_root_access" model="ir.rule">
+        <field name="name">Tower plan log: root access rule</field>
+        <field name="model_id" ref="model_cx_tower_plan_log" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('cetmix_tower_server.group_root'))]" />
+    </record>
+
+
+</odoo>

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_command
 from . import test_key
 from . import test_plan
 from . import test_file
+from . import test_plan_log

--- a/cetmix_tower_server/tests/test_plan_log.py
+++ b/cetmix_tower_server/tests/test_plan_log.py
@@ -1,0 +1,57 @@
+from odoo.exceptions import AccessError
+
+from .common import TestTowerCommon
+
+
+class TestTowerPlanlog(TestTowerCommon):
+    def test_user_access_rule(self):
+        """Test user access rule"""
+        # Create the test command
+        test_plan_log = self.PlanLog.create(
+            {
+                "server_id": self.server_test_1.id,
+                "plan_id": self.plan_1.id,
+            }
+        )
+        # Remove bob from all cxtower_server groups
+        self.remove_from_group(
+            self.user_bob,
+            [
+                "cetmix_tower_server.group_user",
+                "cetmix_tower_server.group_manager",
+                "cetmix_tower_server.group_root",
+            ],
+        )
+        # Ensure that regular user cannot access the command log
+        test_plan_log_as_bob = test_plan_log.with_user(self.user_bob)
+        test_plan_log_as_bob.invalidate_cache()
+        with self.assertRaises(AccessError):
+            plan_name = test_plan_log_as_bob.read(["name"])
+
+        # Add user_bob to group user
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+        # Ensure that user still doesn't have access to command he did't create
+        with self.assertRaises(AccessError):
+            plan_name = test_plan_log_as_bob.read(["name"])
+
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        # Ensure that manager doesn't have access to command belongs to server
+        #  he did't subscribed to
+        with self.assertRaises(AccessError):
+            plan_name = test_plan_log_as_bob.read(["name"])
+        # Subscibe manager to server and test again
+        self.server_test_1.message_subscribe([self.user_bob.partner_id.id])
+        plan_name = test_plan_log_as_bob.read(["name"])
+        self.assertEqual(
+            plan_name[0]["name"],
+            test_plan_log_as_bob.name,
+            "Plan name should be same",
+        )
+
+        # Check if user Bob can unlink command_log entry as member of group_manager
+        with self.assertRaises(
+            AccessError,
+            msg="member of group_manager should \
+                                not be able to unlink log entries",
+        ):
+            test_plan_log_as_bob.unlink()


### PR DESCRIPTION
Restrict access to FP log:
User: can see only log records he created.
Manager: + can see all log records for servers he has access to.
Root: can see all records.