### PR TITLE
[14.0] [IMP ]cetmix_tower_server: flight plan access refactoring

### DIFF
--- a/cetmix_tower_server/security/cx_tower_plan_security.xml
+++ b/cetmix_tower_server/security/cx_tower_plan_security.xml
@@ -1,25 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-
     <record id="cx_tower_plan_rule_group_user_access" model="ir.rule">
         <field name="name">Tower plan: user access rule</field>
         <field name="model_id" ref="model_cx_tower_plan" />
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
-        <field name="domain_force">[('access_level', '=', '1')]</field>
-
-
+        <field name="domain_force">
+            [
+            ('access_level', '=', '1'),
+            '|',
+            ('server_ids', '=', False),
+            ('server_ids.message_partner_ids', 'in', [user.partner_id.id])
+            ]
+        </field>
     </record>
 
     <record id="cx_tower_plan_rule_group_manager_access" model="ir.rule">
         <field name="name">Tower plan: manager access rule</field>
         <field name="model_id" ref="model_cx_tower_plan" />
-        <field name="domain_force">[('access_level', '&lt;=', '2')]</field>
+        <field name="domain_force">
+            [
+            ('access_level', '&lt;=', '2'),
+            '|',
+            ('server_ids', '=', False),
+            ('server_ids.message_partner_ids', 'in', [user.partner_id.id])
+            ]
+        </field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
-
-
     </record>
-
 
     <record id="cx_tower_plan_rule_group_root_access" model="ir.rule">
         <field name="name">Tower plan: root access rule</field>
@@ -27,6 +35,4 @@
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4,ref('cetmix_tower_server.group_root'))]" />
     </record>
-
-
 </odoo>


### PR DESCRIPTION
   Before this PR
    ------------------
    
    - Users have access to all flight plans with access level = "1"
    - Managers have access to all flight plans with access level <= "2"
    
    After this PR
    -----------------
    
 - Users have access to flight plans that belong to servers they are following
   OR flight plans with no server specified AND access level = "1"
 - Managers have access to flight plans that belong to servers they are following
   OR flight plans with no server specified AND access level <= "2"
    
    Task: 4022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced access rules for user and manager groups, improving access control logic.
	- Added functionality to duplicate flight plans, ensuring accurate copying of associated elements.
	- Improved handling of nested plans, including better logging and error reflection.

- **Bug Fixes**
	- Expanded test coverage for user access and plan execution, correcting previous inaccuracies.

- **Tests**
	- Introduced new tests for plan copying, nested plan execution, error handling, and condition-based execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->