### PR TITLE
[FIX] cetmix_tower_server: fixed removing of duplicated server files …

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -357,7 +357,12 @@ class CxTowerServer(models.Model):
 
         file_ids = self.env["cx.tower.file"]
         for file in self.file_ids:
-            file_ids |= file.copy({"auto_sync": False})
+            file_ids |= file.copy(
+                {
+                    "auto_sync": False,
+                    "keep_when_deleted": True,
+                }
+            )
         default["file_ids"] = file_ids.ids
 
         result = super(CxTowerServer, self).copy(default=default)

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -93,6 +93,16 @@ class TestTowerServer(TestTowerCommon):
             msg="Auto sync should be disabled on all the files in the copied server!",
         )
 
+        # Check if 'keep_when_deleted' option is enabled on all the files
+        # in the copied server
+        self.assertTrue(
+            all([file.keep_when_deleted for file in server_test_2_copy.file_ids]),
+            msg=(
+                "keep_when_deleted option should be enabled on all the files "
+                "in the copied server!"
+            ),
+        )
+
         # Check if secret values of keys in the copied server are the same
         # as in source server
         self.assertTrue(


### PR DESCRIPTION
Fixed removing of duplicated server files issue by setting keep_when_deleted = True as a default value for files on duplication.