### PR TITLE
[14.0] [IMP] cetmix_tower_server: update command access rules

### DIFF
--- a/cetmix_tower_server/security/cx_tower_command_security.xml
+++ b/cetmix_tower_server/security/cx_tower_command_security.xml
@@ -6,15 +6,44 @@
         <field name="name">Tower command: user access rule</field>
         <field name="model_id" ref="model_cx_tower_command" />
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
-        <field name="domain_force">[('access_level', '=', '1')]</field>
+        <field name="domain_force">
+            [
+            '|',
+            '&amp;',
+                ('access_level', '=', '1'),
+                ('server_ids', '=', False),
+            '&amp;',
+                ('access_level', '=', '1'),
+                ('server_ids.message_partner_ids', 'in', [user.partner_id.id])
+        ]
+
+        </field>
 
 
     </record>
 
+
+
     <record id="cx_tower_command_rule_group_manager_access" model="ir.rule">
         <field name="name">Tower command: manager access rule</field>
         <field name="model_id" ref="model_cx_tower_command" />
-        <field name="domain_force">[('access_level', '&lt;=', '2')]</field>
+        <field name="domain_force">
+
+            [
+            '|',
+            '&amp;',
+                ('access_level', '&lt;=', '2'),
+                ('server_ids', '=', False),
+            '&amp;',
+                ('access_level', '&lt;=', '2'),
+                ('server_ids.message_partner_ids', 'in', [user.partner_id.id])
+        ]
+
+
+
+
+
+        </field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
 
 


### PR DESCRIPTION
Before this PR
-------------------
Users have access to all commands with access level = "1" 
Managers have access to all commands with access level <= "2"  

After this PR
-------------------
Users have access to commands that belong to server he is follower OR commands with no server specified AND access level = "1" 
Managers have access to commands that belong to server he is follower OR commands with no server specified AND access level <= "2"  