### PR TITLE
[14.0][IMP] cetmix_tower_yaml Many2one fields support

### DIFF
--- a/cetmix_tower_yaml/README.rst
+++ b/cetmix_tower_yaml/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server YAML
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_yaml
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_yaml
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -58,17 +58,65 @@ No configuration is required.
 Usage
 =====
 
+Data Export/Import
+------------------
+
 To export data into YAML format:
 
 -  Open the record you would like to export
--  Copy  YAML code from the text field located under the "YAML" tab in
-   the form view
+-  Copy YAML code from the text field located under the "YAML" tab in
+   the form view. Activate "Explode" switch if you want to export data
+   in `exploded mode <#exploded-mode>`__
 
 To import data from YAML:
 
 -  Open the record you would like to import
 -  Insert YAML code from in the text field located under the "YAML" tab
-   in the form view
+   in the form view.
+
+Data Export/Import Modes
+------------------------
+
+Data stored in related fields such as One2many, Many2one and Many2many
+can be handled using two different modes.
+
+Reference mode
+~~~~~~~~~~~~~~
+
+In this mode related record is represented with its reference:
+
+.. code:: yaml
+
+   file_template_id: my_custom_template
+
+In case related record cannot be resolved using provided reference while
+importing data from YAML, ``Null`` value will be assigned instead.
+
+Exploded mode
+~~~~~~~~~~~~~
+
+In this mode related record is represented as a child YAML structure:
+
+.. code:: yaml
+
+   file_template_id:
+     cetmix_tower_model: file_template
+     cetmix_tower_yaml_version: 1
+     code: false
+     file_name: much_logs.txt
+     file_type: text
+     keep_when_deleted: false
+     name: Very my custom
+     note: Hey!
+     reference: my_custom_template
+     server_dir: /var/log/my/files
+     source: server
+
+This mode allows to export/import child records together with the parent
+one. In case any of the child fields are modified in YAML related record
+in Odoo will be modified using those values. In case related record
+cannot be resolved using child reference while importing data from YAML,
+new child record will be created in Odoo using YAML values.
 
 Bug Tracker
 ===========
@@ -76,7 +124,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_yaml%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_yaml%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -91,6 +139,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_yaml>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_yaml>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_yaml/models/cx_tower_command.py
+++ b/cetmix_tower_yaml/models/cx_tower_command.py
@@ -9,22 +9,13 @@ class CxTowerCommand(models.Model):
 
     def _get_fields_for_yaml(self):
         res = super()._get_fields_for_yaml()
-        if self.action in ["ssh_command", "python_code"]:
-            res += [
-                "access_level",
-                "allow_parallel_run",
-                "path",
-                "note",
-                "code",
-                "action",
-            ]
-        elif self.action == "file_using_template":
-            res += [
-                "access_level",
-                "allow_parallel_run",
-                "path",
-                "note",
-                "action",
-                "file_template_id",
-            ]
+        res += [
+            "access_level",
+            "allow_parallel_run",
+            "action",
+            "code",
+            "file_template_id",
+            "note",
+            "path",
+        ]
         return res

--- a/cetmix_tower_yaml/readme/USAGE.md
+++ b/cetmix_tower_yaml/readme/USAGE.md
@@ -1,9 +1,49 @@
+## Data Export/Import
+
 To export data into YAML format:
 
 - Open the record you would like to export
-- Copy  YAML code from the text field located under the "YAML" tab in the form view
+- Copy YAML code from the text field located under the "YAML" tab in the form view.
+Activate "Explode" switch if you want to export data in [exploded mode](#exploded-mode)
 
 To import data from YAML:
 
 - Open the record you would like to import
-- Insert YAML code from in the text field located under the "YAML" tab in the form view
+- Insert YAML code from in the text field located under the "YAML" tab in the form view.
+
+## Data Export/Import Modes
+
+Data stored in related fields such as One2many, Many2one and Many2many can be handled using two different modes.
+
+### Reference mode
+
+In this mode related record is represented with its reference:
+
+```yaml
+file_template_id: my_custom_template
+```
+
+In case related record cannot be resolved using provided reference while importing  data from YAML, `Null` value will be assigned instead.
+
+### Exploded mode
+
+In this mode related record is represented as a child YAML structure:
+
+```yaml
+file_template_id:
+  cetmix_tower_model: file_template
+  cetmix_tower_yaml_version: 1
+  code: false
+  file_name: much_logs.txt
+  file_type: text
+  keep_when_deleted: false
+  name: Very my custom
+  note: Hey!
+  reference: my_custom_template
+  server_dir: /var/log/my/files
+  source: server
+```
+
+This mode allows to export/import child records together with the parent one.
+In case any of the child fields are modified in YAML related record in Odoo will be modified using those values.
+In case related record cannot be resolved using child reference while importing data from YAML, new child record will be created in Odoo using YAML values.

--- a/cetmix_tower_yaml/static/description/index.html
+++ b/cetmix_tower_yaml/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:e33efeb3e909feba861c7daaed2b87a9a9cc2d37209cee616ba987f532ea5b5e
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>This module implements YAML format data import/export for&nbsp;<a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower.</a></p>
 <p>Following data&nbsp;models are supported:</p>
@@ -388,11 +387,19 @@ Tower.</a></p>
 <ul class="simple">
 <li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
 <li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a><ul>
+<li><a class="reference internal" href="#data-export-import" id="toc-entry-4">Data Export/Import</a></li>
+<li><a class="reference internal" href="#data-export-import-modes" id="toc-entry-5">Data Export/Import Modes</a><ul>
+<li><a class="reference internal" href="#reference-mode" id="toc-entry-6">Reference mode</a></li>
+<li><a class="reference internal" href="#exploded-mode" id="toc-entry-7">Exploded mode</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-8">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-9">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-10">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -411,38 +418,79 @@ such data such as <tt class="docutils literal">YAML</tt>.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
+<div class="section" id="data-export-import">
+<h2><a class="toc-backref" href="#toc-entry-4">Data Export/Import</a></h2>
 <p>To export data into YAML format:</p>
 <ul class="simple">
 <li>Open the record you would like to export</li>
-<li>Copy &nbsp;YAML code from&nbsp;the text field located under the&nbsp;“YAML” tab in
-the form view</li>
+<li>Copy YAML code from&nbsp;the text field located under the&nbsp;“YAML” tab in
+the form view. Activate “Explode” switch if you want to export data
+in <a class="reference external" href="#exploded-mode">exploded mode</a></li>
 </ul>
 <p>To import data from YAML:</p>
 <ul class="simple">
 <li>Open the record you would like to import</li>
 <li>Insert YAML code from in the text field located under the&nbsp;“YAML” tab
-in the form view</li>
+in the form view.</li>
 </ul>
 </div>
+<div class="section" id="data-export-import-modes">
+<h2><a class="toc-backref" href="#toc-entry-5">Data Export/Import Modes</a></h2>
+<p>Data stored in related fields such as One2many, Many2one and Many2many
+can be handled using two different modes.</p>
+<div class="section" id="reference-mode">
+<h3><a class="toc-backref" href="#toc-entry-6">Reference mode</a></h3>
+<p>In this mode related record is represented with its reference:</p>
+<pre class="code yaml literal-block">
+<span class="nt">file_template_id</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">my_custom_template</span>
+</pre>
+<p>In case related record cannot be resolved using provided reference while
+importing data from YAML, <tt class="docutils literal">Null</tt> value will be assigned instead.</p>
+</div>
+<div class="section" id="exploded-mode">
+<h3><a class="toc-backref" href="#toc-entry-7">Exploded mode</a></h3>
+<p>In this mode related record is represented as a child YAML structure:</p>
+<pre class="code yaml literal-block">
+<span class="nt">file_template_id</span><span class="p">:</span><span class="w">
+  </span><span class="nt">cetmix_tower_model</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">file_template</span><span class="w">
+  </span><span class="nt">cetmix_tower_yaml_version</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">1</span><span class="w">
+  </span><span class="nt">code</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">false</span><span class="w">
+  </span><span class="nt">file_name</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">much_logs.txt</span><span class="w">
+  </span><span class="nt">file_type</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">text</span><span class="w">
+  </span><span class="nt">keep_when_deleted</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">false</span><span class="w">
+  </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">Very my custom</span><span class="w">
+  </span><span class="nt">note</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">Hey!</span><span class="w">
+  </span><span class="nt">reference</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">my_custom_template</span><span class="w">
+  </span><span class="nt">server_dir</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">/var/log/my/files</span><span class="w">
+  </span><span class="nt">source</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">server</span>
+</pre>
+<p>This mode allows to export/import child records together with the parent
+one. In case any of the child fields are modified in YAML related record
+in Odoo will be modified using those values. In case related record
+cannot be resolved using child reference while importing data from YAML,
+new child record will be created in Odoo using YAML values.</p>
+</div>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-8">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_yaml%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_yaml%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-9">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
 <ul class="simple">
 <li>Cetmix</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_yaml">cetmix/cetmix-tower</a> project on GitHub.</p>
+<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_yaml">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
@@ -6,24 +6,20 @@ from odoo.tests import TransactionCase
 class TestTowerYamlMixin(TransactionCase):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
-
-        # Patch method to return "access_level" field too
-        def _get_fields_for_yaml(self):
-            return ["access_level", "name", "reference"]
-
         self.YamlMixin = self.env["cx.tower.yaml.mixin"]
-        self.YamlMixin._patch_method("_get_fields_for_yaml", _get_fields_for_yaml)
-
-    def tearDown(self):
-        # Remove the monkey patches
-        self.YamlMixin._revert_method("_get_fields_for_yaml")
-        super(TestTowerYamlMixin, self).tearDown()
 
     def test_post_process_record_values(self):
         """Test value post processing.
         We test common fields only because this method can be overridden
         in models inheriting this mixin.
         """
+
+        # Patch method to return "access_level" field too
+        def _get_fields_for_yaml(self):
+            return ["access_level", "name", "reference"]
+
+        self.YamlMixin._patch_method("_get_fields_for_yaml", _get_fields_for_yaml)
+
         source_values = {
             "access_level": "3",
             "id": 22332,
@@ -55,11 +51,20 @@ class TestTowerYamlMixin(TransactionCase):
             "Other values should remain unchanged",
         )
 
+        # Restore original method
+        self.YamlMixin._revert_method("_get_fields_for_yaml")
+
     def test_post_process_yaml_dict_values(self):
         """Test YAML dict value post processing.
         We test common fields only because this method can be overridden
         in models inheriting this mixin.
         """
+
+        # Patch method to return "access_level" field too
+        def _get_fields_for_yaml(self):
+            return ["access_level", "name", "reference"]
+
+        self.YamlMixin._patch_method("_get_fields_for_yaml", _get_fields_for_yaml)
 
         # -- 1 --
         # Test regular flow
@@ -143,3 +148,176 @@ class TestTowerYamlMixin(TransactionCase):
                 ),
                 "Exception message doesn't match",
             )
+
+        # Restore original method
+        self.YamlMixin._revert_method("_get_fields_for_yaml")
+
+    def test_process_m2o_value_no_explode(self):
+        """Test non exploded m2m values
+        Non exploded values represent related record with reference only
+        """
+
+        # We are using command with file template for that
+        file_template = self.env["cx.tower.file.template"].create(
+            {"name": "Test m2o", "reference": "test_m2o"}
+        )
+        command = self.env["cx.tower.command"].create(
+            {
+                "name": "Command test m2o",
+                "action": "file_using_template",
+                "file_template_id": file_template.id,
+            }
+        )
+
+        # -- 1 --
+        # Record -> Yaml
+        result = command._process_m2o_value(
+            field="file_template_id",
+            value=(command.file_template_id.id, command.file_template_id.name),
+            record_mode=True,
+        )
+        self.assertEqual(
+            result, file_template.reference, "Reference was not resolved correctly"
+        )
+
+        # -- 2 --
+        # Yaml -> Record
+        result = command._process_m2o_value(
+            field="file_template_id", value=file_template.reference, record_mode=False
+        )
+        self.assertEqual(
+            result, file_template.id, "Record ID was not resolved correctly"
+        )
+
+        # -- 3 --
+        # Yaml with non existing reference -> Record
+        result = command._process_m2o_value(
+            field="file_template_id", value="such_much_not_reference", record_mode=False
+        )
+        self.assertFalse(result, "Must be an 'False'")
+
+        # -- 4 --
+        # No record -> Yaml
+        result = command._process_m2o_value(
+            field="file_template_id",
+            value=self.env["cx.tower.file.template"],
+            record_mode=True,
+        )
+        self.assertFalse(result, "Result must be 'False'")
+
+    def test_process_m2o_value_explode(self):
+        """Test exploded m2m values
+        Exploded values represent related record with a child YAML structure
+        """
+
+        # We are using command with file template for that
+        file_template = self.env["cx.tower.file.template"].create(
+            {"name": "Test m2o", "reference": "test_m2o"}
+        )
+        file_template_values = file_template._prepare_record_for_yaml()
+        command = (
+            self.env["cx.tower.command"]
+            .create(
+                {
+                    "name": "Command test m2o",
+                    "action": "file_using_template",
+                    "file_template_id": file_template.id,
+                    "yaml_explode": True,  # This is not used
+                }
+            )
+            .with_context(explode_related_record=True)
+        )  # and this is the actual trigger
+
+        # -- 1 --
+        # Record -> Yaml
+        result = command._process_m2o_value(
+            field="file_template_id",
+            value=(command.file_template_id.id, command.file_template_id.name),
+            record_mode=True,
+        )
+        self.assertEqual(
+            result, file_template_values, "Reference was not resolved correctly"
+        )
+
+        # -- 2 --
+        # Yaml -> Record
+        result = command._process_m2o_value(
+            field="file_template_id", value=file_template_values, record_mode=False
+        )
+        self.assertEqual(
+            result, file_template.id, "Record ID was not resolved correctly"
+        )
+
+        # -- 3 --
+        # Yaml with non existing reference -> Record
+        file_template_values.update(
+            {
+                "name": "Very new name",
+                "reference": "such_much_not_reference",
+                "source": "server",
+                "file_type": "binary",
+            }
+        )
+        result = command._process_m2o_value(
+            field="file_template_id", value=file_template_values, record_mode=False
+        )
+
+        # New record must be created
+        record = self.env["cx.tower.file.template"].browse(result)
+        self.assertEqual(
+            record.name, file_template_values["name"], "New record value doesn't match"
+        )
+        self.assertEqual(
+            record.reference,
+            file_template_values["reference"],
+            "New record value doesn't match",
+        )
+        self.assertEqual(
+            record.source,
+            file_template_values["source"],
+            "New record value doesn't match",
+        )
+        self.assertEqual(
+            record.file_type,
+            file_template_values["file_type"],
+            "New record value doesn't match",
+        )
+
+        # -- 4 --
+        # Yaml with no reference at all -> Record
+        values_with_no_references = {
+            "name": "Sorry no reference here",
+            "source": "tower",
+            "file_type": "binary",
+        }
+        result = command._process_m2o_value(
+            field="file_template_id", value=values_with_no_references, record_mode=False
+        )
+
+        # New record must be created
+        record = self.env["cx.tower.file.template"].browse(result)
+
+        self.assertEqual(
+            record.name,
+            values_with_no_references["name"],
+            "New record value doesn't match",
+        )
+        self.assertEqual(
+            record.source,
+            values_with_no_references["source"],
+            "New record value doesn't match",
+        )
+        self.assertEqual(
+            record.file_type,
+            values_with_no_references["file_type"],
+            "New record value doesn't match",
+        )
+
+        # -- 5 --
+        # No record -> Yaml
+        result = command._process_m2o_value(
+            field="file_template_id",
+            value=self.env["cx.tower.file.template"],
+            record_mode=True,
+        )
+        self.assertFalse(result, "Result must be 'False'")

--- a/cetmix_tower_yaml/views/cx_tower_command_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_command_view.xml
@@ -8,6 +8,9 @@
         <field name="arch" type="xml">
             <page name="code" position="after">
                 <page name="yaml" string="YAML">
+                    <group>
+                        <field name="yaml_explode" widget="boolean_toggle" />
+                    </group>
                     <field name="yaml_code" widget="ace" />
                     <field name="yaml_file" filename="yaml_file_name" />
                     <field name="yaml_file_name" invisible="1" />


### PR DESCRIPTION
Add support for many2one fields export/import
-----------------------------------------------

Field value is saved in yaml as a related record reference.
Eg 'file_template_id: file_template_1' where 'file_template_1' is the 'reference' field value of the related record.

Post fix update
---------------
Enable previously disabled test that was skipped due to an error in reference generation (t3982).