### PR TITLE
[14.0][IMP] cetmix_tower_server File Template references

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -519,6 +519,8 @@ To create a new file template go to ``Cetmix Tower/Files/Templates``
 click ``Create`` and put values in the fields:
 
 -  **Name**: Template name
+-  **Reference**: Leave the "reference" field blank to generate a
+   reference automatically.
 -  **File Name**: Filesystem name of the file(s) created from this
    template. This field supports `Variables <#configure-variables>`__.
 -  **Directory on server**: Directory on remote server where this file
@@ -795,8 +797,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -956,9 +958,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -966,7 +968,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -981,6 +983,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -8,6 +8,7 @@ from .cx_tower_file import TEMPLATE_FILE_FIELD_MAPPING
 
 class CxTowerFileTemplate(models.Model):
     _name = "cx.tower.file.template"
+    _inherit = ["cx.tower.reference.mixin"]
     _description = "Cx Tower File Template"
 
     def _compute_file_count(self):
@@ -17,7 +18,6 @@ class CxTowerFileTemplate(models.Model):
         for template in self:
             template.file_count = len(template.file_ids)
 
-    name = fields.Char(help="Template Name")
     file_name = fields.Char(
         help="Default full file name with file type for example: test.txt",
     )

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -286,6 +286,7 @@ File templates are used to create and manage multiple files in bulk. Once a temp
 To create a new file template go to `Cetmix Tower/Files/Templates` click `Create` and put values in the fields:
 
 - **Name**: Template name
+- **Reference**: Leave the "reference" field blank to generate a reference automatically.
 - **File Name**: Filesystem name of the file(s) created from this template. This field supports [Variables](#configure-variables).
 - **Directory on server**: Directory on remote server where this file will be stored. This field supports [Variables](#configure-variables).
 - **Source**: File source. Available options are `Server` and `Tower`. Check above for more details.

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:5a33edf097b57dc04d2940477088ab5680c461d222dba5a8e80d26a37c0cd2f2
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -473,7 +472,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting/Users &amp; Companies/Users</tt> and open a user whom you would like
 to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In <tt class="docutils literal">Other</tt> section find the <tt class="docutils literal">Cetmix Tower</tt> field and select one of
 the following options:</p>
 <ul class="simple">
@@ -829,6 +828,8 @@ Once a template is modified all related files are automatically updated.</p>
 click <tt class="docutils literal">Create</tt> and put values in the fields:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Template name</li>
+<li><strong>Reference</strong>: Leave the “reference” field blank to generate a
+reference automatically.</li>
 <li><strong>File Name</strong>: Filesystem name of the file(s) created from this
 template. This field supports <a class="reference external" href="#configure-variables">Variables</a>.</li>
 <li><strong>Directory on server</strong>: Directory on remote server where this file
@@ -990,7 +991,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1125,7 +1126,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1221,14 +1222,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
 the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
 order to refresh all logs at once. Log output will be displayed in
 the HTML field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1245,7 +1246,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1258,7 +1259,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -26,6 +26,12 @@
                                 required="1"
                             />
                         </h1>
+                        <h3>
+                            <field
+                                name="reference"
+                                placeholder="Can contain English letters, digits and '_'. Leave blank to autogenerate"
+                            />
+                        </h3>
                     </div>
                     <group>
                         <group>
@@ -65,9 +71,10 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="reference" optional="show" />
                 <field name="file_type" optional="show" />
                 <field name="file_name" optional="show" />
-                <field name="server_dir" optional="show" />
+                <field name="server_dir" optional="hide" />
                 <field
                     name="tag_ids"
                     widget="many2many_tags"
@@ -84,6 +91,7 @@
         <field name="arch" type="xml">
             <search string="Search File Templates">
                 <field name="name" />
+                <field name="reference" />
                 <field name="server_dir" />
                 <field name="tag_ids" />
                 <filter


### PR DESCRIPTION
Add reference support for File Templates.
Allows to refer File Templates easy way in various automation flows as well export/import them eg in yaml.