### PR TITLE
[14.0][FIX] cetmix_tower_server Fix system variables in python commands

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -291,6 +291,52 @@ You can use any ``jinja2`` supported expressions. For example
        -v {{ odoo_config_location }}:/etc/odoo \
    {% endif %}
 
+Variable Rendering Modes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two rendering modes available:
+
+-  Generic (or ssh) mode
+-  Pythonic mode
+
+Let use the following code as example:
+
+.. code:: bash
+
+   current_branch={{ branch }}
+   current_version={{ package_version }}
+   need_update={{ update_available }}
+
+where ``branch`` is ``main``, ``package_version`` is ``0.12`` and
+``update_available`` is ``False``
+
+Generic Mode
+^^^^^^^^^^^^
+
+Default mode which renders variable values "as is". It is done in order
+to keep compatibility with any code interpreter which may be used to run
+a command. The code from example will be rendered the following way:
+
+.. code:: bash
+
+   current_branch=main
+   current_version=0.12
+   need_update=False
+
+Pythonic Mode
+^^^^^^^^^^^^^
+
+This mode is used in `commands <#configure-a-command>`__ that run Python
+code (``Action: Execute Python code``). In this mode all variable values
+except Boolean and None are enclosed in double quotes. The code from
+example will be rendered the following way:
+
+.. code:: python
+
+   current_branch="main"
+   current_version="0.12"
+   need_update=False
+
 Variable Types
 ~~~~~~~~~~~~~~
 
@@ -531,7 +577,9 @@ and put values in the fields:
 
 -  **Code**: Code to execute. Can be an SSH command or Python code based
    on selected action. This field supports
-   `Variables <#configure-variables>`__.
+   `Variables <#configure-variables>`__. **Important!** Variables used
+   in command are rendered in `different
+   modes <#variable-rendering-modes>`__ based on the command action.
 
 -  **File Template**: File template that will be used to create or
    update file. Check `File Templates <#file-templates>`__ for more
@@ -718,8 +766,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -869,9 +917,9 @@ To check a server log:
 
 |Update server log|
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -879,7 +927,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -894,6 +942,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -7,7 +7,7 @@ from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_compare
 from odoo.tools.safe_eval import wrap_module
 
-requests = wrap_module(__import__("requests"), ["post", "get"])
+requests = wrap_module(__import__("requests"), ["post", "get", "request"])
 
 
 DEFAULT_PYTHON_CODE = """# Available variables:

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -128,6 +128,46 @@ docker run -d -p {{ odoo_port }}:8069 \
 {% endif %}
 ```
 
+### Variable Rendering Modes
+
+There are two rendering modes available:
+
+- Generic (or ssh) mode
+- Pythonic mode
+
+Let use the following code as example:
+
+```bash
+current_branch={{ branch }}
+current_version={{ package_version }}
+need_update={{ update_available }}
+```
+
+where `branch` is `main`, `package_version` is `0.12` and `update_available` is `False`
+
+#### Generic Mode
+
+Default mode which renders variable values "as is". It is done in order to keep compatibility with any code interpreter which may be used to run a command.
+The code from example will be rendered the following way:
+
+```bash
+current_branch=main
+current_version=0.12
+need_update=False
+```
+
+#### Pythonic Mode
+
+This mode is used in [commands](#configure-a-command) that run Python code (`Action: Execute Python code`).
+In this mode all variable values except Boolean and None are enclosed in double quotes.
+The code from example will be rendered the following way:
+
+```python
+current_branch="main"
+current_version="0.12"
+need_update=False
+```
+
 ### Variable Types
 
 Following types of variable values available in [Cetmix Tower](https://cetmix.com/tower):
@@ -272,6 +312,7 @@ To create a new command go to `Cetmix Tower/Commands/Commands` click `Create` an
 
 - **Default Path**: Specify path where command will be executed. This field supports [Variables](#configure-variables). Important: ensure ssh user has access to the location even if executing command using sudo.
 - **Code**: Code to execute. Can be an SSH command or Python code based on selected action. This field supports [Variables](#configure-variables).
+**Important!** Variables used in command are rendered in [different modes](#variable-rendering-modes) based on the command action.
 - **File Template**: File template that will be used to create or update file. Check [File Templates](#file-templates) for more details.
 
 ## Configure a Flight Plan

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:8cb7d9354296b0141e4817259cd70deff721829a82acee198307923364a42cfe
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -473,7 +472,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting/Users &amp; Companies/Users</tt> and open a user whom you would like
 to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In <tt class="docutils literal">Other</tt> section find the <tt class="docutils literal">Cetmix Tower</tt> field and select one of
 the following options:</p>
 <ul class="simple">
@@ -617,6 +616,45 @@ docker run -d -p {{ odoo_port }}:8069 \
     -v {{ odoo_config_location }}:/etc/odoo \
 {% endif %}
 </pre>
+</div>
+<div class="section" id="variable-rendering-modes">
+<h3>Variable Rendering Modes</h3>
+<p>There are two rendering modes available:</p>
+<ul class="simple">
+<li>Generic (or ssh) mode</li>
+<li>Pythonic mode</li>
+</ul>
+<p>Let use the following code as example:</p>
+<pre class="code bash literal-block">
+<span class="nv">current_branch</span><span class="o">={{</span><span class="w"> </span>branch<span class="w"> </span><span class="o">}}</span><span class="w">
+</span><span class="nv">current_version</span><span class="o">={{</span><span class="w"> </span>package_version<span class="w"> </span><span class="o">}}</span><span class="w">
+</span><span class="nv">need_update</span><span class="o">={{</span><span class="w"> </span>update_available<span class="w"> </span><span class="o">}}</span>
+</pre>
+<p>where <tt class="docutils literal">branch</tt> is <tt class="docutils literal">main</tt>, <tt class="docutils literal">package_version</tt> is <tt class="docutils literal">0.12</tt> and
+<tt class="docutils literal">update_available</tt> is <tt class="docutils literal">False</tt></p>
+<div class="section" id="generic-mode">
+<h4>Generic Mode</h4>
+<p>Default mode which renders variable values “as is”. It is done in order
+to keep compatibility with any code interpreter which may be used to run
+a command. The code from example will be rendered the following way:</p>
+<pre class="code bash literal-block">
+<span class="nv">current_branch</span><span class="o">=</span>main<span class="w">
+</span><span class="nv">current_version</span><span class="o">=</span><span class="m">0</span>.12<span class="w">
+</span><span class="nv">need_update</span><span class="o">=</span>False
+</pre>
+</div>
+<div class="section" id="pythonic-mode">
+<h4>Pythonic Mode</h4>
+<p>This mode is used in <a class="reference external" href="#configure-a-command">commands</a> that run Python
+code (<tt class="docutils literal">Action: Execute Python code</tt>). In this mode all variable values
+except Boolean and None are enclosed in double quotes. The code from
+example will be rendered the following way:</p>
+<pre class="code python literal-block">
+<span class="n">current_branch</span><span class="o">=</span><span class="s2">&quot;main&quot;</span><span class="w">
+</span><span class="n">current_version</span><span class="o">=</span><span class="s2">&quot;0.12&quot;</span><span class="w">
+</span><span class="n">need_update</span><span class="o">=</span><span class="kc">False</span>
+</pre>
+</div>
 </div>
 <div class="section" id="variable-types">
 <h3>Variable Types</h3>
@@ -840,7 +878,9 @@ ensure ssh user has access to the location even if executing command
 using sudo.</li>
 <li><strong>Code</strong>: Code to execute. Can be an SSH command or Python code based
 on selected action. This field supports
-<a class="reference external" href="#configure-variables">Variables</a>.</li>
+<a class="reference external" href="#configure-variables">Variables</a>. <strong>Important!</strong> Variables used
+in command are rendered in <a class="reference external" href="#variable-rendering-modes">different
+modes</a> based on the command action.</li>
 <li><strong>File Template</strong>: File template that will be used to create or
 update file. Check <a class="reference external" href="#file-templates">File Templates</a> for more
 details.</li>
@@ -922,7 +962,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1057,7 +1097,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1153,14 +1193,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
 the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
 order to refresh all logs at once. Log output will be displayed in
 the HTML field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
@@ -1168,7 +1208,7 @@ the HTML field below.</li>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1181,7 +1221,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/test_variable.py
+++ b/cetmix_tower_server/tests/test_variable.py
@@ -445,7 +445,6 @@ class TestTowerVariable(TestTowerCommon):
         )
         self.assertEqual(variable_new_global_value_as_bob.value_char, "Global Value 1")
 
-    # @patch("uuid.uuid4", return_value="SuchMuchUUID4")
     def test_system_variable_server_type_values(self):
         """Test system variables of `server` type"""
 
@@ -548,4 +547,52 @@ class TestTowerVariable(TestTowerCommon):
             variable_values["tower"]["tools"]["now"],
             str(mock_now.return_value),
             "System variable doesn't match result provided by tools",
+        )
+
+    def test_make_value_pythonic(self):
+        """Test making variable values 'pythonic`"""
+
+        # Number
+        value = 12.34
+        expected_value = '"12.34"'
+        result_value = self.Command._make_value_pythonic(value)
+
+        self.assertEqual(
+            expected_value, result_value, "Result value doesn't match expected"
+        )
+
+        # Text
+        value = "Doge much like"
+        expected_value = '"Doge much like"'
+        result_value = self.Command._make_value_pythonic(value)
+
+        self.assertEqual(
+            expected_value, result_value, "Result value doesn't match expected"
+        )
+
+        # Boolean
+        value = True
+        expected_value = True
+        result_value = self.Command._make_value_pythonic(value)
+
+        self.assertEqual(
+            expected_value, result_value, "Result value doesn't match expected"
+        )
+
+        # None
+        value = None
+        expected_value = None
+        result_value = self.Command._make_value_pythonic(value)
+
+        self.assertEqual(
+            expected_value, result_value, "Result value doesn't match expected"
+        )
+
+        # Dict
+        value = {"doge": {"likes": "memes", "much": 200}}
+        expected_value = {"doge": {"likes": '"memes"', "much": '"200"'}}
+        result_value = self.Command._make_value_pythonic(value)
+
+        self.assertEqual(
+            expected_value, result_value, "Result value doesn't match expected"
         )


### PR DESCRIPTION
### Steps to reproduce

Create a Python type command with a system variable. Eg {{ tower.server.ipv4 }​.

### Expected result

Variable is replaced with the server IPv4 address.

### Current result

Error:
'str object' has no attribute 'server'

### After this update

System variables are rendered correctly in the Python code commands

### Additional updates 

- Improve test coverage
- Add documentation for variable rendering modes
