### PR TITLE
[FIX] cetmix_tower_server Reference generation

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -197,10 +197,8 @@ class CxTowerPlanLine(models.Model):
             **log_vals,
         )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        # Use the common method from mixin
-        vals_list = self._populate_references(
-            "cx.tower.plan", "plan_id", vals_list, suffix="_line"
-        )
-        return super().create(vals_list)
+    # Check cx.tower.reference.mixin for the function documentation
+    def _get_pre_populated_model_data(self):
+        res = super()._get_pre_populated_model_data()
+        res.update({"cx.tower.plan.line": ["cx.tower.plan", "plan_id", "line"]})
+        return res

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -78,10 +78,10 @@ class CxTowerPlanLineAction(models.Model):
             else:
                 rec.name = _("Wrong action")
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        # Use the common method from mixin with a custom suffix
-        vals_list = self._populate_references(
-            "cx.tower.plan.line", "line_id", vals_list, suffix="_action"
+    # Check cx.tower.reference.mixin for the function documentation
+    def _get_pre_populated_model_data(self):
+        res = super()._get_pre_populated_model_data()
+        res.update(
+            {"cx.tower.plan.line.action": ["cx.tower.plan.line", "line_id", "action"]}
         )
-        return super().create(vals_list)
+        return res

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -282,10 +282,16 @@ class TowerVariableValue(models.Model):
                     )
                 )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        # Use the common method from mixin
-        vals_list = self._populate_references(
-            "cx.tower.variable", "variable_id", vals_list, suffix="_variable"
+    # Check cx.tower.reference.mixin for the function documentation
+    def _get_pre_populated_model_data(self):
+        res = super()._get_pre_populated_model_data()
+        res.update(
+            {
+                "cx.tower.variable.value": [
+                    "cx.tower.variable",
+                    "variable_id",
+                    "variable",
+                ]
+            }
         )
-        return super().create(vals_list)
+        return res


### PR DESCRIPTION
This commit fixes the following issue:

Steps to reproduce
------------------

- Create a new flight plan line with no flight plan but with reference
- Save it

Expected result
---------------

- Flight plan line is created with provided reference

Current result
--------------

- Flight plan line is created with auto generated reference. Which looks like "no__line_1"

What is done
------------

- When pre-populating references do not overwrite explicitly provided ones.
- Add test for such scenario.
- Remove 'create' method overriding from models:
  - cx.tower.plan.line
  - cx.tower.plan.line.action
  - cx.tower.variable.value
- Pre-populate references for selected models directly in the 'cx.tower.reference.mixin' in order to apply
`_generate_or_fix_reference` method to them.
- Fix naming of some functions and variables.
- Fix reference suffix application: it should not contain `_`.

Task: 4046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced reference generation logic for improved handling of complex relationships.
	- New method for retrieving pre-populated model data across various classes.

- **Bug Fixes**
	- Ensured existing references are preserved during record creation.

- **Tests**
	- Updated tests to reflect changes in reference handling and naming conventions.
	- Added tests to verify preservation of existing references and to cover various scenarios involving references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->