### PR TITLE
[14.0 t3956 cetmix tower server appearance fixes

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -153,3 +153,13 @@ class CxTowerCommand(models.Model):
                 name = rec.name
             res.append((rec.id, name))
         return res
+
+    def action_open_command_logs(self):
+        """
+        Open current current command log records
+        """
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "cetmix_tower_server.action_cx_tower_command_log"
+        )
+        action["domain"] = [("command_id", "=", self.id)]
+        return action

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -179,13 +179,17 @@ class CxTowerCommandLog(models.Model):
         """
         # Trigger next flightplan line
         for rec in self:
+            context_timestamp = fields.Datetime.context_timestamp(
+                self, fields.Datetime.now()
+            )
             if rec.plan_log_id:  # type: ignore
                 rec.plan_log_id._plan_command_finished(rec)  # type: ignore
             elif rec.command_status == 0:
                 rec.create_uid.notify_success(
                     message=_(
-                        "Command '%(name)s' finished successfully",
+                        "%(timestamp)s<br/>" "Command '%(name)s' finished successfully",
                         name=rec.command_id.name,
+                        timestamp=context_timestamp,
                     ),
                     title=rec.server_id.name,
                     sticky=True,
@@ -193,10 +197,12 @@ class CxTowerCommandLog(models.Model):
             else:
                 rec.create_uid.notify_danger(
                     message=_(
+                        "%(timestamp)s<br/>"
                         "Command '%(name)s'"
-                        " finished with error.\n"
+                        " finished with error. "
                         "Please check the command log for details.",
                         name=rec.command_id.name,
+                        timestamp=context_timestamp,
                     ),
                     title=rec.server_id.name,
                     sticky=True,

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -263,3 +263,13 @@ class CxTowerPlan(models.Model):
                 )
             else:
                 record.access_level_warn_msg = False
+
+    def action_open_plan_logs(self):
+        """
+        Open current flight plan log records
+        """
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "cetmix_tower_server.action_cx_tower_plan_log"
+        )
+        action["domain"] = [("plan_id", "=", self.id)]
+        return action

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -160,11 +160,16 @@ class CxTowerPlanLog(models.Model):
         Inherit to implement your own hooks
         """
         for log in self:
+            context_timestamp = fields.Datetime.context_timestamp(
+                self, fields.Datetime.now()
+            )
             if log.plan_status == 0:
                 log.create_uid.notify_success(
                     message=_(
+                        "%(timestamp)s<br/>"
                         "Flight Plan '%(name)s' finished successfully",
                         name=log.plan_id.name,
+                        timestamp=context_timestamp,
                     ),
                     title=log.server_id.name,
                     sticky=True,
@@ -172,10 +177,12 @@ class CxTowerPlanLog(models.Model):
             else:
                 log.create_uid.notify_danger(
                     message=_(
+                        "%(timestamp)s<br/>"
                         "Flight Plan '%(name)s'"
-                        " finished with error.\n"
+                        " finished with error. "
                         "Please check the flight plan log for details.",
                         name=log.plan_id.name,
+                        timestamp=context_timestamp,
                     ),
                     title=log.server_id.name,
                     sticky=True,

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -83,6 +83,7 @@ class CxTowerServerLog(models.Model):
         Open log record in current window
         """
         self.ensure_one()
+        self.action_get_log_text()
         return {
             "type": "ir.actions.act_window",
             "name": self.name,

--- a/cetmix_tower_server/models/cx_tower_variable_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_variable_mixin.py
@@ -5,7 +5,7 @@ import uuid
 from odoo import fields, models
 
 
-class TowerValueMixin(models.AbstractModel):
+class TowerVariableMixin(models.AbstractModel):
     """Used to implement variables and variable values.
     Inherit in your model if you want to use variables in it.
     """

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -6,7 +6,18 @@
         <field name="model">cx.tower.command</field>
         <field name="arch" type="xml">
             <form>
+
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="action_open_command_logs"
+                            type="object"
+                            string="Logs"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                        />
+                    </div>
+
                     <div
                         class="alert alert-warning"
                         role="alert"
@@ -19,10 +30,12 @@
                             This command can be used only in Flight Plans.
                         </p>
                         <p attrs="{'invisible': [('action', '!=', 'python_code')]}">
-                            Remember: Python code is executed on the Tower server, not on the remote one.
+                            Remember: Python code is executed on the Tower server, not on the remote
+                            one.
                         </p>
                     </div>
                     <group>
+
                         <group>
                             <field name="name" />
                             <field name="reference" />
@@ -79,29 +92,35 @@
                             <div style="margin-top: 4px;">
                                 <h3>Help with Python expressions</h3>
                                 <p
-                                >Various fields may use Python code or Python expressions. The following variables can be used:</p>
+                                >Various fields may use Python code or Python expressions. The
+                                    following variables can be used:</p>
                                 <ul>
                                     <li><code>user</code>: Current Odoo user</li>
                                     <li><code
-                                        >env</code>: Odoo Environment on which the action is triggered</li>
+                                        >env</code>: Odoo Environment on which the action is
+                                        triggered</li>
                                     <li><code
                                         >server</code>: Server on which the command is run</li>
                                     <li><code>time</code>, <code>datetime</code>, <code
-                                        >dateutil</code>, <code
+                                        >dateutil</code>
+                                        , <code
                                         >timezone</code>: useful Python libraries</li>
                                     <li><code
                                         >requests</code>: Python 'requests' library</li>
                                     <li><code
                                         >UserError</code>: Warning Exception to use with <code
-                                        >raise</code></li>
+                                        >
+                                        raise</code></li>
                                     <li
-                                    >Each python code command returns the COMMAND_RESULT value which is a dictionary.</li>
+                                    >Each python code command returns the COMMAND_RESULT value
+                                        which is a dictionary.</li>
                                 </ul>
                                 <p
                                 >There are two default keys in the dictionary, e.g.:</p>
-<code style='white-space: pre-wrap'>
-x = 2*10
-COMMAND_RESULT = {"exit_code": x, "message": "This will be logged as an error message because exit code !=0"}
+                                <code style='white-space: pre-wrap'>
+                                    x = 2*10
+                                    COMMAND_RESULT = {"exit_code": x, "message": "This will be
+                                    logged as an error message because exit code !=0"}
 </code>
                             </div>
                         </page>
@@ -170,12 +189,17 @@ COMMAND_RESULT = {"exit_code": x, "message": "This will be logged as an error me
                 />
                 <separator />
                 <filter
-                    string="Run shell command"
+                    string="SSH Command"
                     name="filter_run_command"
                     domain="[('action', '=', 'ssh_command')]"
                 />
                 <filter
-                    string="Push file (template)"
+                    string="Python code"
+                    name="filter_python_command"
+                    domain="[('action', '=', 'python_code')]"
+                />
+                <filter
+                    string="File from template"
                     name="file_from_template"
                     domain="[('action', '=', 'file_using_template')]"
                 />
@@ -191,7 +215,15 @@ COMMAND_RESULT = {"exit_code": x, "message": "This will be logged as an error me
                     name="archived"
                     domain="[('active', '=', False)]"
                 />
-             </search>
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Action"
+                        name="group_action"
+                        domain="[]"
+                        context="{'group_by': 'action'}"
+                    />
+                </group>
+            </search>
         </field>
     </record>
 

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -155,6 +155,8 @@
                 <field name="server_id" />
                 <field name="full_server_path" optional="hide" />
                 <field name="sync_date_last" />
+                <field name="template_id" optional="show" />
+
             </tree>
         </field>
     </record>

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -10,11 +10,7 @@
                     <group>
                         <group>
                             <field name="sequence" />
-                            <field
-                                name="condition"
-                                widget="ace"
-                                options="{'mode': 'python'}"
-                            />
+
                             <field
                                 name="command_id"
                                 context="{'command_show_server_names': True}"
@@ -25,7 +21,12 @@
                                 placeholder="e.g. /such/much/{{ path }}, overrides command path"
                             />
                         </group>
+
+
                     </group>
+                    <group>
+                    <field name="condition" widget="ace" options="{'mode': 'python'}" />
+            </group>
                     <notebook>
                         <page name="preview" string="Command Preview">
                             <group>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -7,7 +7,15 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="action_open_plan_logs"
+                            type="object"
+                            string="Logs"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                        />
+                    </div>
                     <div
                         groups="cetmix_tower_server.group_root,cetmix_tower_server.group_manager"
                         class="alert alert-warning"

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -75,8 +75,22 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="reference" optional="show" />
+
                 <field name="value_ids_count" />
+
             </tree>
+        </field>
+    </record>
+
+    <record id="cx_tower_variable_search_view" model="ir.ui.view">
+        <field name="name">cx.tower.variable.view.search</field>
+        <field name="model">cx.tower.variable</field>
+        <field name="arch" type="xml">
+            <search string="Search Values">
+                <field name="name" />
+                <field name="reference" />
+            </search>
         </field>
     </record>
 


### PR DESCRIPTION
- [x] 1.     Files: Show template (option) in the file list
- [x] 2.     Command/Plan: Show smart button which leads from Commands/Plans to logs
- [x] 3.     Command/plan finished notification: show local user time in notifications
- [x] 4.     Variables: class TowerValueMixin -> class TowerVariableMixin
- [x] 5.     Server logs: refresh log when "Open" button is clicked.
- [x] 6.     Command: Move "condition" field to some other place to make it readable
- [x] 7.     Add to variable list view reference field optional = hide
- [x] 8.     Add to variable search view reference
- [x] 9.     Add to command tree view group_by action field
- [x] 10.     Add to commands tree view python commands filter