### PR TITLE
[14.0][IMP] t4009 cetmix_tower_server: Visual improvements

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -38,7 +38,8 @@ class CxTowerPlanLine(models.Model):
         " If empty next command will be executed",
     )
     command_code = fields.Text(related="command_id.code", readonly=True)
-
+    action = fields.Selection(related="command_id.action", readonly=True)
+    tag_ids = fields.Many2many(related="command_id.tag_ids", readonly=True)
     access_level = fields.Selection(
         related="plan_id.access_level",
         readonly=True,

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -66,9 +66,20 @@
                     <notebook>
                         <page name="plan_lines" string="Code">
                             <field name="line_ids">
-                                <tree>
+                                <tree decoration-bf="action=='plan'">
                                     <field name="sequence" widget="handle" />
                                     <field name="name" />
+                                    <field
+                                        name="action"
+                                        optional="show"
+                                        groups="cetmix_tower_server.group_manager"
+                                    />
+                                    <field
+                                        name="tag_ids"
+                                        optional="show"
+                                        widget="many2many_tags"
+                                        groups="cetmix_tower_server.group_manager"
+                                    />
                                     <field name="use_sudo" optional="show" />
                                     <field name="path" optional="show" />
                                     <field

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -49,11 +49,24 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
         help="Run commands using 'sudo'",
     )
     code = fields.Text(compute="_compute_code", readonly=False, store=True)
-    any_server = fields.Boolean()
+    any_server = fields.Boolean(default=True)
     rendered_code = fields.Text(
         compute="_compute_rendered_code",
     )
     result = fields.Text()
+    show_servers = fields.Boolean(
+        compute="_compute_show_servers",
+    )
+
+    @api.depends("server_ids")
+    def _compute_show_servers(self):
+        """
+        Show "Servers" field only if the number of servers is greater than 1.
+        """
+
+        self.show_servers = (
+            True if self.server_ids and len(self.server_ids) > 1 else False
+        )
 
     @api.onchange("action")
     def _onchange_action(self):

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -20,7 +20,13 @@
                     Rendered code is shown as for the first selected server!
                 </h2>
                 <group>
-                    <field name="server_ids" widget="many2many_tags" required="1" />
+                    <field name="show_servers" invisible="1" />
+                    <field
+                        name="server_ids"
+                        widget="many2many_tags"
+                        required="1"
+                        attrs="{'invisible': [('show_servers', '=', False)]}"
+                    />
                     <field
                         name="tag_ids"
                         widget="many2many_tags"

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
@@ -27,13 +27,26 @@ class CxTowerPlanExecuteWizard(models.TransientModel):
         column2="tag_id",
         string="Tags",
     )
-    any_server = fields.Boolean()
+    any_server = fields.Boolean(default=True)
     # Lines
     plan_line_ids = fields.One2many(
         string="Commands",
         comodel_name="cx.tower.plan.line",
         compute="_compute_plan_line_ids",
     )
+    show_servers = fields.Boolean(
+        compute="_compute_show_servers",
+    )
+
+    @api.depends("server_ids")
+    def _compute_show_servers(self):
+        """
+        Show "Servers" field only if the number of servers is greater than 1.
+        """
+
+        self.show_servers = (
+            True if self.server_ids and len(self.server_ids) > 1 else False
+        )
 
     @api.depends("plan_id")
     def _compute_plan_line_ids(self):

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="cx_tower_plan_execute_wizard_view_form" model="ir.ui.view">
         <field name="name">cx.tower.plan.execute.wizard.view.form</field>
         <field name="model">cx.tower.plan.execute.wizard</field>
         <field name="arch" type="xml">
             <form string="Execute Plan">
                 <group>
-                    <field name="server_ids" widget="many2many_tags" required="1" />
+                     <field name="show_servers" invisible="1" />
+                    <field
+                        name="server_ids"
+                        widget="many2many_tags"
+                        required="1"
+                        attrs="{'invisible': [('show_servers', '=', False)]}"
+                    />
                     <field name="tag_ids" widget="many2many_tags" />
                     <label for="plan_id" />
                     <div class="o_row">
@@ -16,7 +21,22 @@
                         <span>show shared</span>
                         <field name="any_server" />
                     </div>
-                    <field name="plan_line_ids" />
+                    <field name="plan_line_ids">
+                        <tree decoration-bf="action=='plan'">
+                            <field name="name" />
+                            <field
+                                name="action"
+                                optional="show"
+                                groups="cetmix_tower_server.group_manager"
+                            />
+                            <field
+                                name="tag_ids"
+                                optional="show"
+                                groups="cetmix_tower_server.group_manager"
+                                widget="many2many_tags"
+                            />
+                        </tree>
+                    </field>
                 </group>
                 <footer>
                     <button
@@ -30,7 +50,6 @@
             </form>
         </field>
     </record>
-
     <record id="cx_tower_plan_execute_wizard_action" model="ir.actions.act_window">
         <field name="name">Cetmix Tower Execute Flight Plan</field>
         <field name="res_model">cx.tower.plan.execute.wizard</field>
@@ -40,5 +59,4 @@
         <field name="context">{'default_server_ids': [active_id]}</field>
         <field name="target">new</field>
     </record>
-
 </odoo>


### PR DESCRIPTION
This commit improve the following views:

Flight plan
-----------
- Add "Action" column (command_id -> action) "optional=show"
- Mark commands that run another flight plan bold

Plan execute wizard
-------------------

- Show "Servers" field only if number of servers > 1
- Activate "show shared" by default
- Add "Action" related field (command_id -> Action). Commands with action "Plan" must be marked bold

Command execute wizard
-------------------

Show "Servers" field only if number of server > 1
Enable "Show shared" by default

Task: 4009