### PR TITLE
[14.0][FIX] cetmix_tower_server Reference generation

### DIFF
--- a/cetmix_tower_server/models/cx_tower_reference_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_reference_mixin.py
@@ -66,9 +66,21 @@ class CxTowerReferenceMixin(models.AbstractModel):
         # Check if the same reference already exists and add a suffix if yes
         counter = 1
         final_reference = reference
-        while self.search_count([("reference", "=", final_reference)]) > 0:
+
+        # If exclude same records from search results
+        if self:
+            domain = [("id", "not in", self.ids)]
+        else:
+            domain = []
+
+        final_domain = expression.AND([domain, [("reference", "=", final_reference)]])
+
+        while self.search_count(final_domain) > 0:
             counter += 1
             final_reference = _(f"{reference}_{counter}")
+            final_domain = expression.AND(
+                [domain, [("reference", "=", final_reference)]]
+            )
 
         return final_reference
 

--- a/cetmix_tower_server/tests/test_reference_mixin.py
+++ b/cetmix_tower_server/tests/test_reference_mixin.py
@@ -72,6 +72,11 @@ class TestTowerReference(TestTowerCommon):
         yet_another_template_copy.write({"reference": False})
         self.assertEqual(yet_another_template_copy.reference, "chad")
 
+        # -- 9 --
+        # Update record with the same reference name and ensure it remains the same
+        yet_another_template_copy.write({"reference": "chad"})
+        self.assertEqual(yet_another_template_copy.reference, "chad")
+
     def test_search_by_reference(self):
         """Search record by its reference"""
 


### PR DESCRIPTION
This commit fixes the following issue:

## Steps to reproduce

- Create a new record with reference, eg a command with reference "my_command"
- Update this record with the same reference value: `write({"reference": "my_command"})`

## Expected result

- Reference should remain the same because it's not changed

## Current result

- Reference is updated to "my_command_2"