### PR TITLE
[14.0][IMP] cetmix_tower_server: UI/UX imporovents

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -130,6 +130,10 @@ class CxTowerCommand(models.Model):
     server_status = fields.Selection(
         selection=lambda self: self.env["cx.tower.server"]._selection_status(),
         string="Server Status",
+        help=(
+            "Set the following status if command is executed successfully."
+            " Leave 'Undefined' if you don't need to update the status"
+        ),
     )
 
     @api.depends("action")

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -33,7 +33,7 @@ class CxTowerCommandLog(models.Model):
     command_id = fields.Many2one(
         comodel_name="cx.tower.command", required=True, index=True, ondelete="restrict"
     )
-    command_action = fields.Selection(related="command_id.action")
+    command_action = fields.Selection(related="command_id.action", store=True)
     path = fields.Char(string="Execution Path", help="Where command was executed")
     code = fields.Text(string="Command Code")
     command_status = fields.Integer(string="Exit Code")

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -49,7 +49,7 @@ class CxTowerPlanLog(models.Model):
     )
     plan_status = fields.Integer(string="Status")
     parent_flight_plan_log_id = fields.Many2one(
-        "cx.tower.plan.log",
+        "cx.tower.plan.log", string="Main Log", ondelete="cascade"
     )
 
     @api.depends("server_id.name", "name")

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -106,6 +106,7 @@
                 <field name="duration_current" optional="show" />
                 <field name="server_id" optional="show" />
                 <field name="command_id" optional="show" />
+                <field name="command_action" optional="show" />
                 <field name="command_status" optional="show" />
                 <field name="is_running" optional="hide" />
             </tree>
@@ -120,6 +121,28 @@
                 <field name="label" />
                 <field name="server_id" />
                 <field name="command_id" />
+                <separator />
+                <filter
+                    string="SSH command"
+                    name="filter_action_ssh_command"
+                    domain="[('command_action', '=', 'ssh_command')]"
+                />
+                <filter
+                    string="Python code"
+                    name="filter_action_python_code"
+                    domain="[('command_action', '=', 'python_code')]"
+                />
+                <filter
+                    string="File from template"
+                    name="filter_file_action"
+                    domain="[('command_action', '=', 'file_using_template')]"
+                />
+                <filter
+                    string="Run a flight plan"
+                    name="filter_plan_action"
+                    domain="[('command_action', '=', 'plan')]"
+                />
+                <separator />
                 <filter
                     string="Success"
                     name="filter_success"
@@ -153,6 +176,12 @@
                         name="group_command"
                         domain="[]"
                         context="{'group_by': 'command_id'}"
+                    />
+                    <filter
+                        string="Action"
+                        name="group_action"
+                        domain="[]"
+                        context="{'group_by': 'command_action'}"
                     />
                     <filter
                         string="Start date"

--- a/cetmix_tower_server/views/cx_tower_plan_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_log_view.xml
@@ -62,6 +62,7 @@
                                 decoration-muted="command_status == -20"
                             >
                             <field name="command_id" optional="show" />
+                            <field name="command_action" optional="show" />
                             <field name="start_date" optional="hide" />
                             <field name="finish_date" optional="hide" />
                             <field name="duration_current" optional="show" />
@@ -88,6 +89,7 @@
                 <field name="duration_current" optional="show" />
                 <field name="server_id" optional="show" />
                 <field name="plan_id" optional="show" />
+                <field name="parent_flight_plan_log_id" optional="hide" />
                 <field name="plan_status" optional="show" />
                 <field name="is_running" optional="hide" />
             </tree>
@@ -95,70 +97,88 @@
     </record>
 
     <record id="cx_tower_plan_log_search_view" model="ir.ui.view">
-        <field name="name">cx.tower.plan.log.view.search</field>
-        <field name="model">cx.tower.plan.log</field>
-        <field name="arch" type="xml">
-            <search string="Search Flight Plan Log">
-                <field name="label" />
-                <field name="server_id" />
-                <field name="plan_id" />
-                <filter
+    <field name="name">cx.tower.plan.log.view.search</field>
+    <field name="model">cx.tower.plan.log</field>
+    <field name="arch" type="xml">
+        <search string="Search Flight Plan Log">
+            <field name="label" />
+            <field name="server_id" />
+            <field name="plan_id" />
+            <filter
                     string="Success"
                     name="filter_success"
                     domain="[('plan_status', '=', 0)]"
                 />
-                <filter
+            <filter
                     string="Error"
                     name="filter_error"
                     domain="[('plan_status', '!=', 0)]"
                 />
-                <filter
+            <filter
                     string="Running Now"
                     name="filter_is_running"
                     domain="[('is_running', '=', True)]"
                 />
-                <separator />
-                <filter
+            <separator />
+            <filter
                     string="Labeled"
                     name="filter_labeled"
                     domain="[('label', '!=', False)]"
                 />
-                <group expand="0" string="Group By">
-                    <filter
+            <filter
+                    string="Main plans"
+                    name="filter_main_plans"
+                    domain="[('parent_flight_plan_log_id', '=', False)]"
+                />
+            <filter
+                    string="Child plans"
+                    name="filter_child_plans"
+                    domain="[('parent_flight_plan_log_id', '!=', False)]"
+                />
+            <separator />
+            <group expand="0" string="Group By">
+                <filter
                         string="Server"
                         name="group_server"
                         domain="[]"
                         context="{'group_by': 'server_id'}"
                     />
-                    <filter
+                <filter
                         string="Flight Plan"
                         name="group_plan"
                         domain="[]"
                         context="{'group_by': 'plan_id'}"
                     />
-                    <filter
+                <filter
                         string="Start date"
                         name="group_start"
                         domain="[]"
                         context="{'group_by': 'start_date:day'}"
                     />
-                    <filter
+                <filter
                         string="Finish date"
                         name="group_finish"
                         domain="[]"
                         context="{'group_by': 'finish_date:day'}"
                     />
-                </group>
-            </search>
-        </field>
-    </record>
+                <filter
+                        string="Main plan"
+                        name="group_main_plan"
+                        domain="[]"
+                        context="{'group_by': 'parent_flight_plan_log_id'}"
+                    />
+            </group>
+        </search>
+    </field>
+</record>
+
 
     <record id="action_cx_tower_plan_log" model="ir.actions.act_window">
         <field name="name">Flight Plan Log</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">cx.tower.plan.log</field>
         <field name="view_mode">tree,form</field>
-        <field name="context">{}</field>
+        <field name="context">{'search_default_filter_main_plans': 1}</field>
     </record>
 
 </odoo>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -79,6 +79,7 @@
                                         optional="show"
                                         widget="many2many_tags"
                                         groups="cetmix_tower_server.group_manager"
+                                        options="{'color_field': 'color'}"
                                     />
                                     <field name="use_sudo" optional="show" />
                                     <field name="path" optional="show" />

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -18,6 +18,7 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
     command_id = fields.Many2one(
         "cx.tower.command",
     )
+    note = fields.Text(related="command_id.note", readonly=True)
     action = fields.Selection(
         selection=[
             ("ssh_command", "SSH command"),

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -54,6 +54,11 @@
                         attrs="{'invisible': [('action', '=', 'python_code')]}"
                         placeholder="e.g. /home/user This field does NOT support variables"
                     />
+                    <field
+                        name="note"
+                        readonly="1"
+                        attrs="{'invisible': [('note', '=', False)]}"
+                    />
                 </group>
                     <field
                     name="result"

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard.py
@@ -17,6 +17,7 @@ class CxTowerPlanExecuteWizard(models.TransientModel):
         "cx.tower.plan",
         required=True,
     )
+    note = fields.Text(related="plan_id.note", readonly=True)
     plan_domain = fields.Binary(
         compute="_compute_plan_domain",
     )

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
@@ -21,6 +21,11 @@
                         <span>show shared</span>
                         <field name="any_server" />
                     </div>
+                    <field
+                        name="note"
+                        readonly="1"
+                        attrs="{'invisible': [('note', '=', False)]}"
+                    />
                     <field name="plan_line_ids">
                         <tree decoration-bf="action=='plan'">
                             <field name="name" />
@@ -34,6 +39,7 @@
                                 optional="show"
                                 groups="cetmix_tower_server.group_manager"
                                 widget="many2many_tags"
+                                options="{'color_field': 'color'}"
                             />
                         </tree>
                     </field>


### PR DESCRIPTION
This commit improve the following views:

Flight plan log:
    - Add "Action" field (command_id->action) "optional=show"
    - Add pre defined filters:
        - Main plans (parent_flight_plan_log_id = False) Set it as default
        - Child plans (parent_flight_plan_log_id != False)
        -  Add "Group by" by "Main plan" (parent_flight_plan_log_id) 
        - Add "Main Log" (parent_flight_plan_log_id) field (optional=hide) 
Command log:
    - Show related command action (optional=show)
    - Add filters per each action (SSH, Python, Plan, File) so user could select only logs of command with selected action
    - Add a new "Group By" by command action

Command wizard:
    - Add "Note" field (command_id -> note),  readonly, between "Command" and "Path". Show it only if it is not empty.

Flight plan wizard:
    - Tags must be coloured according to their defined colours
    - Show "Note" field between "Plan" and "Commands" Same as for the command wizard.

Flight plan form:
    - Tags must be coloured according to their defined colours

Command.
    - Add help message to the "Status" field: "Set the following status if command is executed successfully. Leave 'Undefined' if you don't need to update the status"
 
Task: 4021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added help text for the `server_status` field to clarify its usage.
  - Introduced a new `command_action` field in the command log model, now stored for improved performance.
  - Enhanced user interface with new filters for `command_action` in search views, allowing for more granular filtering.
  - Added a `note` field in command and plan execution wizards for additional context.
  - Improved the visibility and attributes for fields in various views, including color coding for tags.

- **Improvements**
  - Enhanced search and tree views with new filtering options for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->