### PR TITLE
[UPD] cetmix_tower_server: set default file directory to empty string…

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -42,7 +42,7 @@ class CxTowerFile(models.Model):
     server_dir = fields.Char(
         string="Directory on server",
         required=True,
-        default="~",
+        default="",
         help="Eg '/home/user' or '/var/log'",
     )
     rendered_server_dir = fields.Char(


### PR DESCRIPTION
Set default file directory to empty string instead of '~'