### PR TITLE
[14.0][FIX] cetmix_tower_server: Security restrictions on the command wizard path field

### DIFF
--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -78,6 +78,12 @@
         <field name="note">This server has variables configured</field>
     </record>
 
+    <record id="mail_follower_server_test_2" model="mail.followers">
+        <field name="res_model">cx.tower.server</field>
+        <field name="res_id" ref="server_test_2" />
+        <field name="partner_id" ref="base.partner_demo" />
+    </record>
+
     <!--  File templates  -->
     <record id="cx_tower_file_template_demo_1" model="cx.tower.file.template">
         <field name="name">Demo File Template 1</field>
@@ -231,6 +237,7 @@
         <field name="name">List files in directory</field>
         <field name="path">/home/{{ tower.server.username }}</field>
         <field name="code">ls -l</field>
+        <field name="access_level">1</field>
     </record>
     <record id="command_upload_file" model="cx.tower.command">
         <field name="name">Upload file by template</field>
@@ -248,6 +255,7 @@ if {{ branch }}:
 else:
     COMMAND_RESULT={"exit_code": -1, "message": "Branch is not defined!"}
         </field>
+        <field name="access_level">1</field>
     </record>
 
     <record id="command_download_file" model="cx.tower.command">
@@ -266,6 +274,18 @@ else:
             eval="[(6, 0, [ref('cetmix_tower_server.tag_staging')])]"
         />
     </record>
+
+    <record id="plan_test_3" model="cx.tower.plan">
+        <field name="name">Test #3 User</field>
+        <field name="note">Demo of a user-accessible flight plan</field>
+        <field
+            name="tag_ids"
+            eval="[(6, 0, [ref('cetmix_tower_server.tag_staging')])]"
+        />
+        <field name="access_level">1</field>
+
+    </record>
+
     <!-- Line -->
     <record id="plan_test_1_line_1" model="cx.tower.plan.line">
         <field name="sequence">5</field>
@@ -343,6 +363,14 @@ else:
         <field name="sequence">5</field>
         <field name="plan_id" ref="plan_test_2" />
         <field name="command_id" ref="command_execute_flight_plan" />
+    </record>
+
+    <!-- Line -->
+    <record id="plan_test_3_line_1" model="cx.tower.plan.line">
+        <field name="sequence">1</field>
+        <field name="plan_id" ref="plan_test_3" />
+        <field name="command_id" ref="command_list_dir" />
+        <field name="path">/such/much/{{ test_path }}</field>
     </record>
 
 </odoo>

--- a/cetmix_tower_server/tests/test_command_wizard.py
+++ b/cetmix_tower_server/tests/test_command_wizard.py
@@ -67,3 +67,65 @@ class TestTowerCommandWizard(TestTowerCommon):
         # Should not allow to run command on server if no command is selected
         with self.assertRaises(ValidationError):
             test_wizard.execute_command_on_server()
+
+    def test_execute_command_on_server_access_rights(self):
+        """Test access rights for executing command on server"""
+
+        # Add Bob to `root` group
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_root")
+
+        # Create new wizard with Bob as a root user
+        test_wizard = (
+            self.env["cx.tower.command.execute.wizard"]
+            .with_user(self.user_bob)
+            .create(
+                {
+                    "server_ids": [self.server_test_1.id],
+                    "command_id": self.command_create_dir.id,
+                }
+            )
+        ).with_user(self.user_bob)
+
+        # Ensure command can be executed by root
+        test_wizard.execute_command_on_server()
+
+        # Remove Bob from all tower server groups
+        self.remove_from_group(
+            self.user_bob,
+            [
+                "cetmix_tower_server.group_user",
+                "cetmix_tower_server.group_manager",
+                "cetmix_tower_server.group_root",
+            ],
+        )
+
+        # Ensure that regular user cannot execute command on server
+        with self.assertRaises(AccessError):
+            test_wizard.execute_command_on_server()
+
+        #  Add Bob to `user` group and ensure he can execute commands
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+        test_wizard.execute_command_on_server()
+        # Ensure that Bob has access to path field but can't read its value
+        allowed_path = (
+            self.user_bob.has_group("cetmix_tower_server.group_manager")
+            and test_wizard.path
+        )
+
+        self.assertEqual(allowed_path, False)
+        # Ensure that Bob can write to the path field as a member of `group_user`
+        # the result will be None
+        test_wizard.write({"path": "/new/invalid/path"})
+        allowed_path = (
+            test_wizard.path
+            if self.user_bob.has_group("cetmix_tower_server.group_manager")
+            and test_wizard.path
+            else None
+        )
+        self.assertEqual(allowed_path, None)
+
+        # Add Bob to `manager` group and ensure access to execute commands
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        test_wizard.execute_command_on_server()
+        # Check that path access is valid for the manager
+        test_wizard.read(["path"])

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -148,14 +148,16 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
             raise ValidationError(_("Please select a command to execute"))
         # Generate custom label. Will be used later to locate the command log
         log_label = generate_random_id(4)
+        path_value = (
+            self.env.user.has_group("cetmix_tower_server.group_manager") and self.path
+        )
         # Add custom values for log
         custom_values = {"log": {"label": log_label}}
         for server in self.server_ids:
             server.execute_command(
                 self.command_id,
                 sudo=self.use_sudo,
-                path=self.env.user.has_group("cetmix_tower_server.group_manager")
-                and self.path,
+                path=path_value,
                 **custom_values,
             )
         return {

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -30,7 +30,6 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
         compute="_compute_code",
         readonly=False,
         store=True,
-        groups="cetmix_tower_server.group_manager",
         help="Put custom path to run the command.\n"
         "IMPORTANT: this field does NOT support variables!",
     )
@@ -153,7 +152,11 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
         custom_values = {"log": {"label": log_label}}
         for server in self.server_ids:
             server.execute_command(
-                self.command_id, sudo=self.use_sudo, path=self.path, **custom_values
+                self.command_id,
+                sudo=self.use_sudo,
+                path=self.env.user.has_group("cetmix_tower_server.group_manager")
+                and self.path,
+                **custom_values,
             )
         return {
             "type": "ir.actions.act_window",

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -44,6 +44,7 @@
                     </div>
                     <field
                         name="path"
+                        groups="cetmix_tower_server.group_manager"
                         attrs="{'invisible': [('action', '=', 'python_code')]}"
                         placeholder="e.g. /home/user This field does NOT support variables"
                     />


### PR DESCRIPTION
Fixing an [issue](https://github.com/cetmix/cetmix-tower/pull/59#pullrequestreview-2364938160) reported in #59 
Before this PR:

Group_user members can't run command wizards on servers due to field "path" restricitions

After this PR:

Members of group_user can run command wizards on servers