### PR TITLE
[FIX] cetmix_tower_server_queue: Fix order of command executions that trigger running other plans

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -33,6 +33,7 @@ class CxTowerCommandLog(models.Model):
     command_id = fields.Many2one(
         comodel_name="cx.tower.command", required=True, index=True, ondelete="restrict"
     )
+    command_action = fields.Selection(related="command_id.action")
     path = fields.Char(string="Execution Path", help="Where command was executed")
     code = fields.Text(string="Command Code")
     command_status = fields.Integer(string="Exit Code")
@@ -57,6 +58,7 @@ class CxTowerCommandLog(models.Model):
 
     # -- Flight Plan
     plan_log_id = fields.Many2one(comodel_name="cx.tower.plan.log", ondelete="cascade")
+    triggered_plan_log_id = fields.Many2one(comodel_name="cx.tower.plan.log")
 
     @api.depends("name", "command_id.name")
     def _compute_name(self):
@@ -161,7 +163,6 @@ class CxTowerCommandLog(models.Model):
         Returns:
             (cx.tower.command.log()) new command log record
         """
-
         vals = kwargs or {}
         vals.update(
             {

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -116,6 +116,12 @@ class CxTowerPlanLine(models.Model):
         # Set current line as currently executed in log
         plan_log_record.plan_line_executed_id = self
 
+        # It is necessary to save information about which plan log
+        # was created for a command log that has the command action “plan”
+        flight_plan_command_log = kwargs.get("flight_plan_command_log")
+        if flight_plan_command_log:
+            flight_plan_command_log.triggered_plan_log_id = plan_log_record.id
+
         # Pass plan_log to command so it will be saved in command log
         log_vals = kwargs.get("log", {})
         log_vals.update({"plan_log_id": plan_log_record.id})

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1100,7 +1100,9 @@ class CxTowerServer(models.Model):
                 "label": generate_random_id(4),
                 "parent_flight_plan_log_id": log_record.plan_log_id.id,
             }
-            plan_status = flight_plan._execute_single(self, **kwargs)
+            # add executed command with action "plan" to save link to plan log
+            kwargs["flight_plan_command_log"] = log_record
+            plan_status = flight_plan.with_context()._execute_single(self, **kwargs)
         except Exception as e:
             if raise_on_error:
                 raise ValidationError(

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -807,6 +807,11 @@ class TestTowerPlan(TestTowerCommon):
             "The command status of main plan should be equal "
             "of status second flight plan",
         )
+        self.assertEqual(
+            parent_plan_log.command_log_ids.triggered_plan_log_id,
+            child_plan_log,
+            "The command triggered plan line should be equal to child plan",
+        )
 
         # Check that we cannot add recursive plan
         with self.assertRaisesRegex(
@@ -942,6 +947,23 @@ class TestTowerPlan(TestTowerCommon):
             child_plan_log.parent_flight_plan_log_id.plan_id,
             plan_3,
             "Parent plan should be equal to plan 3",
+        )
+        self.assertEqual(
+            child_plan_log.command_log_ids.triggered_plan_log_id,
+            last_child_plan_log,
+            "The command triggered plan line should be equal to last child plan",
+        )
+        self.assertEqual(
+            child_plan_log.command_log_ids.triggered_plan_log_id,
+            last_child_plan_log,
+            "The command triggered plan line should be equal to last child plan",
+        )
+        parent_plan_log = plan_log_records - child_plan_log - last_child_plan_log
+        self.assertEqual(
+            parent_plan_log.command_log_ids.triggered_plan_log_id,
+            child_plan_log,
+            "The command triggered plan line from parent plan "
+            "should be equal to child plan",
         )
 
         # Check that we cannot change command with existing plan,

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -35,6 +35,7 @@
                             <field name="create_uid" />
                             <field name="server_id" />
                             <field name="command_id" />
+                            <field name="command_action" invisible="1" />
                             <field
                                 name="condition"
                                 attrs="{'invisible': [('condition', '=', False)]}"
@@ -53,7 +54,14 @@
                                 name="use_sudo"
                                 attrs="{'invisible': [('use_sudo', '=', False)]}"
                             />
-                            <field name="command_status" />
+                            <field
+                                name="command_status"
+                                attrs="{'invisible': [('is_running', '=', True)]}"
+                            />
+                            <field
+                                name="triggered_plan_log_id"
+                                attrs="{'invisible': [('triggered_plan_log_id', '=', False)]}"
+                            />
                         </group>
                         <group>
                             <field
@@ -65,7 +73,7 @@
                             <field name="duration_current" />
                         </group>
                     </group>
-                    <notebook>
+                    <notebook attrs="{'invisible': [('command_action', '=', 'plan')]}">
                         <page name="result" string="Result">
                             <field
                                 name="command_response"

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -15,8 +15,12 @@ class CxTowerServer(models.Model):
         ssh_connection=None,
         **kwargs,
     ):
-        # Use runner only if command log record is provided
-        if log_record:
+        # If the flight plan log has an entry on the parent flight plan log,
+        # it means that this flight plan was launched from another plan,
+        # this plan should be launched as a synchronous command to
+        # preserve the order of execution of commands with action “Run flight plan”.
+        # Use runner only if command log record is provided.
+        if log_record and not log_record.plan_log_id.parent_flight_plan_log_id:
             self.with_delay()._command_runner(
                 command,
                 log_record,


### PR DESCRIPTION
This commits fixes the following issues:

Steps to reproduce
-------------------

- Create a flight plan that contains another flight plans as commands
- Install `cetmix_tower_server_queue`
- Run the plan

Before these commits
--------------------

- Child fling plans are queued and executed later
- Main flight plan doesn't wait for child flight plans exectution
- Command log for the command that runs a flight plan doesn't have a link to a flight plan log. 
- `code` and `command` fields are displayed

After these commits
------------------

​- Parent plan commands are executed one after child  flight plan finishes execution
- Command log for commands that run flight plan has a link to the corresponding flight plan log. 
- All fields that are not needed for such command are hidden (code, command)


Task: 3996