### PR TITLE
[14.0][IMP] cetmix_tower_server: Server Template mods

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -155,7 +155,7 @@ class TowerVariableValue(models.Model):
                 break
         return is_global
 
-    @api.depends("server_id", "server_template_id")
+    @api.depends("server_id", "server_template_id", "plan_line_action_id")
     def _compute_is_global(self):
         """
         If variable considered `global` when it's not linked to any record.

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -262,20 +262,17 @@ class TowerVariableValue(models.Model):
         """Ensure that a variable is only assigned to one model at a time."""
         for record in self:
             # Check how many of the fields are set
-            count_assigned = sum(
-                1
-                for field in [
-                    record.server_id,
-                    record.server_template_id,
-                    record.plan_line_action_id,
-                ]
-                if field
+            count_assigned = (
+                bool(record.server_id)
+                + bool(record.server_template_id)
+                + bool(record.plan_line_action_id)
             )
-
             if count_assigned > 1:
                 raise ValidationError(
                     _(
-                        "A variable value can only be assigned to one of the models:"
-                        "Server, Server Template, or Plan Line Action."
+                        "Variable '%(var)s' can only be assigned to one of the models "
+                        "at a time: "
+                        "Server, Server Template, or Plan Line Action.",
+                        var=record.variable_id.name,
                     )
                 )

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -48,4 +48,5 @@ access_server_log_manager,Server Log->Manager,model_cx_tower_server_log,group_ma
 access_server_log_root,Server Log->Root,model_cx_tower_server_log,group_root,1,1,1,1
 access_server_template_manager,Server Template->Manager,model_cx_tower_server_template,group_manager,1,1,1,0
 access_server_template_root,Server Template->Root,model_cx_tower_server_template,group_root,1,1,1,1
-access_create_server_from_template_user,Create Server From Template->User,model_cx_tower_server_template_create_wizard,group_user,1,1,1,1
+access_create_server_from_template_manager,Create Server From Template->Manager,model_cx_tower_server_template_create_wizard,group_manager,1,1,1,1
+access_create_server_from_template_line_manager,Create Server From Template Line->Manager,model_cx_tower_server_template_create_wizard_line,group_manager,1,1,1,1

--- a/cetmix_tower_server/views/cx_tower_server_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_template_view.xml
@@ -33,18 +33,25 @@
                                         /></a>
                             </div>
                         </div>
-
-                            <div
+                        <div
                                 class="container o_kanban_card_manage_pane dropdown-menu"
                                 role="menu"
                             >
-                                <div class="o_kanban_card_manage_settings row">
-                                    <ul
-                                        class="oe_kanban_colorpicker"
-                                        data-field="color"
-                                    />
+                            <div class="row">
+                                <div class="col-8">
+                                    <div>
+                                        <a
+                                                role="menuitem"
+                                                type="object"
+                                                name="action_create_server"
+                                            >Create Server</a>
+                                    </div>
                                 </div>
                             </div>
+                            <div class="o_kanban_card_manage_settings row">
+                                <ul class="oe_kanban_colorpicker" data-field="color" />
+                            </div>
+                        </div>
                         <div class="oe_kanban_content">
                             <div class="oe_kanban_global_click">
                                 <div class="col-12 pt8 o_kanban_primary_right">
@@ -158,20 +165,13 @@
                                     <field name="ssh_port" />
                                     <field name="ssh_username" />
                                     <field name="use_sudo" />
-                                    <field
-                                        name="ssh_password"
-                                        attrs="{'required': [('ssh_auth_mode', '=', 'p')]}"
-                                        password="True"
-                                    />
-                                    <field
-                                        name="ssh_key_id"
-                                        attrs="{'required': [('ssh_auth_mode', '=', 'k')]}"
-                                    />
+                                    <field name="ssh_password" password="True" />
+                                    <field name="ssh_key_id" />
                                 </group>
                                 <field name="note" placeholder="Put your notes here" />
                             </group>
                         </page>
-                        <page name="variables" string="Variables">
+                        <page name="variables" string="Configuration">
                             <field name="variable_value_ids" order="variable_reference">
                                 <tree editable="bottom">
                                     <field name="variable_reference" invisible="1" />

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard.py
@@ -5,6 +5,8 @@ from odoo import fields, models
 
 
 class CxTowerServerTemplateCreateWizard(models.TransientModel):
+    """Create new server from template"""
+
     _name = "cx.tower.server.template.create.wizard"
     _description = "Create new server from template"
 
@@ -17,10 +19,16 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
         string="Server Name",
         required=True,
     )
+    color = fields.Integer(help="For better visualization in views")
     ip_v4_address = fields.Char(string="IPv4 Address")
     ip_v6_address = fields.Char(string="IPv6 Address")
-    ssh_port = fields.Char(string="SSH port", required=True, default="22")
-    ssh_username = fields.Char(string="SSH Username", required=True)
+    ssh_port = fields.Char(string="SSH port", default="22")
+    ssh_username = fields.Char(
+        string="SSH Username",
+        required=True,
+        help="This is required, however you can change this later "
+        "in the server settings",
+    )
     ssh_password = fields.Char(string="SSH Password")
     ssh_key_id = fields.Many2one(
         comodel_name="cx.tower.key",
@@ -36,22 +44,45 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
         default="p",
         required=True,
     )
+    line_ids = fields.One2many(
+        comodel_name="cx.tower.server.template.create.wizard.line",
+        inverse_name="wizard_id",
+    )
+
+    def _prepare_server_parameters(self):
+        """Prepare new server parameters
+
+        Returns:
+            dict(): New server parameters
+        """
+        res = {
+            "ip_v4_address": self.ip_v4_address,
+            "ip_v6_address": self.ip_v6_address,
+            "ssh_port": self.ssh_port,
+            "ssh_username": self.ssh_username,
+            "ssh_password": self.ssh_password,
+            "ssh_key_id": self.ssh_key_id.id,
+            "ssh_auth_mode": self.ssh_auth_mode,
+        }
+        if self.line_ids:
+            res.update(
+                {
+                    "configuration_variables": {
+                        line.variable_reference: line.value_char
+                        for line in self.line_ids
+                    }
+                }
+            )
+        return res
 
     def action_confirm(self):
         """
         Create and open new created server from template
         """
         self.ensure_one()
-        server = self.server_template_id._create_new_server(
-            self.name,
-            ip_v4_address=self.ip_v4_address,
-            ip_v6_address=self.ip_v6_address,
-            ssh_port=self.ssh_port,
-            ssh_username=self.ssh_username,
-            ssh_password=self.ssh_password,
-            ssh_key_id=self.ssh_key_id.id,
-            ssh_auth_mode=self.ssh_auth_mode,
-        )
+
+        kwargs = self._prepare_server_parameters()
+        server = self.server_template_id._create_new_server(self.name, **kwargs)
         action = self.env["ir.actions.actions"]._for_xml_id(
             "cetmix_tower_server.action_cx_tower_server"
         )
@@ -59,3 +90,15 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
             {"view_mode": "form", "res_id": server.id, "views": [(False, "form")]}
         )
         return action
+
+
+class CxTowerServerTemplateCreateWizardVariableLine(models.TransientModel):
+    """Configuration variables"""
+
+    _name = "cx.tower.server.template.create.wizard.line"
+    _description = "Create new server from template variables"
+
+    wizard_id = fields.Many2one("cx.tower.server.template.create.wizard")
+    variable_id = fields.Many2one(comodel_name="cx.tower.variable", required=True)
+    variable_reference = fields.Char(related="variable_id.reference", readonly=True)
+    value_char = fields.Char(string="Value")

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
@@ -6,10 +6,13 @@
         <field name="model">cx.tower.server.template.create.wizard</field>
         <field name="arch" type="xml">
             <form>
+                <div class="oe_title">
+                    <h1 class="d-flex flex-grow justify-content-between">
+                        <field name="name" placeholder="new server name" />
+                    </h1>
+                    <field name="color" widget="color_picker" />
+                </div>
                 <group>
-                    <group colspan="2">
-                        <field name="name" />
-                    </group>
                     <group name="main">
                         <field name="ip_v4_address" />
                         <field name="ip_v6_address" />
@@ -17,23 +20,27 @@
                     <group name="ssh">
                         <field name="ssh_auth_mode" />
                         <field name="ssh_port" />
-                        <field name="ssh_username" />
                         <field
-                            name="ssh_password"
-                            attrs="{'required': [('ssh_auth_mode', '=', 'p')]}"
-                            password="True"
+                            name="ssh_username"
+                            placeholder="this can be changed later"
                         />
-                        <field
-                            name="ssh_key_id"
-                            attrs="{'required': [('ssh_auth_mode', '=', 'k')]}"
-                        />
+                        <field name="ssh_password" password="True" />
+                        <field name="ssh_key_id" />
                     </group>
+                    <field name="line_ids">
+                        <tree editable="bottom">
+                            <field name="variable_reference" invisible="1" />
+                            <field name="variable_id" />
+                            <field name="value_char" />
+                        </tree>
+                    </field>
                 </group>
                 <footer>
                     <button
                         name="action_confirm"
                         type="object"
                         string="Confirm"
+                        confirm="Are you sure?"
                         class="oe_highlight"
                     />
                     <button string="Cancel" special="cancel" />


### PR DESCRIPTION
Improve UX by adding new features and modifying existing ones.

Server template and wizard
--------------------------

- Variable values can be edited in wizard before server creation
- Make some template fields not required because they can be set later
- Add 'Create Server' action in the kanban tile 'Action' menu
- Improve server template wizard layout

Server
------

Add context key that allows to skip constraint checks for ssh fields. This is needed in order to avoid exceptions when creating a new server from a server template using wizard.

While it's possible to modify server properties from a flight plan that is called after server is created those SSH fields can be populated later. So there is no need to block them.

Task: 4027
Doc: 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced SSH settings validation with a new context key for optional checks.
	- Simplified `ssh_port` field in server templates, making it non-mandatory.
	- Added support for additional configuration variables during server creation.
	- Introduced a color field for better visualization in the server template wizard.

- **User Interface Improvements**
	- Updated kanban view with a "Create Server" action link for better management.
	- Reorganized form layout with new fields for improved user interaction, including a color picker and editable variable entries.
	- Updated `ssh_username` field with a placeholder indicating it can be changed later.

- **Bug Fixes**
	- Improved error handling for SSH settings validation, allowing multiple issues to be reported at once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->