### PR TITLE
[14.0][FIX] cetmix_tower_server: Custom code can be executed on a single server at once

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -819,8 +819,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -910,16 +910,18 @@ Run a Command
       to this location even if you run command using sudo.
    -  **Code**: Raw command code
    -  **Preview**: Command code rendered using server variables.
-      **IMPORTANT:** If several servers are selected preview will be
-      rendered for the first one. However during the command execution
-      command code will be rendered for each server separately.
+      **IMPORTANT:** If several servers are selected preview will not be
+      rendered. However during the command execution command code will
+      be rendered for each server separately.
 
 There are two action buttons available in the wizard:
 
 -  **Run**. Executes a command using server "run" method and log command
    result into the "Command Log".
 -  **Run in wizard**. Executes a command directly in the wizard and show
-   command log in a new wizard window.
+   command log in a new wizard window. **IMPORTANT:** Button will be
+   show only if single server is selected. If you try to run a command
+   for several servers from code, you will get a ValidationError.
 
 You can check command execution logs in the
 ``Cetmix Tower/Commands/Command Logs`` menu. Important! If you want to
@@ -980,9 +982,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -990,7 +992,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -1005,6 +1007,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/readme/USAGE.md
+++ b/cetmix_tower_server/readme/USAGE.md
@@ -69,12 +69,13 @@ for record in records:
   - **Path**: Directory where command will be executed. Important: this field does not support variables! Ensure that user has access to this location even if you run command using sudo.
   - **Code**: Raw command code
   - **Preview**: Command code rendered using server variables.
-  **IMPORTANT:** If several servers are selected preview will be rendered for the first one. However during the command execution command code will be rendered for each server separately.
+  **IMPORTANT:** If several servers are selected preview will not be rendered. However during the command execution command code will be rendered for each server separately.
 
 There are two action buttons available in the wizard:
 
 - **Run**. Executes a command using server "run" method and log command result into the "Command Log".
 - **Run in wizard**. Executes a command directly in the wizard and show command log in a new wizard window.
+**IMPORTANT:** Button will be show only if single server is selected. If you try to run a command for several servers from code, you will get a ValidationError.
 
 You can check command execution logs in the `Cetmix Tower/Commands/Command Logs` menu.
 Important! If you want to delete a command you need to delete all its logs manually before doing that.

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:6c40ab716b16ec044499d473b85e83f8864c734ca0dccf1ad533cd84a97e46eb
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -470,7 +470,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting/Users &amp; Companies/Users</tt> and open a user whom you would like
 to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In <tt class="docutils literal">Other</tt> section find the <tt class="docutils literal">Cetmix Tower</tt> field and select one of
 the following options:</p>
 <ul class="simple">
@@ -1014,7 +1014,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1149,7 +1149,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1192,9 +1192,9 @@ this field does not support variables! Ensure that user has access
 to this location even if you run command using sudo.</li>
 <li><strong>Code</strong>: Raw command code</li>
 <li><strong>Preview</strong>: Command code rendered using server variables.
-<strong>IMPORTANT:</strong> If several servers are selected preview will be
-rendered for the first one. However during the command execution
-command code will be rendered for each server separately.</li>
+<strong>IMPORTANT:</strong> If several servers are selected preview will not be
+rendered. However during the command execution command code will
+be rendered for each server separately.</li>
 </ul>
 </li>
 </ul>
@@ -1203,7 +1203,9 @@ command code will be rendered for each server separately.</li>
 <li><strong>Run</strong>. Executes a command using server “run” method and log command
 result into the “Command Log”.</li>
 <li><strong>Run in wizard</strong>. Executes a command directly in the wizard and show
-command log in a new wizard window.</li>
+command log in a new wizard window. <strong>IMPORTANT:</strong> Button will be
+show only if single server is selected. If you try to run a command
+for several servers from code, you will get a ValidationError.</li>
 </ul>
 <p>You can check command execution logs in the
 <tt class="docutils literal">Cetmix Tower/Commands/Command Logs</tt> menu. Important! If you want to
@@ -1245,14 +1247,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
 the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
 order to refresh all logs at once. Log output will be displayed in
 the HTML field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1269,7 +1271,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1282,7 +1284,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -77,7 +77,11 @@
                             groups="cetmix_tower_server.group_manager"
                         />
                     </page>
-                    <page name="preview" string="Preview">
+                    <page
+                        name="preview"
+                        string="Preview"
+                        attrs="{'invisible': [('show_servers', '=', True)]}"
+                    >
                         <field
                             name="rendered_code"
                             widget="ace"
@@ -102,7 +106,7 @@
                         help="Run code as it appears in 'Rendered code' in wizard and return to wizard. Result will not be logged"
                         class="oe_highlight"
                         groups="cetmix_tower_server.group_manager"
-                        attrs="{'invisible': ['|', ('result', '!=', False),('code', '=', False)]}"
+                        attrs="{'invisible': ['|', '|', ('result', '!=', False), ('code', '=', False), ('show_servers', '=', True)]}"
                     />
                     <button string="Cancel" special="cancel" />
                     <button


### PR DESCRIPTION
This commit addresses the issue of executing custom code in the wizard when multiple servers are selected.
The following changes have been made:

API/Backend:
- A `UserError` is raised if a user tries to run custom code for multiple servers in the wizard.

UI/UX:
- The "Run in wizard" button is hidden if multiple servers are selected.
- The "Rendered code" tab is not rendered if multiple servers are selected.

Task: 3663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation Updates**
	- Updated URLs in the README and usage documentation to point to the stable version `14.0`.
	- Clarified instructions regarding server creation and command execution, particularly for scenarios involving multiple servers.

- **User Interface Enhancements**
	- Adjusted visibility logic for the command execution wizard and the 'Run in wizard' button to improve user experience when selecting multiple servers.

- **New Tests**
	- Introduced a test for command execution behavior when multiple servers are selected, enhancing error handling validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->