### PR TITLE
[14.0][FIX] cetmix_tower_server: Clean up Python command execution result

### DIFF
--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -450,6 +450,9 @@ class CxTowerKey(models.Model):
 
         # Replace keys with values
         for key_value in key_values:
+            # If key_value includes quotes, remove them for the replacement
+            if key_value.startswith('"') and key_value.endswith('"'):
+                key_value = key_value[1:-1]
             # Replace key including key terminator
             code = code.replace(key_value, self.SECRET_VALUE_SPOILER)
 

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -451,8 +451,7 @@ class CxTowerKey(models.Model):
         # Replace keys with values
         for key_value in key_values:
             # If key_value includes quotes, remove them for the replacement
-            if key_value.startswith('"') and key_value.endswith('"'):
-                key_value = key_value[1:-1]
+            key_value = key_value.strip('"')
             # Replace key including key terminator
             code = code.replace(key_value, self.SECRET_VALUE_SPOILER)
 

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1166,9 +1166,9 @@ class CxTowerServer(models.Model):
             if result:
                 status = result.get("exit_code", 0)
                 if status == 0:
-                    response = result.get("message")
+                    response = [result.get("message")]
                 else:
-                    error = result.get("message")
+                    error = [result.get("message")]
 
         except Exception as e:
             if raise_on_error:

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -266,7 +266,7 @@ class TestTowerCommon(TransactionCase):
             if status != 0:
                 if raise_on_error:
                     raise ValidationError(_("SSH execute command error"))
-                return self._parse_ssh_command_results(-1, [], error, secrets, **kwargs)
+                return self._parse_command_results(-1, [], error, secrets, **kwargs)
 
             command = self._prepare_ssh_command(command, command_path, sudo)
 
@@ -280,7 +280,7 @@ class TestTowerCommon(TransactionCase):
                     response_list += response
                     error_list += error
 
-            return self._parse_ssh_command_results(
+            return self._parse_command_results(
                 status, response, error, secrets, **kwargs
             )
 

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -45,6 +45,19 @@ else:
             }
         )
 
+        self.command_create_new_command_2 = self.Command.create(
+            {
+                "name": "Create new command",
+                "action": "python_code",
+                "code": """
+COMMAND_RESULT = {
+    "exit_code": 0,
+    "message": #!cxtower.secret.key_2_secret!#,
+}
+    """,
+            }
+        )
+
     def test_ssh_command_prepare_method_without_path(self):
         """Test ssh command preparation in different modes without path"""
 
@@ -493,7 +506,7 @@ else:
         response = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
         error = []
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
+        ssh_command_result = self.Server._parse_command_results(
             status, response, error, key_values=[f"{self.secret_2.secret_value}"]
         )
 
@@ -521,9 +534,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -547,9 +558,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -571,9 +580,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -597,7 +604,7 @@ else:
         error = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
         response = []
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
+        ssh_command_result = self.Server._parse_command_results(
             status, response, error, key_values=[f"{self.secret_2.secret_value}"]
         )
 
@@ -831,6 +838,30 @@ else:
         self.assertEqual(
             command_result["response"],
             "New command was created",
+            "The response must be text",
+        )
+        self.assertIsNone(
+            command_result["error"],
+            "Error in command result must be set to None",
+        )
+
+    def test_execute_python_code_with_secret(self):
+        """
+        Test python execution code
+        """
+        rendered_command = self.server_test_1._render_command(
+            self.command_create_new_command_2
+        )
+
+        command_result = self.server_test_1._execute_python_code(
+            rendered_command["rendered_code"]
+        )
+        self.assertEqual(
+            command_result["status"], 0, "The command result status must be 0"
+        )
+        self.assertEqual(
+            command_result["response"],
+            "Wow! Such much secret!",
             "The response must be text",
         )
         self.assertIsNone(


### PR DESCRIPTION
Renamed method _parse_ssh_command_results to  _parse_command_results for using not only for SSH but for any command including Python one.

Task: 3952