### PR TITLE
[14.0][IMP] cetmix_tower_server: add reference to models

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -294,13 +294,15 @@ class CxTowerPlan(models.Model):
 
             # Duplicate actions linked to the line
             for action in line.action_ids:
-                new_action = action.copy(
+                new_action = action.with_context(reference_mixin_skip_copy=True).copy(
                     # link new actions to the new line
-                    {"line_id": new_line.id}
+                    {"line_id": new_line.id, "name": line.name}
                 )
 
                 # Duplicate variable values linked to the action
                 for variable_value in action.variable_value_ids:
-                    variable_value.copy({"plan_line_action_id": new_action.id})
+                    variable_value.with_context(reference_mixin_skip_self=True).copy(
+                        {"plan_line_action_id": new_action.id}
+                    )
 
         return new_plan

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -10,6 +10,9 @@ from .constants import PLAN_LINE_CONDITION_CHECK_FAILED
 
 class CxTowerPlanLine(models.Model):
     _name = "cx.tower.plan.line"
+    _inherit = [
+        "cx.tower.reference.mixin",
+    ]
     _order = "sequence, plan_id"
     _description = "Cetmix Tower Flight Plan Line"
 
@@ -193,3 +196,11 @@ class CxTowerPlanLine(models.Model):
             is_skipped=True,
             **log_vals,
         )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Use the common method from mixin
+        vals_list = self._populate_references(
+            "cx.tower.plan", "plan_id", vals_list, suffix="_line"
+        )
+        return super().create(vals_list)

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, fields, models
 
 
 class CxTowerPlanLineAction(models.Model):
-    _inherit = ["cx.tower.variable.mixin"]
+    _inherit = ["cx.tower.variable.mixin", "cx.tower.reference.mixin"]
     _name = "cx.tower.plan.line.action"
     _description = "Cetmix Tower Flight Plan Line Action"
 
@@ -76,3 +77,11 @@ class CxTowerPlanLineAction(models.Model):
                 )
             else:
                 rec.name = _("Wrong action")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Use the common method from mixin with a custom suffix
+        vals_list = self._populate_references(
+            "cx.tower.plan.line", "line_id", vals_list, suffix="_action"
+        )
+        return super().create(vals_list)

--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -358,7 +358,9 @@ class CxTowerServerTemplate(models.Model):
 
         # Duplicate variable values
         for variable_value in self.variable_value_ids:
-            variable_value.copy({"server_template_id": new_template.id})
+            variable_value.with_context(reference_mixin_skip_self=True).copy(
+                {"server_template_id": new_template.id}
+            )
 
         # Duplicate server logs
         for server_log in self.server_log_ids:

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.osv.expression import OR
@@ -9,12 +10,16 @@ from odoo.osv.expression import OR
 class TowerVariableValue(models.Model):
     _name = "cx.tower.variable.value"
     _description = "Cetmix Tower Variable Values"
+    _inherit = [
+        "cx.tower.reference.mixin",
+    ]
     _rec_name = "variable_reference"
     _order = "variable_reference"
 
     variable_id = fields.Many2one(
         string="Variable", comodel_name="cx.tower.variable", required=True
     )
+    name = fields.Char(related="variable_id.name", readonly=True)
     variable_reference = fields.Char(
         related="variable_id.reference", store=True, index=True
     )
@@ -276,3 +281,11 @@ class TowerVariableValue(models.Model):
                         var=record.variable_id.name,
                     )
                 )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Use the common method from mixin
+        vals_list = self._populate_references(
+            "cx.tower.variable", "variable_id", vals_list, suffix="_variable"
+        )
+        return super().create(vals_list)

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -367,18 +367,18 @@ class TestTowerPlan(TestTowerCommon):
         command_1 = self.Command.create(
             {"name": "New Test Command", "access_level": "3"}
         )
-        self.plan_line_2_1 = self.plan_line.create(
-            {
-                "sequence": 5,
-                "command_id": command_1.id,
-            }
-        )
 
         self.plan_2 = self.Plan.create(
             {
                 "name": "Test plan 2",
                 "note": "Create directory and list its content",
-                "line_ids": [(4, self.plan_line_2_1.id)],
+            }
+        )
+        self.plan_line_2_1 = self.plan_line.create(
+            {
+                "sequence": 5,
+                "plan_id": self.plan_2.id,
+                "command_id": command_1.id,
             }
         )
         self.assertTrue(self.plan_2.access_level_warn_msg)
@@ -663,12 +663,12 @@ class TestTowerPlan(TestTowerCommon):
                 "command_id": command.id,
                 "path": "/test/path",
                 # Condition based on Linux version
-                "condition": '{{ linux_version }} >= "5.0"',
+                "condition": '{{ test_linux_version }} >= "5.0"',
             }
         )
 
         # Create a variable for the action
-        variable = self.Variable.create({"name": "linux_version"})
+        variable = self.Variable.create({"name": "test_linux_version"})
 
         # Create an Action for the Plan Line
         action = self.plan_line_action.create(

--- a/cetmix_tower_server/tests/test_reference_mixin.py
+++ b/cetmix_tower_server/tests/test_reference_mixin.py
@@ -8,6 +8,21 @@ class TestTowerReference(TestTowerCommon):
     We are using ServerTemplate for that.
     """
 
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+
+        self.plan_reference_mixin = self.Plan.create(
+            {"name": "Test Plan reference mixin", "note": "Test Note reference mixin"}
+        )
+
+        self.plan_line_reference_mixin = self.plan_line.create(
+            {
+                "plan_id": self.plan_reference_mixin.id,
+                "sequence": 1,
+                "command_id": self.command_list_dir.id,
+            }
+        )
+
     def test_reference_generation(self):
         """Test reference generation"""
 
@@ -92,3 +107,122 @@ class TestTowerReference(TestTowerCommon):
         # Search using malformed (case sensitive)
         search_result = self.ServerTemplate.get_by_reference("not_much_template")
         self.assertEqual(len(search_result), 0, "Result should be empty")
+
+    def test_prepare_references_valid_input(self):
+        """
+        Ensure references are correctly prepared for valid input.
+        """
+
+        vals_list = [{"plan_id": self.plan_reference_mixin.id}]
+        result = self.plan_line._prepare_references(
+            "cx.tower.plan", "plan_id", vals_list
+        )
+
+        # Verify the result contains the expected reference
+        self.assertIn(
+            self.plan_reference_mixin.id,
+            result,
+            "The reference ID should be in the result.",
+        )
+        self.assertEqual(
+            result[self.plan_reference_mixin.id],
+            self.plan_reference_mixin.reference,
+            "The reference should match the expected value.",
+        )
+
+    def test_prepare_references_invalid_model_name(self):
+        """
+        Check that an error is raised for an invalid model name.
+        """
+
+        vals_list = [{"plan_id": self.plan_reference_mixin.id}]
+        with self.assertRaises(ValueError) as cm:
+            self.plan_line._prepare_references("invalid.model", "plan_id", vals_list)
+
+        # Confirm the exception message is as expected
+        self.assertEqual(
+            str(cm.exception),
+            "Model 'invalid.model' does not exist. Please provide a valid model name.",
+            "The error message should indicate an invalid model name.",
+        )
+
+    def test_prepare_references_empty_vals_list(self):
+        """
+        Verify that an empty vals_list returns an empty dictionary.
+        """
+        result = self.plan_line._prepare_references("cx.tower.plan", "plan_id", [])
+        self.assertEqual(
+            result,
+            {},
+            "The result should be an empty dictionary when vals_list is empty.",
+        )
+
+    def test_populate_references_with_valid_input(self):
+        """
+        Ensure references are populated correctly in the provided values list.
+        """
+        vals_list = [{"plan_id": self.plan_reference_mixin.id}]
+        updated_vals = self.plan_line._populate_references(
+            "cx.tower.plan", "plan_id", vals_list, suffix="TEST"
+        )
+
+        # Check the updated values contain the expected reference format
+        self.assertEqual(
+            updated_vals[0]["reference"],
+            f"{self.plan_reference_mixin.reference}TEST_1",
+            "The reference should be correctly populated with the suffix.",
+        )
+
+    def test_populate_references_missing_field(self):
+        """
+        Confirm that entries missing the required field are handled properly.
+        """
+
+        vals_list_with_missing_field = [{"another_key": 123}]
+        updated_vals_with_missing = self.plan_line._populate_references(
+            "cx.tower.plan", "plan_id", vals_list_with_missing_field, suffix="MISSING"
+        )
+        self.assertEqual(
+            updated_vals_with_missing[0]["reference"],
+            "no_MISSING_1",
+            "Entries missing the required field should have a default reference.",
+        )
+
+    def test_populate_references_duplicate_ids(self):
+        """
+        Ensure that duplicate IDs in the input list are correctly
+        handled and referenced.
+        """
+        vals_list = [
+            {"plan_id": self.plan_reference_mixin.id},
+            {"plan_id": self.plan_reference_mixin.id},
+        ]
+        updated_vals = self.plan_line._populate_references(
+            "cx.tower.plan", "plan_id", vals_list, suffix="DUPLICATE"
+        )
+
+        # Verify that each duplicate entry has a unique suffix
+        self.assertEqual(
+            updated_vals[0]["reference"],
+            f"{self.plan_reference_mixin.reference}DUPLICATE_1",
+            "The first duplicate reference should have the correct suffix.",
+        )
+        self.assertEqual(
+            updated_vals[1]["reference"],
+            f"{self.plan_reference_mixin.reference}DUPLICATE_2",
+            "The second duplicate reference should have the correct suffix.",
+        )
+
+    def test_populate_references_empty_vals_list(self):
+        """
+        Check that an empty input list returns an empty result
+        when populating references.
+        """
+        updated_vals = self.plan_line._populate_references(
+            "cx.tower.plan", "plan_id", [], suffix="EMPTY"
+        )
+        self.assertEqual(
+            updated_vals,
+            [],
+            "The result should be an empty list when vals_list is empty.",
+        )

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -10,7 +10,10 @@
                     <group>
                         <group>
                             <field name="sequence" />
-
+                            <field
+                                name="reference"
+                                placeholder="Can contain English letters, digits and '_'. Leave blank to autogenerate"
+                            />
                             <field
                                 name="command_id"
                                 context="{'command_show_server_names': True}"
@@ -38,6 +41,7 @@
                                 <tree>
                                     <field name="sequence" widget="handle" />
                                     <field name="name" />
+                                    <field name="reference" optional="hide" />
                                 </tree>
                                 <form>
                                     <group>
@@ -65,8 +69,13 @@
                                         >
                                             <tree editable="bottom">
                                                 <field
+                                                    name="reference"
+                                                    optional="hide"
+                                                />
+                                                <field
                                                     name="variable_reference"
-                                                    invisible="1"
+                                                    optional="hide"
+                                                    string="Variable Reference"
                                                 />
                                                 <field name="variable_id" />
                                                 <field name="value_char" />

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -69,6 +69,7 @@
                                 <tree decoration-bf="action=='plan'">
                                     <field name="sequence" widget="handle" />
                                     <field name="name" />
+                                    <field name="reference" optional="hide" />
                                     <field
                                         name="action"
                                         optional="show"

--- a/cetmix_tower_server/views/cx_tower_variable_value_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_value_view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="cx_tower_variable_value_view_tree" model="ir.ui.view">
         <field name="name">cx.tower.variable.value.view.tree</field>
         <field name="model">cx.tower.variable.value</field>
         <field name="arch" type="xml">
             <tree editable="top" decoration-bf="is_global==True">
+                <field name="reference" optional="hidden" />
                 <field name="variable_id" />
                 <field name="is_global" widget="boolean_toggle" />
                 <field
@@ -21,12 +21,12 @@
             </tree>
         </field>
     </record>
-
     <record id="cx_tower_variable_value_search_view" model="ir.ui.view">
         <field name="name">cx.tower.variable.value.view.search</field>
         <field name="model">cx.tower.variable.value</field>
         <field name="arch" type="xml">
             <search string="Search Values">
+                <field name="reference" />
                 <field name="variable_id" string="Variable" />
                 <field name="value_char" string="Value" />
                 <filter
@@ -39,15 +39,13 @@
                     name="global"
                     domain="[('is_global', '=', True)]"
                 />
-             </search>
+            </search>
         </field>
     </record>
-
     <record id="action_cx_tower_variable_value" model="ir.actions.act_window">
         <field name="name">Variable Values</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">cx.tower.variable.value</field>
         <field name="view_mode">tree</field>
     </record>
-
 </odoo>


### PR DESCRIPTION
This commit adds references to the following models:

- cx.tower.plan.line
- cx.tower.plan.line.action
- cx.tower.variable.value

Changes

Inherit from cx.tower.reference.mixin
Add reference fields to views, including search view 
Update tests

Task: 4017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced duplication process for flight plans and variable values, ensuring integrity during copying.
  - New `create` methods added to various models to manage references effectively during record creation.
  - New `reference` field added to the `cx.tower.plan.line`, `cx.tower.variable.value`, and `cx.tower.plan` views, improving data handling and visibility control based on user permissions.

- **Bug Fixes**
  - Improved test cases for plan execution and command handling, ensuring accurate validation.

- **Tests**
  - Expanded test coverage for reference preparation and population functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->