### PR TITLE
[14.0][FIX] t3952 cetmix_tower_server: Clean up Python command execution

### DIFF
--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -442,14 +442,13 @@ class CxTowerKey(models.Model):
             Text: cleaned code
         """
 
-        ## No need to search if code is too short
-        if not key_values or len(code) <= len(self.KEY_PREFIX) + 3 + len(
-            self.KEY_TERMINATOR
-        ):  # at least one dot separator and two symbols
+        if not key_values:
             return code
 
         # Replace keys with values
         for key_value in key_values:
+            # If key_value includes quotes, remove them for the replacement
+            key_value = key_value.strip('"')
             # Replace key including key terminator
             code = code.replace(key_value, self.SECRET_VALUE_SPOILER)
 

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -266,7 +266,7 @@ class TestTowerCommon(TransactionCase):
             if status != 0:
                 if raise_on_error:
                     raise ValidationError(_("SSH execute command error"))
-                return self._parse_ssh_command_results(-1, [], error, secrets, **kwargs)
+                return self._parse_command_results(-1, [], error, secrets, **kwargs)
 
             command = self._prepare_ssh_command(command, command_path, sudo)
 
@@ -280,7 +280,7 @@ class TestTowerCommon(TransactionCase):
                     response_list += response
                     error_list += error
 
-            return self._parse_ssh_command_results(
+            return self._parse_command_results(
                 status, response, error, secrets, **kwargs
             )
 

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -29,6 +29,39 @@ class TestTowerCommand(TestTowerCommon):
                 "key_type": "s",
             }
         )
+        self.secret_python_key = self.Key.create(
+            {
+                "name": "python",
+                "reference": "PYTHON",
+                "secret_value": "secretPythonCode",
+                "key_type": "s",
+            }
+        )
+
+        self.python_ssh_key = self.Key.create(
+            {
+                "name": "Test Python SSH Key",
+                "key_type": "k",
+                "secret_value": "Python much key",
+            }
+        )
+
+        self.secret_test_rsa_key = self.Key.create(
+            {
+                "name": "test rsa",
+                "reference": "test_rsa",
+                "secret_value": """-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
+KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
+o3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k
+TQIhAKMSvzIBnni7ot/OSie2TmJLY4SwTQAevXysE2RbFDYdAiEBCUEaRQnMnbp7
+9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy
+v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
+/5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
+-----END RSA PRIVATE KEY----- """,
+                "key_type": "s",
+            }
+        )
         # Command
         self.command_create_new_command = self.Command.create(
             {
@@ -41,6 +74,59 @@ if server_name and #!cxtower.secret.FOLDER!# == "secretFolder":
     COMMAND_RESULT = {"exit_code": 0, "message": "New command was created"}
 else:
     COMMAND_RESULT = {"exit_code": -1, "message": "error"}
+    """,
+            }
+        )
+
+        self.command_python_command_1 = self.Command.create(
+            {
+                "name": "Python command with secret #1",
+                "action": "python_code",
+                "code": """
+COMMAND_RESULT = {
+    "exit_code": 0,
+    "message": #!cxtower.secret.PYTHON!#,
+}
+    """,
+            }
+        )
+
+        self.command_python_command_2 = self.Command.create(
+            {
+                "name": "Python command with secret #2",
+                "action": "python_code",
+                "code": """
+COMMAND_RESULT = {
+    "exit_code": 0,
+    "message": 'We use #!cxtower.secret.PYTHON!#' ,
+}
+    """,
+            }
+        )
+
+        self.command_python_command_3 = self.Command.create(
+            {
+                "name": "Python command with secret #3",
+                "action": "python_code",
+                "code": """
+COMMAND_RESULT = {
+    "exit_code": 0,
+    "message": ""#!cxtower.secret.test_rsa!#"" ,
+}
+    """,
+            }
+        )
+
+        self.command_python_command_4 = self.Command.create(
+            {
+                "name": "Python command with secret #4",
+                "action": "python_code",
+                "code": """
+top_secret = #!cxtower.secret.test_python_ssh_key!#
+COMMAND_RESULT = {
+    "exit_code": 0,
+    "message": top_secret ,
+}
     """,
             }
         )
@@ -528,7 +614,7 @@ else:
         response = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
         error = []
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
+        ssh_command_result = self.Server._parse_command_results(
             status, response, error, key_values=[f"{self.secret_2.secret_value}"]
         )
 
@@ -556,9 +642,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -582,9 +666,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -606,9 +688,7 @@ else:
         response = []
         error = ["Ooops", "I did", "it again"]
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
-            status, response, error
-        )
+        ssh_command_result = self.Server._parse_command_results(status, response, error)
 
         # Get result
         result_status = ssh_command_result["status"]
@@ -632,7 +712,7 @@ else:
         error = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
         response = []
 
-        ssh_command_result = self.Server._parse_ssh_command_results(
+        ssh_command_result = self.Server._parse_command_results(
             status, response, error, key_values=[f"{self.secret_2.secret_value}"]
         )
 
@@ -904,4 +984,126 @@ else:
         # Check command result
         self.assertEqual(
             self.server_test_1.status, "stopping", "Server status must be 'stopping'"
+        )
+
+    def test_execute_python_code_with_secret(self):
+        """
+        Test execution of Python code with a secret value.
+        This test ensures that a command is rendered and executed correctly,
+        and that the secret value is correctly handled and replaced in the output.
+        """
+        # Case 1
+        # Render the command using server_test_1
+        rendered_command = self.server_test_1._render_command(
+            self.command_python_command_1
+        )
+
+        # Execute the rendered Python code
+        command_result = self.server_test_1._execute_python_code(
+            rendered_command["rendered_code"]
+        )
+
+        # Assert that the command execution status is 0 (indicating success)
+        self.assertEqual(
+            command_result["status"], 0, "The command result status must be 0"
+        )
+
+        # Assert that the response contains the secret spoiler text
+        self.assertEqual(
+            command_result["response"],
+            self.Key.SECRET_VALUE_SPOILER,
+            "The response must correctly include the secret value placeholder",
+        )
+
+        # Assert that no error occurred during execution (error should be None)
+        self.assertIsNone(
+            command_result["error"],
+            "The error in command result must be None",
+        )
+
+        # Case 2
+        # Render the command using server_test_1
+        rendered_command = self.server_test_1._render_command(
+            self.command_python_command_2
+        )
+
+        # Execute the rendered Python code
+        command_result = self.server_test_1._execute_python_code(
+            rendered_command["rendered_code"]
+        )
+
+        # Assert that the command execution status is 0 (indicating success)
+        self.assertEqual(
+            command_result["status"], 0, "The command result status must be 0"
+        )
+
+        # Assert that the response contains the secret spoiler text
+        self.assertEqual(
+            command_result["response"],
+            f'We use "{self.Key.SECRET_VALUE_SPOILER}"',
+            "The response must correctly include the secret value placeholder",
+        )
+
+        # Assert that no error occurred during execution (error should be None)
+        self.assertIsNone(
+            command_result["error"],
+            "The error in command result must be None",
+        )
+
+        # Case 3
+        # Render the command using server_test_1
+        rendered_command = self.server_test_1._render_command(
+            self.command_python_command_3
+        )
+
+        # Execute the rendered Python code
+        command_result = self.server_test_1._execute_python_code(
+            rendered_command["rendered_code"]
+        )
+
+        # Assert that the command execution status is 0 (indicating success)
+        self.assertEqual(
+            command_result["status"], 0, "The command result status must be 0"
+        )
+
+        # Assert that the response contains the secret spoiler text
+        self.assertEqual(
+            command_result["response"],
+            self.Key.SECRET_VALUE_SPOILER,
+            "The response must correctly include the secret value placeholder",
+        )
+
+        # Assert that no error occurred during execution (error should be None)
+        self.assertIsNone(
+            command_result["error"],
+            "The error in command result must be None",
+        )
+
+        # Case 4
+        # Render the command using server_test_1
+        rendered_command = self.server_test_1._render_command(
+            self.command_python_command_4
+        )
+
+        # Execute the rendered Python code
+        command_result = self.server_test_1._execute_python_code(
+            rendered_command["rendered_code"]
+        )
+
+        # Assert that the command execution status is 0 (indicating success)
+        self.assertEqual(
+            command_result["status"], 0, "The command result status must be 0"
+        )
+
+        # Assert that the response contains the secret spoiler text
+        self.assertEqual(
+            command_result["response"],
+            self.Key.SECRET_VALUE_SPOILER,
+            "The response must correctly include the secret value placeholder",
+        )
+
+        # Assert that no error occurred during execution (error should be None)
+        self.assertIsNone(
+            command_result["error"],
+            "The error in command result must be None",
         )


### PR DESCRIPTION
This commit fixes the following issue:

Expected result
---------------
The Python command does not necessarily have to execute successfully, but the secret values ​​must be replaced with the correct placeholders in the output.

Current result
--------------
The Python command does not necessarily have to execute successfully, but secret values are not handled or replaced correctly in the output.

Solution
--------
Renamed method _parse_ssh_command_results to _parse_command_results for using not only for SSH but for any command including Python one.

Task: 3952