### PR TITLE
[14.0][IMP] cetmix_tower_server Clean up sensitive data

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1074,10 +1074,13 @@ class CxTowerServer(models.Model):
 
             status = final_status
 
+        # This is needed to remove keys
+        if key_values:
+            key_model = self.env["cx.tower.key"]
+
         # Compose response message
         if response and isinstance(response, list):
             # Replace secrets with spoiler
-            key_model = self.env["cx.tower.key"]
             response_vals = [
                 key_model._replace_with_spoiler(str(r), key_values)
                 if key_values
@@ -1092,7 +1095,13 @@ class CxTowerServer(models.Model):
 
         # Compose error message
         if error and isinstance(error, list):
-            error_vals = [str(r) for r in error]
+            # Replace secrets with spoiler
+            error_vals = [
+                key_model._replace_with_spoiler(str(e), key_values)
+                if key_values
+                else str(e)
+                for e in error
+            ]
             error = "".join(error_vals)
         elif not error:
             # For not to save an empty list `[]` in log

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -469,10 +469,10 @@ class TestTowerCommand(TestTowerCommon):
         """Test ssh command result parsing"""
 
         # -------------------------------------------------------
-        # Case 1: regular command execution result with not error
+        # Case 1: regular command execution result with no error
         # We are testing secret value placeholder here
         # -------------------------------------------------------
-        status = 1
+        status = 0
         response = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
         error = []
 
@@ -570,6 +570,36 @@ class TestTowerCommand(TestTowerCommon):
         self.assertEqual(
             result_error, "OoopsI didit again", "Error in result doesn't match expected"
         )
+
+        # -------------------------------------------------------
+        # Case 5: regular command execution result with no error
+        # However the command result is saved in the "error" value.
+        # For example this happens in 'docker build'.
+        # -------------------------------------------------------
+        status = 0
+        error = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
+        response = []
+
+        ssh_command_result = self.Server._parse_ssh_command_results(
+            status, response, error, key_values=[f"{self.secret_2.secret_value}"]
+        )
+
+        # Get result
+        result_status = ssh_command_result["status"]
+        result_response = ssh_command_result["response"]
+        result_error = ssh_command_result["error"]
+
+        self.assertEqual(
+            result_status,
+            result_status,
+            "Status in result must be the same as the initial one",
+        )
+        self.assertEqual(
+            result_error,
+            f"Such muchDoge like SSH {self.Key.SECRET_VALUE_SPOILER}",
+            "Response in result doesn't match expected",
+        )
+        self.assertIsNone(result_response, "Error in response must be set to None")
 
     def test_execute_command_no_log(self):
         """Execute command without creating a log record.


### PR DESCRIPTION
Before this commit
------------------

Key values are removed from command response and replaced with placeholder.

After this commit
------------------

Key values are removed from command response AND command error and replaced with placeholder.

Comment
-------
Some commands like `docker build` return information in the `stderr` output even if the command finished with no error (exit code == 0).