### PR TITLE
[14.0][FIX] cetmix_tower_server: Fix attributes

### DIFF
--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -185,7 +185,7 @@
                 />
                 <filter
                     string="Server tight"
-                    name="filter_global"
+                    name="server_tight"
                     domain="[('server_ids', '!=', False)]"
                 />
                 <separator />

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -137,7 +137,7 @@
                 />
                 <filter
                     string="Server tight"
-                    name="filter_global"
+                    name="server_tight"
                     domain="[('server_ids', '!=', False)]"
                 />
                 <separator />

--- a/cetmix_tower_server/views/cx_tower_variable_value_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_value_view.xml
@@ -10,13 +10,16 @@
                 <field name="is_global" widget="boolean_toggle" />
                 <field
                     name="server_id"
-                    attrs="{'readonly': [('server_template_id', '!=', False)]}"
+                    attrs="{'readonly': ['|',('server_template_id', '!=', False), ('plan_line_action_id', '!=', False)]}"
                 />
-                <field
+            <field
                     name="server_template_id"
-                    attrs="{'readonly': [('server_id', '!=', False)]}"
+                    attrs="{'readonly': ['|',('server_id', '!=', False), ('plan_line_action_id', '!=', False)]}"
                 />
-                <field name="plan_line_action_id" />
+            <field
+                    name="plan_line_action_id"
+                    attrs="{'readonly': ['|',('server_id', '!=', False), ('server_template_id', '!=', False)]}"
+                />
                 <field name="value_char" />
             </tree>
         </field>

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -16,9 +16,6 @@
                         Remember: Python code is executed on the Tower server, not on the remote one.
                     </p>
                 </div>
-                <h2>
-                    Rendered code is shown as for the first selected server!
-                </h2>
                 <group>
                     <field name="show_servers" invisible="1" />
                     <field


### PR DESCRIPTION
This commit fixes the following issue:

Issue 1
There are two filters with the same name attribute name="filter_global":

 - "Global"
 - "Server tight"

Change  attribute name for "Server tight" to "server_tight"

Issue 2
Only one of those fields can be selectable at once:

- server_id
- server_template_id
- plan_line_action_id

Task: 4038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added "Logs" buttons in the form views for command and plan management, enabling quick access to logs.
	- Introduced a new field, `plan_line_action_id`, enhancing the conditional logic for field visibility and usability.

- **User Interface Enhancements**
	- Improved visibility and requirements for fields based on user actions, streamlining the command management interface.
	- Updated search filter name from "filter_global" to "server_tight" for enhanced clarity in filtering options.
	- Removed unnecessary header from the command execution wizard, simplifying the user interface.

- **Bug Fixes**
	- Adjusted field attributes to ensure proper read-only conditions for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->