### PR TITLE
[14.0][FIX] cetmix_tower_server: Reference generation

### DIFF
--- a/cetmix_tower_server/models/cetmix_tower.py
+++ b/cetmix_tower_server/models/cetmix_tower.py
@@ -1,4 +1,4 @@
-# Copyright (C) 20224Cetmix OÜ
+# Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, models
 

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -200,5 +200,5 @@ class CxTowerPlanLine(models.Model):
     # Check cx.tower.reference.mixin for the function documentation
     def _get_pre_populated_model_data(self):
         res = super()._get_pre_populated_model_data()
-        res.update({"cx.tower.plan.line": ["cx.tower.plan", "plan_id", "line"]})
+        res.update({"cx.tower.plan.line": ["cx.tower.plan", "plan_id"]})
         return res

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -81,7 +81,5 @@ class CxTowerPlanLineAction(models.Model):
     # Check cx.tower.reference.mixin for the function documentation
     def _get_pre_populated_model_data(self):
         res = super()._get_pre_populated_model_data()
-        res.update(
-            {"cx.tower.plan.line.action": ["cx.tower.plan.line", "line_id", "action"]}
-        )
+        res.update({"cx.tower.plan.line.action": ["cx.tower.plan.line", "line_id"]})
         return res

--- a/cetmix_tower_server/models/cx_tower_reference_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_reference_mixin.py
@@ -164,11 +164,12 @@ class CxTowerReferenceMixin(models.AbstractModel):
                     continue
 
                 # Remove leading and trailing whitespaces from name
-                vals_name = vals.get("name", "")
-                name = vals_name.strip()
+                vals_name = vals.get("name")
+                name = vals_name.strip() if vals_name else vals_name
 
                 # Remove leading and trailing whitespaces from reference
-                reference = vals.get("reference", "").strip()
+                vals_reference = vals.get("reference")
+                reference = vals_reference.strip() if vals_reference else vals_reference
 
                 # Nothing can be done if no name or reference is provided
                 if not name and not reference:

--- a/cetmix_tower_server/models/cx_tower_reference_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_reference_mixin.py
@@ -50,7 +50,7 @@ class CxTowerReferenceMixin(models.AbstractModel):
 
         Returns:
             dict: Model values dictionary:
-            {model_name: [parent_model, relation_field, custom_suffix]}
+            {model_name: [parent_model, relation_field]}
         """
         return {}
 
@@ -75,10 +75,13 @@ class CxTowerReferenceMixin(models.AbstractModel):
         else:
             # Modify the pattern to be used in `sub`
             inner_pattern = reference_pattern[1:-1]
-            reference = re.sub(
-                rf"[^{inner_pattern}]",
-                "",
-                reference_source.strip().replace(" ", "_").lower(),
+            reference = (
+                re.sub(
+                    rf"[^{inner_pattern}]",
+                    "",
+                    reference_source.strip().replace(" ", "_").lower(),
+                )
+                or self._get_model_generic_reference()
             )
 
         # Check if the same reference already exists and add a suffix if yes
@@ -153,9 +156,9 @@ class CxTowerReferenceMixin(models.AbstractModel):
                 self._name
             )
             if auto_generate_settings:
-                parent_model, relation_field, suffix = auto_generate_settings
+                parent_model, relation_field = auto_generate_settings
                 vals_list = self._pre_populate_references(
-                    parent_model, relation_field, vals_list, suffix
+                    parent_model, relation_field, vals_list
                 )
 
             # Fix or create references
@@ -269,6 +272,22 @@ class CxTowerReferenceMixin(models.AbstractModel):
             default["reference"] = self._generate_or_fix_reference(default["name"])
         return super().copy(default=default)
 
+    def _get_model_generic_reference(self):
+        """Get generic reference for current model.
+        Generic references are used as a fallback in the automatic
+        reference generation.
+        When a reference cannot be generated neither from the 'reference'
+        nor from the 'name' field values.
+
+        Eg for the 'cx.tower.plan' model such reference will look like
+        'tower_plan'.
+
+        Returns:
+            Char: generated prefix
+        """
+        model_prefix = self._name.replace("cx.tower.", "").replace(".", "_")
+        return model_prefix
+
     def get_by_reference(self, reference):
         """Get record based on its reference.
 
@@ -348,7 +367,7 @@ class CxTowerReferenceMixin(models.AbstractModel):
         return {line.id: line.reference for line in lines if line.reference}
 
     @api.model
-    def _pre_populate_references(self, model_name, field_name, vals_list, suffix=""):
+    def _pre_populate_references(self, model_name, field_name, vals_list):
         """
         Populates reference fields in a list of dictionaries (vals_list)
         intended for record creation.
@@ -367,8 +386,6 @@ class CxTowerReferenceMixin(models.AbstractModel):
                               containing the related record's ID.
             vals_list (list of dict): A list of dictionaries where each dictionary
                                represents values for a new record.
-            suffix (str, optional): A suffix to append to each generated reference.
-                               Defaults to an empty string.
 
         Returns:
             list: The modified `vals_list`, with a unique 'reference'
@@ -378,6 +395,9 @@ class CxTowerReferenceMixin(models.AbstractModel):
         # Extract parent record references from vals_list
         parent_record_refs = self._prepare_references(model_name, field_name, vals_list)
         line_index_dict = defaultdict(int)
+
+        # Used to make reference more readable
+        model_reference = self._get_model_generic_reference()
 
         # Populate vals with references
         for vals in vals_list:
@@ -395,11 +415,11 @@ class CxTowerReferenceMixin(models.AbstractModel):
                 line_index = line_index_dict[record_id]
                 vals[
                     "reference"
-                ] = f"{parent_record_refs[record_id]}_{suffix}_{line_index}"
+                ] = f"{parent_record_refs[record_id]}_{model_reference}_{line_index}"
             else:
                 # Handle cases where the field is not present
                 line_index_dict["no_record"] += 1
                 line_index = line_index_dict["no_record"]
-                vals["reference"] = f"no_{suffix}_{line_index}"
+                vals["reference"] = f"no_{model_reference}_{line_index}"
 
         return vals_list

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -285,13 +285,5 @@ class TowerVariableValue(models.Model):
     # Check cx.tower.reference.mixin for the function documentation
     def _get_pre_populated_model_data(self):
         res = super()._get_pre_populated_model_data()
-        res.update(
-            {
-                "cx.tower.variable.value": [
-                    "cx.tower.variable",
-                    "variable_id",
-                    "variable",
-                ]
-            }
-        )
+        res.update({"cx.tower.variable.value": ["cx.tower.variable", "variable_id"]})
         return res

--- a/cetmix_tower_server/tests/test_reference_mixin.py
+++ b/cetmix_tower_server/tests/test_reference_mixin.py
@@ -92,6 +92,20 @@ class TestTowerReference(TestTowerCommon):
         yet_another_template_copy.write({"reference": "chad"})
         self.assertEqual(yet_another_template_copy.reference, "chad")
 
+        # -- 10 --
+        # Create new template with reference set to False
+        expected_reference = self.ServerTemplate._generate_or_fix_reference(
+            "Such Much False Template"
+        )
+        new_template_with_false = self.ServerTemplate.create(
+            {"name": "Such Much False Template", "reference": False}
+        )
+        self.assertEqual(
+            new_template_with_false.reference,
+            expected_reference,
+            "Reference doesn't match expected one",
+        )
+
     def test_search_by_reference(self):
         """Search record by its reference"""
 


### PR DESCRIPTION
This commit fixes the following issue:

# Issue 1

Steps to reproduce
------------------

- Create a new flight plan with an empty reference​ field
- Click "Save"

Expected result
---------------

- Flight plan is created
- Reference is generated automatically

Current result
--------------

Error: 'bool' object has no attribute 'strip'.

Why?
----

Because Odoo adds empty field value to vals as 'False'.

Task: 4058

# Issue 2

Steps to reproduce
------------------

- Create a new flight plan with name '/' and empty reference field.
- Save it.

Expected behavior
-----------------

- Flight plan is created, reference is generated automatically

Current behavior
----------------

- Flight plan is created, reference is empty

# Other updates


- Generate auto reference body based on model it's used in.
- Use autogenerated reference body instead of explicitly provided
  suffix when pre-populating references.   
- Fix copyright year.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reference generation logic for improved uniqueness and robustness.
	- Introduced a method for generating a generic reference format when specific references cannot be generated.

- **Bug Fixes**
	- Adjusted whitespace handling in the `create` method to prevent errors with `name` and `reference` fields.
	- Updated data structures in multiple models to simplify returned information.

- **Tests**
	- Added new test cases to validate reference generation behavior for server templates with invalid symbols and empty references.

- **Chores**
	- Updated existing test references for consistency across test cases.
	- Corrected copyright year in the header comment of the main file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->