### PR TITLE
[14.0][IMP] cetmix_tower_server Server references

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -154,7 +154,11 @@ Configure a Server
 ------------------
 
 Go to the ``Cetmix Tower/Servers/Servers`` menu and click ``Create``.
-Enter the server name and fill the values it the tabs below:
+Enter server name and a unique server reference. Leave the "reference"
+field blank to generate a reference automatically. You can also select a
+color which is used to mark a server in the kanban view.
+
+Fill the values it the tabs below:
 
 **General Settings**
 
@@ -220,9 +224,8 @@ Configure a Server Template
 ---------------------------
 
 Go to the ``Cetmix Tower/Servers/Templates`` menu and click ``Create``.
-Add a name and a unique template reference. Leave the "reference" field
-blank in order for a reference to be generated automatically based on
-the template name.
+Enter template name and a unique template reference. Leave the
+"reference" field blank to generate a reference automatically.
 
 Fill the values it the tabs below:
 
@@ -715,8 +718,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -866,9 +869,9 @@ To check a server log:
 
 |Update server log|
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -876,7 +879,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -891,6 +894,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -43,7 +43,7 @@
 
     <!-- Servers -->
     <record id="server_test_1" model="cx.tower.server">
-        <field name="name">Test Server #1</field>
+        <field name="name">Demo Server #1</field>
         <field name="color">1</field>
         <field name="ip_v4_address">localhost</field>
         <field name="ssh_username">admin</field>
@@ -61,7 +61,7 @@
     </record>
     <record id="server_test_2" model="cx.tower.server">
         <field name="color">2</field>
-        <field name="name">Test Server #2</field>
+        <field name="name">Demo Server #2</field>
         <field name="ip_v4_address">localhost</field>
         <field name="ssh_username">admin</field>
         <field name="ssh_password">password</field>

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -231,13 +231,17 @@ class CxTowerServer(models.Model):
     """
 
     _name = "cx.tower.server"
-    _inherit = ["cx.tower.variable.mixin", "mail.thread", "mail.activity.mixin"]
+    _inherit = [
+        "cx.tower.variable.mixin",
+        "cx.tower.reference.mixin",
+        "mail.thread",
+        "mail.activity.mixin",
+    ]
     _description = "Cetmix Tower Server"
     _order = "name asc"
 
     # ---- Main
     active = fields.Boolean(default=True)
-    name = fields.Char(required=True)
     color = fields.Integer(help="For better visualization in views")
     partner_id = fields.Many2one(comodel_name="res.partner")
     status = fields.Selection(
@@ -399,8 +403,6 @@ class CxTowerServer(models.Model):
     @api.returns("self", lambda value: value.id)
     def copy(self, default=None):
         default = default or {}
-        default["name"] = _("%(name)s (copy)", name=self.name)
-
         file_ids = self.env["cx.tower.file"]
         for file in self.file_ids:
             file_ids |= file.copy(

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -19,7 +19,11 @@ Users of this group have access to the entities with `Access Level` set to `Mana
 
 ## Configure a Server
 
-Go to the `Cetmix Tower/Servers/Servers` menu and click `Create`. Enter the server name and fill the values it the tabs below:
+Go to the `Cetmix Tower/Servers/Servers` menu and click `Create`. 
+Enter server name and a unique server reference. Leave the "reference" field blank to generate a reference automatically.
+You can also select a color which is used to mark a server in the kanban view.
+
+Fill the values it the tabs below:
 
 **General Settings**
 
@@ -72,7 +76,8 @@ Following action buttons are located in the top of the form:
 
 ## Configure a Server Template
 
-Go to the `Cetmix Tower/Servers/Templates` menu and click `Create`. Add a name and a unique template reference. Leave the "reference" field blank in order for a reference to be generated automatically based on the template name.
+Go to the `Cetmix Tower/Servers/Templates` menu and click `Create`.
+Enter template name and a unique template reference. Leave the "reference" field blank to generate a reference automatically.
 
 Fill the values it the tabs below:
 

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:44f1352e66d48e03e3f13ef54e22ac50675ee50f2178ec9919d1ca7c033d811c
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -473,7 +472,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting/Users &amp; Companies/Users</tt> and open a user whom you would like
 to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In <tt class="docutils literal">Other</tt> section find the <tt class="docutils literal">Cetmix Tower</tt> field and select one of
 the following options:</p>
 <ul class="simple">
@@ -499,7 +498,10 @@ additional access management variations.</p>
 <div class="section" id="configure-a-server">
 <h2>Configure a Server</h2>
 <p>Go to the <tt class="docutils literal">Cetmix Tower/Servers/Servers</tt> menu and click <tt class="docutils literal">Create</tt>.
-Enter the server name and fill the values it the tabs below:</p>
+Enter server name and a unique server reference. Leave the “reference”
+field blank to generate a reference automatically. You can also select a
+color which is used to mark a server in the kanban view.</p>
+<p>Fill the values it the tabs below:</p>
 <p><strong>General Settings</strong></p>
 <ul class="simple">
 <li><strong>Partner</strong>: Partner this server belongs to</li>
@@ -557,9 +559,8 @@ this server</li>
 <div class="section" id="configure-a-server-template">
 <h2>Configure a Server Template</h2>
 <p>Go to the <tt class="docutils literal">Cetmix Tower/Servers/Templates</tt> menu and click <tt class="docutils literal">Create</tt>.
-Add a name and a unique template reference. Leave the “reference” field
-blank in order for a reference to be generated automatically based on
-the template name.</p>
+Enter template name and a unique template reference. Leave the
+“reference” field blank to generate a reference automatically.</p>
 <p>Fill the values it the tabs below:</p>
 <p><strong>General Settings</strong></p>
 <ul class="simple">
@@ -920,7 +921,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1055,7 +1056,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1151,14 +1152,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
 the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
 order to refresh all logs at once. Log output will be displayed in
 the HTML field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
@@ -1166,7 +1167,7 @@ the HTML field below.</li>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1179,7 +1180,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -64,6 +64,12 @@ class TestTowerCommon(TransactionCase):
         self.variable_url = self.Variable.create({"name": "test_url"})
         self.variable_version = self.Variable.create({"name": "test_version"})
 
+        # Key
+        self.Key = self.env["cx.tower.key"]
+
+        self.key_1 = self.Key.create({"name": "Test Key 1"})
+        self.secret_2 = self.Key.create({"name": "Test Key 2", "key_type": "s"})
+
         # Command
         self.sudo_prefix = "sudo -S -p ''"
         self.Command = self.env["cx.tower.command"]
@@ -119,27 +125,8 @@ class TestTowerCommon(TransactionCase):
             }
         )
 
-        self.command_create_new_command = self.Command.create(
-            {
-                "name": "Create new command",
-                "action": "python_code",
-                "code": """
-if #!cxtower.secret.FOLDER!#:
-    command = env["cx.tower.command"].create({"name": {{ test_path_ }}})
-    COMMAND_RESULT = {"exit_code": 0, "message": "New command was created"}
-else:
-    COMMAND_RESULT = {"exit_code": -1, "message": "error"}
-""",
-            }
-        )
         # Command log
         self.CommandLog = self.env["cx.tower.command.log"]
-
-        # Key
-        self.Key = self.env["cx.tower.key"]
-
-        self.key_1 = self.Key.create({"name": "Test Key 1"})
-        self.secret_2 = self.Key.create({"name": "Test Key 2", "key_type": "s"})
 
         # File template
         self.FileTemplate = self.env["cx.tower.file.template"]

--- a/cetmix_tower_server/tests/test_reference_mixin.py
+++ b/cetmix_tower_server/tests/test_reference_mixin.py
@@ -45,7 +45,7 @@ class TestTowerReference(TestTowerCommon):
 
         yet_another_template_copy = yet_another_template.copy()
 
-        self.assertEqual(yet_another_template_copy.name, "Yet another template (Copy)")
+        self.assertEqual(yet_another_template_copy.name, "Yet another template (copy)")
 
         self.assertEqual(
             yet_another_template_copy.reference, "yet_another_template_copy"
@@ -56,6 +56,21 @@ class TestTowerReference(TestTowerCommon):
 
         yet_another_template_copy.write({"reference": " Some reference x*((*)) "})
         self.assertEqual(yet_another_template_copy.reference, "some_reference_x_3")
+
+        # -- 6 ---
+        # Update template with a new name and remove reference simultaneously
+        yet_another_template_copy.write({"name": "Doge so like", "reference": False})
+        self.assertEqual(yet_another_template_copy.reference, "doge_so_like")
+
+        # -- 7 ---
+        # Rename the template and ensure reference is not affected
+        yet_another_template_copy.write({"name": "Chad"})
+        self.assertEqual(yet_another_template_copy.reference, "doge_so_like")
+
+        # -- 8 ---
+        # Remove the reference and ensure it's regenerated from the name
+        yet_another_template_copy.write({"reference": False})
+        self.assertEqual(yet_another_template_copy.reference, "chad")
 
     def test_search_by_reference(self):
         """Search record by its reference"""

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -222,7 +222,7 @@ class TestTowerServer(TestTowerCommon):
         # Check if user Bob can create new server as member of group_manager
         new_server_1 = self.Server.with_user(self.user_bob).create(
             {
-                "name": "Test Server 2",
+                "name": "New Server 1",
                 "ip_v4_address": "localhost",
                 "ssh_username": "admin",
                 "ssh_password": "password",
@@ -232,7 +232,7 @@ class TestTowerServer(TestTowerCommon):
         )
         # Check if server has been created by Bob as member of group_manager
         self.assertEqual(
-            new_server_1.name, "Test Server 2", msg="Sever name does not match!"
+            new_server_1.name, "New Server 1", msg="Sever name does not match!"
         )
 
         # Check if user Bob can unlink new server as member of group_manager

--- a/cetmix_tower_server/views/cx_tower_server_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_template_view.xml
@@ -245,7 +245,8 @@
         <field name="model">cx.tower.server.template</field>
         <field name="arch" type="xml">
             <search string="Search Server Templates">
-                <field name="name" string="Server" />
+                <field name="name" />
+                <field name="reference" />
                 <field name="os_id" />
                 <field name="tag_ids" />
                 <filter

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -118,6 +118,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="reference" optional="hide" />
                 <field name="partner_id" optional="show" />
                 <field
                     name="tag_ids"
@@ -132,7 +133,7 @@
                     decoration-danger="status == '2'"
                     decoration-info="status == '1'"
                     decoration-success="status == '4'"
-                    decoration-warning="status in '356'"
+                    decoration-warning="status in ['3','5','6']"
                 />
             </tree>
         </field>
@@ -197,6 +198,12 @@
                                 class="ml-auto"
                             />
                         </h1>
+                        <h3>
+                            <field
+                                name="reference"
+                                placeholder="Can contain English letters, digits and '_'. Leave blank to autogenerate"
+                            />
+                        </h3>
                         <field name="color" widget="color_picker" />
                     </div>
                     <notebook>
@@ -298,7 +305,8 @@
         <field name="model">cx.tower.server</field>
         <field name="arch" type="xml">
             <search string="Search Servers">
-                <field name="name" string="Server" />
+                <field name="name" />
+                <field name="reference" />
                 <field name="status" />
                 <field name="os_id" />
                 <field name="tag_ids" />


### PR DESCRIPTION
This commit implements unique references for Servers. These references are meant to be used in automation flows such as Odoo automated actions or API calls.

- cx.tower.server: implement references by inheriting 
- cx.tower.reference mixin cx.tower.reference.mixin:
  - `reference` field is now indexed
  - `copy()` function: '(copy)' suffix is now translatable 
- cx.tower.command: fix tests, improve tests structure