### PR TITLE
[14.0][IMP] cetmix_tower_server: Implemented binary files processing

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -269,6 +269,12 @@ and put values in the fields:
 -  **Name**: Filesystem filename
 -  **Source**: File source. Available options are ``Server`` and
    ``Tower``. Check above for more details.
+-  **File type**: Type of file contents. Possible options:
+
+   -  **Text**: Regular text. Eg configuration file or log
+   -  **Binary**: Binary file. Eg file archive or pdf document
+
+-  **File**: Is used to store binary file data.
 -  **Template**: File template used to render this file. If selected
    file will be automatically updated every time template is modified.
    Used only with ``Tower`` source.
@@ -312,6 +318,11 @@ click ``Create`` and put values in the fields:
 -  **Directory on server**: Directory on remote server where this file
    will be stored. This field supports
    `Variables <#configure-variables>`__.
+-  **File type**: Type of file contents. Possible options:
+
+   -  **Text**: Regular text. Eg configuration file or log
+   -  **Binary**: Binary file. Eg file archive or pdf document
+
 -  **Tags**: Make usage as search more convenient
 -  **Note**: Comments or user notes
 -  **Code**: Raw file content. This field supports
@@ -556,7 +567,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -571,6 +582,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -38,6 +38,11 @@ class CxTowerFileTemplate(models.Model):
     keep_when_deleted = fields.Boolean(
         help="File will be kept on server when deleted in Tower",
     )
+    file_type = fields.Selection(
+        selection=lambda self: self.env["cx.tower.file"]._selection_file_type(),
+        default=lambda self: self.env["cx.tower.file"]._default_file_type(),
+        required=True,
+    )
 
     def write(self, vals):
         """

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1091,16 +1091,10 @@ class CxTowerServer(models.Model):
         if from_path:
             result = client.upload_file(data, remote_path)
         else:
+            # Convert string to bytes
             if isinstance(data, str):
-                data = str.encode(data)
-            if not isinstance(data, bytes):
-                raise TypeError(
-                    "Incorrect type of file ({}) allowed: string, bytes.".format(
-                        type(data).__name__
-                    )
-                )
+                data = data.encode()
             file = io.BytesIO(data)
-            file.seek(0)
             result = client.upload_file(file, remote_path)
         return result
 

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -127,6 +127,10 @@ To create a new file go to `Cetmix Tower/Files/Files` click `Create` and put val
 
 - **Name**: Filesystem filename
 - **Source**: File source. Available options are `Server` and `Tower`. Check above for more details.
+- **File type**: Type of file contents. Possible options:
+  - **Text**: Regular text. Eg configuration file or log
+  - **Binary**: Binary file. Eg file archive or pdf document
+- **File**:  Is used to store binary file data.
 - **Template**: File template used to render this file. If selected file will be automatically updated every time template is modified. Used only with `Tower` source.
 - **Server**: Server where this file is located
 - **Directory on Server**: This is where the file is located on the remote server
@@ -151,6 +155,9 @@ To create a new file template go to `Cetmix Tower/Files/Templates` click `Create
 - **Name**: Template name
 - **File Name**: Filesystem name of the file(s) created from this template. This field supports [Variables](#configure-variables).
 - **Directory on server**: Directory on remote server where this file will be stored. This field supports [Variables](#configure-variables).
+- **File type**: Type of file contents. Possible options:
+  - **Text**: Regular text. Eg configuration file or log
+  - **Binary**: Binary file. Eg file archive or pdf document
 - **Tags**: Make usage as search more convenient
 - **Note**: Comments or user notes
 - **Code**: Raw file content. This field supports [Variables](#configure-variables).

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -368,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:9a6377426019e72bf8e1511ff801e53b5ee96507487812c6cd888634fb73f17c
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>Cetmix Tower offers a streamlined solution for managing remote servers
 via SSH directly from Odoo. This module is designed for versatility
 across different operating systems and software environments, providing
@@ -644,6 +645,12 @@ and put values in the fields:</p>
 <li><strong>Name</strong>: Filesystem filename</li>
 <li><strong>Source</strong>: File source. Available options are <tt class="docutils literal">Server</tt> and
 <tt class="docutils literal">Tower</tt>. Check above for more details.</li>
+<li><strong>File type</strong>: Type of file contents. Possible options:<ul>
+<li><strong>Text</strong>: Regular text. Eg configuration file or log</li>
+<li><strong>Binary</strong>: Binary file. Eg file archive or pdf document</li>
+</ul>
+</li>
+<li><strong>File</strong>: Is used to store binary file data.</li>
 <li><strong>Template</strong>: File template used to render this file. If selected
 file will be automatically updated every time template is modified.
 Used only with <tt class="docutils literal">Tower</tt> source.</li>
@@ -684,6 +691,11 @@ template. This field supports <a class="reference external" href="#configure-var
 <li><strong>Directory on server</strong>: Directory on remote server where this file
 will be stored. This field supports
 <a class="reference external" href="#configure-variables">Variables</a>.</li>
+<li><strong>File type</strong>: Type of file contents. Possible options:<ul>
+<li><strong>Text</strong>: Regular text. Eg configuration file or log</li>
+<li><strong>Binary</strong>: Binary file. Eg file archive or pdf document</li>
+</ul>
+</li>
 <li><strong>Tags</strong>: Make usage as search more convenient</li>
 <li><strong>Note</strong>: Comments or user notes</li>
 <li><strong>Code</strong>: Raw file content. This field supports
@@ -913,7 +925,7 @@ before doing that.</p>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -37,11 +37,16 @@
                                 options="{'color_field': 'color'}"
                             />
                             <field name="keep_when_deleted" />
+                            <field name="file_type" />
                             <field name="note" />
                         </group>
                     </group>
                     <notebook>
-                        <page name="code" string="Code">
+                        <page
+                            name="code"
+                            string="Code"
+                            attrs="{'invisible': [('file_type', '=', 'binary')]}"
+                        >
                             <field name="code" nolabel="1" />
                         </page>
                     </notebook>
@@ -56,6 +61,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="file_type" optional="show" />
                 <field name="file_name" optional="show" />
                 <field name="server_dir" optional="show" />
                 <field
@@ -76,6 +82,23 @@
                 <field name="name" />
                 <field name="server_dir" />
                 <field name="tag_ids" />
+                <filter
+                    name="filter_binary"
+                    string="Binary"
+                    domain="[('file_type', '=', 'binary')]"
+                />
+                <filter
+                    name="filter_text"
+                    string="Text"
+                    domain="[('file_type', '=', 'text')]"
+                />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_by_file_type"
+                        string="File Type"
+                        context="{'group_by': 'file_type'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -40,6 +40,17 @@
                         <group>
                             <group>
                                 <field name="source" required="1" />
+                                <field name="file_type" />
+                                <field name="id" invisible="1" />
+                                <field
+                                name="file"
+                                filename="name"
+                                attrs="{
+                                    'invisible': [('file_type', '!=', 'binary')],
+                                    'required': [('file_type', '=', 'binary'), ('source', '!=', 'server')],
+                                    'readonly': ['|', ('id', '!=', False), ('source', '=', 'server')]
+                                }"
+                            />
                                 <field
                                 name="template_id"
                                 attrs="{'invisible': [('source', '!=', 'tower')]}"
@@ -70,7 +81,11 @@
                             </group>
                         </group>
                     <notebook>
-                        <page name="code" string="Code">
+                        <page
+                            name="code"
+                            string="Code"
+                            attrs="{'invisible': [('file_type', '=', 'binary')]}"
+                        >
                             <button
                                 string="Modify Code"
                                 icon="fa-pencil-square-o"
@@ -89,7 +104,7 @@
                         <page
                             name="rendered_code"
                             string="Preview"
-                            attrs="{'invisible': [('source', '!=', 'tower')]}"
+                            attrs="{'invisible': ['|', ('source', '!=', 'tower'), ('file_type', '=', 'binary')]}"
                         >
                             <field
                                 name="rendered_code"
@@ -100,7 +115,7 @@
                         <page
                             name="code_on_server"
                             string="Server Version"
-                            attrs="{'invisible': [('source', '!=', 'tower')]}"
+                            attrs="{'invisible': ['|', ('source', '!=', 'tower'), ('file_type', '=', 'binary')]}"
                         >
                             <group>
                                 <button
@@ -134,6 +149,9 @@
             <tree>
                 <field name="rendered_name" />
                 <field name="source" />
+                <field name="file_type" optional="show" />
+                <field name="file" widget="binary" optional="show" filename="name" />
+                <field name="name" invisible="1" />
                 <field name="server_id" />
                 <field name="full_server_path" optional="hide" />
                 <field name="sync_date_last" />
@@ -186,12 +204,29 @@
                     name="filter_is_error_synced"
                     domain="[('server_response', 'not in', ['ok', False])]"
                 />
+                <separator />
+                <filter
+                    string="Text"
+                    name="filter_text"
+                    domain="[('file_type', '=', 'text')]"
+                />
+                <filter
+                    string="Binary"
+                    name="filter_binary"
+                    domain="[('file_type', '=', 'binary')]"
+                />
                 <group expand="0" string="Group By">
                     <filter
-                        string="Type"
-                        name="group_by_type"
+                        string="Source"
+                        name="group_by_source"
                         domain="[]"
                         context="{'group_by': 'source'}"
+                    />
+                    <filter
+                        string="File Type"
+                        name="group_by_file_type"
+                        domain="[]"
+                        context="{'group_by': 'file_type'}"
                     />
                     <filter
                         string="Server"


### PR DESCRIPTION
- **File**:
   - Added 2 fields:
       - **Binary** (boolean) - if true, binary file field will be used in upload method as data source instead of code. Will be prefilled from related template
       - **File** - binary content of the file
   - When binary switch is on - all code related fields become hidden and will not be rendered
- **File Template**:
   - Added 1 field:
      - **Binary** (boolean) - is used to prefill same field in files created from this template.