### PR TITLE
[14.0][IMP] cetmix_tower_server Value field is not required in variable values

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -12,7 +12,9 @@ class TowerVariableValue(models.Model):
     _rec_name = "variable_reference"
     _order = "variable_reference"
 
-    variable_id = fields.Many2one(string="Variable", comodel_name="cx.tower.variable")
+    variable_id = fields.Many2one(
+        string="Variable", comodel_name="cx.tower.variable", required=True
+    )
     variable_reference = fields.Char(
         related="variable_id.reference", store=True, index=True
     )
@@ -23,7 +25,7 @@ class TowerVariableValue(models.Model):
         store=True,
     )
 
-    value_char = fields.Char(string="Value", required=True)
+    value_char = fields.Char(string="Value")
     note = fields.Text(related="variable_id.note", readonly=True)
     active = fields.Boolean(default=True)
 

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -59,7 +59,7 @@ class TestTowerCommon(TransactionCase):
 
         # Variable
         self.Variable = self.env["cx.tower.variable"]
-        self.VariableValues = self.env["cx.tower.variable.value"]
+        self.VariableValue = self.env["cx.tower.variable.value"]
 
         self.variable_path = self.Variable.create({"name": "test_path_"})
         self.variable_dir = self.Variable.create({"name": "test_dir"})

--- a/cetmix_tower_server/tests/test_cetmix_tower.py
+++ b/cetmix_tower_server/tests/test_cetmix_tower.py
@@ -29,7 +29,7 @@ class TestCetmixTower(TestTowerCommon):
         self.assertEqual(result["exit_code"], 0, "Exit code must be equal to 0")
 
         # Check variable value
-        variable_value = self.VariableValues.search(
+        variable_value = self.VariableValue.search(
             [("variable_id", "=", variable_meme.id)]
         )
 
@@ -50,7 +50,7 @@ class TestCetmixTower(TestTowerCommon):
         self.assertEqual(result["exit_code"], 0, "Exit code must be equal to 0")
 
         # Check variable value
-        variable_value = self.VariableValues.search(
+        variable_value = self.VariableValue.search(
             [("variable_id", "=", variable_meme.id)]
         )
 
@@ -62,7 +62,7 @@ class TestCetmixTower(TestTowerCommon):
         variable_meme = self.Variable.create(
             {"name": "Meme Variable", "reference": "meme_variable"}
         )
-        global_value = self.VariableValues.create(
+        global_value = self.VariableValue.create(
             {"variable_id": variable_meme.id, "value_char": "Memes Globalvs"}
         )
 
@@ -79,7 +79,7 @@ class TestCetmixTower(TestTowerCommon):
         self.assertIsNone(value)
 
         # -- 3 -- Add server value and try again
-        server_value = self.VariableValues.create(
+        server_value = self.VariableValue.create(
             {
                 "variable_id": variable_meme.id,
                 "value_char": "Memes Servervs",

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -305,6 +305,7 @@ COMMAND_RESULT = {
         of cx.tower.server
         """
 
+        # -- 1 --
         # Test with default path
         rendered_command = self.server_test_1._render_command(self.command_create_dir)
         rendered_code_expected = "cd /opt/tower && mkdir test-odoo-1"
@@ -321,6 +322,7 @@ COMMAND_RESULT = {
             "Rendered path doesn't match",
         )
 
+        # -- 2 --
         # Test with custom path
         rendered_command = self.server_test_1._render_command(
             self.command_create_dir, path="/such/much/path"
@@ -339,6 +341,28 @@ COMMAND_RESULT = {
             "Rendered path doesn't match",
         )
 
+        # -- 3 --
+        # Set variable_path to None and check again
+        variable_value_path = self.server_test_1.variable_value_ids.filtered(
+            lambda var_val: var_val.variable_id.id == self.variable_path.id
+        )
+        variable_value_path.value_char = None
+        rendered_command = self.server_test_1._render_command(self.command_create_dir)
+        rendered_code_expected = "cd False && mkdir test-odoo-1"
+        rendered_path_expected = f"/home/{self.server_test_1.ssh_username}"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+        self.assertEqual(
+            rendered_command["rendered_path"],
+            rendered_path_expected,
+            "Rendered path doesn't match",
+        )
+
+        # -- 4 --
         # Set both path and code to None
         self.write_and_invalidate(
             self.command_create_dir, **{"code": None, "path": None}

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -476,7 +476,7 @@ class TestTowerPlan(TestTowerCommon):
         # Add condition for first plan line
         self.plan_line_1.condition = "1 == 1"
         # Create a global value for the 'Version' variable
-        self.VariableValues.create(
+        self.VariableValue.create(
             {"variable_id": self.variable_version.id, "value_char": "14.0"}
         )
         # Add condition with variable
@@ -504,7 +504,7 @@ class TestTowerPlan(TestTowerCommon):
         Test plan with update server variables
         """
         # Add new variable to server
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "value_char": "14.0",
@@ -512,7 +512,7 @@ class TestTowerPlan(TestTowerCommon):
             }
         )
         # Create new variable value to action to update existing server variable
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "value_char": "16.0",
@@ -535,7 +535,7 @@ class TestTowerPlan(TestTowerCommon):
         )
 
         # Add a new variable value to an action that does not exist on the server
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_os.id,
                 "value_char": "Ubuntu",
@@ -586,7 +586,7 @@ class TestTowerPlan(TestTowerCommon):
         value as condition for next plan line
         """
         # Add new variable to server
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "value_char": "14.0",
@@ -594,7 +594,7 @@ class TestTowerPlan(TestTowerCommon):
             }
         )
         # Create new variable value to action to update existing server variable
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "value_char": "16.0",

--- a/cetmix_tower_server/tests/test_server_template.py
+++ b/cetmix_tower_server/tests/test_server_template.py
@@ -13,7 +13,7 @@ class TestTowerServerTemplate(TestTowerCommon):
             "The servers shouldn't exist",
         )
         # add variable values to server template
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "server_template_id": self.server_template_sample.id,
@@ -136,14 +136,14 @@ class TestTowerServerTemplate(TestTowerCommon):
             "Server should not exist",
         )
         # add variable values to server template
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "server_template_id": self.server_template_sample.id,
                 "value_char": "test template version",
             }
         )
-        self.VariableValues.create(
+        self.VariableValue.create(
             {
                 "variable_id": self.variable_url.id,
                 "server_template_id": self.server_template_sample.id,
@@ -209,7 +209,7 @@ class TestTowerServerTemplate(TestTowerCommon):
         server_template = self.server_template_sample
 
         # Add variable values to the server template
-        original_variable_value = self.VariableValues.create(
+        original_variable_value = self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
                 "server_template_id": server_template.id,

--- a/cetmix_tower_server/tests/test_update_related_variable_names.py
+++ b/cetmix_tower_server/tests/test_update_related_variable_names.py
@@ -53,7 +53,7 @@ class TestUpdateRelatedVariableNames(TestTowerCommon):
             }
         )
 
-        self.test_variable_value = self.VariableValues.create(
+        self.test_variable_value = self.VariableValue.create(
             {
                 "variable_id": self.variable_os.id,
                 "value_char": "{{ var1 }} is here and {{ var2 }} too",

--- a/cetmix_tower_server/tests/test_update_related_variable_names.py
+++ b/cetmix_tower_server/tests/test_update_related_variable_names.py
@@ -2,7 +2,7 @@ from .common import TestTowerCommon
 
 
 class TestUpdateRelatedVariableNames(TestTowerCommon):
-    """Test Update Related Variable Names."""
+    """Test Update Related Variable Names"""
 
     def setUp(self):
         super().setUp()
@@ -54,7 +54,10 @@ class TestUpdateRelatedVariableNames(TestTowerCommon):
         )
 
         self.test_variable_value = self.VariableValues.create(
-            {"value_char": "{{ var1 }} is here and {{ var2 }} too"}
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "{{ var1 }} is here and {{ var2 }} too",
+            }
         )
 
         self.test_file_template = self.FileTemplate.create(

--- a/cetmix_tower_server/tests/test_variable.py
+++ b/cetmix_tower_server/tests/test_variable.py
@@ -23,7 +23,7 @@ class TestTowerVariable(TestTowerCommon):
         if server_ids:
             variable_records = server_ids.variable_value_ids
         else:
-            variable_records = self.VariableValues.search([("is_global", "=", True)])
+            variable_records = self.VariableValue.search([("is_global", "=", True)])
         len_vals = len(vals)
 
         # Ensure correct number of records
@@ -124,7 +124,7 @@ class TestTowerVariable(TestTowerCommon):
         # Test global variable values
 
         # Create a global value for the 'dir' variable
-        self.VariableValues.create(
+        self.VariableValue.create(
             {"variable_id": self.variable_dir.id, "value_char": "/global/dir"}
         )
         res = self.server_test_1.get_variable_values(
@@ -193,7 +193,7 @@ class TestTowerVariable(TestTowerCommon):
             f.save()
 
         # Create a global value for the 'Version' variable
-        self.VariableValues.create(
+        self.VariableValue.create(
             {"variable_id": self.variable_version.id, "value_char": "10.0"}
         )
 
@@ -229,7 +229,7 @@ class TestTowerVariable(TestTowerCommon):
             Arg: (cx.tower.variable) variable rec
             Returns: (int) record count
             """
-            return self.VariableValues.search_count([("variable_id", "=", variable.id)])
+            return self.VariableValue.search_count([("variable_id", "=", variable.id)])
 
         # Get variable values count before adding variables to server
         count_dir_before = get_value_count(self.variable_dir)
@@ -285,7 +285,7 @@ class TestTowerVariable(TestTowerCommon):
         """Test what happens when variable value 'global' setting is togged"""
 
         variable_meme = self.Variable.create({"name": "meme"})
-        variable_value_pepe = self.VariableValues.create(
+        variable_value_pepe = self.VariableValue.create(
             {"variable_id": variable_meme.id, "value_char": "Pepe"}
         )
 
@@ -302,7 +302,7 @@ class TestTowerVariable(TestTowerCommon):
 
         # Try to create another global value for the same variable
         with self.assertRaises(ValidationError) as err:
-            self.VariableValues.create(
+            self.VariableValue.create(
                 {"variable_id": variable_meme.id, "value_char": "Doge"}
             )
 
@@ -339,7 +339,7 @@ class TestTowerVariable(TestTowerCommon):
         # Create variables assigned to server
         # Private
         variable_private = self.Variable.create({"name": "Private Variable"})
-        variable_private_value = self.VariableValues.create(
+        variable_private_value = self.VariableValue.create(
             {
                 "variable_id": variable_private.id,
                 "server_id": server.id,
@@ -349,7 +349,7 @@ class TestTowerVariable(TestTowerCommon):
 
         # Global
         variable_global = self.Variable.create({"name": "Variable Global"})
-        variable_global_value = self.VariableValues.create(
+        variable_global_value = self.VariableValue.create(
             {
                 "variable_id": variable_global.id,
                 "is_global": True,
@@ -394,7 +394,7 @@ class TestTowerVariable(TestTowerCommon):
 
         # Check that user_bob can't create new variable values
         with self.assertRaises(AccessError):
-            self.VariableValues.with_user(user_bob).create(
+            self.VariableValue.with_user(user_bob).create(
                 {
                     "variable_id": variable_private.id,
                     "server_id": server.id,
@@ -409,7 +409,7 @@ class TestTowerVariable(TestTowerCommon):
         variable_new_global_as_bob = self.Variable.with_user(user_bob).create(
             {"name": "New Global Variable"}
         )
-        variable_new_global_value_as_bob = self.VariableValues.with_user(
+        variable_new_global_value_as_bob = self.VariableValue.with_user(
             user_bob
         ).create(
             {
@@ -427,7 +427,7 @@ class TestTowerVariable(TestTowerCommon):
         variable_new_private_as_bob = self.Variable.with_user(user_bob).create(
             {"name": "New Private Variable"}
         )
-        variable_vale_new_private_as_bob = self.VariableValues.with_user(
+        variable_vale_new_private_as_bob = self.VariableValue.with_user(
             user_bob
         ).create(
             {
@@ -621,12 +621,12 @@ class TestTowerVariable(TestTowerCommon):
         variable_meme = self.Variable.create(
             {"name": "Meme Variable", "reference": "meme_variable"}
         )
-        global_value = self.VariableValues.create(
+        global_value = self.VariableValue.create(
             {"variable_id": variable_meme.id, "value_char": "Memes Globalvs"}
         )
 
         # -- 1 -- Get value for Server with no server value defined
-        server_result = self.VariableValues.get_by_variable_reference(
+        server_result = self.VariableValue.get_by_variable_reference(
             variable_meme.reference, server_id=self.server_test_1.id
         )
         self.assertIsNone(server_result.get("server"))
@@ -634,14 +634,14 @@ class TestTowerVariable(TestTowerCommon):
         self.assertEqual(server_result.get("global"), global_value.value_char)
 
         # -- 2 -- Add server value and try again
-        server_value = self.VariableValues.create(
+        server_value = self.VariableValue.create(
             {
                 "variable_id": variable_meme.id,
                 "value_char": "Memes Servervs",
                 "server_id": self.server_test_1.id,
             }
         )
-        server_result = self.VariableValues.get_by_variable_reference(
+        server_result = self.VariableValue.get_by_variable_reference(
             variable_meme.reference, server_id=self.server_test_1.id
         )
         self.assertEqual(server_result.get("server"), server_value.value_char)
@@ -649,7 +649,7 @@ class TestTowerVariable(TestTowerCommon):
         self.assertIsNone(server_result.get("server_template"))
 
         # -- 3 -- Do not fetch global value now
-        server_result = self.VariableValues.get_by_variable_reference(
+        server_result = self.VariableValue.get_by_variable_reference(
             variable_meme.reference, server_id=self.server_test_1.id, check_global=False
         )
         self.assertIsNone(server_result.get("global"))
@@ -657,14 +657,14 @@ class TestTowerVariable(TestTowerCommon):
         self.assertIsNone(server_result.get("server_template"))
 
         # -- 4 -- Check server template value
-        server_template_value = self.VariableValues.create(
+        server_template_value = self.VariableValue.create(
             {
                 "variable_id": variable_meme.id,
                 "value_char": "Memes Servervs Templatvs",
                 "server_template_id": self.server_template_sample.id,
             }
         )
-        server_result = self.VariableValues.get_by_variable_reference(
+        server_result = self.VariableValue.get_by_variable_reference(
             variable_meme.reference, server_template_id=self.server_template_sample.id
         )
         self.assertEqual(server_result.get("global"), global_value.value_char)

--- a/cetmix_tower_server/tests/test_variable.py
+++ b/cetmix_tower_server/tests/test_variable.py
@@ -48,6 +48,9 @@ class TestTowerVariable(TestTowerCommon):
     def test_variable_values(self):
         """Test common variable operations"""
 
+        # -- 1 --
+        #  Server specific variables
+
         # Add two variables
         with Form(self.server_test_1) as f:
             with f.variable_value_ids.new() as line:
@@ -87,9 +90,17 @@ class TestTowerVariable(TestTowerCommon):
             with f.variable_value_ids.new() as line:
                 line.variable_id = self.variable_os
                 line.value_char = "Debian"
+
+            # Add an empty variable value
+            with f.variable_value_ids.new() as line:
+                line.variable_id = self.variable_url
             f.save()
 
-        vals = [(self.variable_os.id, "Debian"), (self.variable_version.id, "10.0")]
+        vals = [
+            (self.variable_os.id, "Debian"),
+            (self.variable_version.id, "10.0"),
+            (self.variable_url.id, False),
+        ]
         self.check_variable_values(vals=vals, server_ids=self.server_test_1)
 
         # Test 'get_variable_values' function
@@ -105,13 +116,12 @@ class TestTowerVariable(TestTowerCommon):
         var_version = res_vars["test_version"]
 
         self.assertIsNone(var_dir, msg="Variable 'dir' must be None")
-        self.assertIsNone(var_url, msg="Variable 'url' must be None")
+        self.assertFalse(var_url, msg="Variable 'url' must be False")
         self.assertEqual(var_os, "Debian", msg="Variable 'os' must be 'Debian'")
         self.assertEqual(var_version, "10.0", msg="Variable 'version' must be '10.0'")
 
-        # ***
-        # *** Test global variable values ***
-        # ***
+        # -- 2 --
+        # Test global variable values
 
         # Create a global value for the 'dir' variable
         self.VariableValues.create(
@@ -131,7 +141,7 @@ class TestTowerVariable(TestTowerCommon):
         self.assertEqual(
             var_dir, "/global/dir", msg="Variable 'dir' must be equal to '/global/dir'"
         )
-        self.assertIsNone(var_url, msg="Variable 'url' must be None")
+        self.assertFalse(var_url, msg="Variable 'url' must be False")
         self.assertEqual(var_os, "Debian", msg="Variable 'os' must be 'Debian'")
         self.assertEqual(var_version, "10.0", msg="Variable 'version' must be '10.0'")
 
@@ -157,7 +167,7 @@ class TestTowerVariable(TestTowerCommon):
         self.assertEqual(
             var_dir, "/opt/odoo", msg="Variable 'dir' must be equal to '/opt/odoo'"
         )
-        self.assertIsNone(var_url, msg="Variable 'url' must be None")
+        self.assertFalse(var_url, msg="Variable 'url' must be False")
         self.assertEqual(var_os, "Debian", msg="Variable 'os' must be 'Debian'")
         self.assertEqual(var_version, "10.0", msg="Variable 'version' must be '10.0'")
 


### PR DESCRIPTION
Before this commit
------------------

- 'Value' field was required
- 'Variable' field was not required

After this commit
-----------------

- 'Value' field is not required
- 'Variable' field is required

Why?
----
This is needed to allow overriding global variable values locally
with 'False' value.
Also there cannot be a variable value without a variable,
therefore 'Variable' must be a mandatory field.

Example
-------
Variable 'branch' has a global value 'main'.
There is a command that creates a new branch on;y if branch is
not defined (==False).
Before this commit the only way to achieve that was to assign some value
eg "no" and check for it: `if {{ branch }} == 'no':`
After this commit value field may remain empty so the same check
will look like: `if not {{ branch }}:`