### PR TITLE
[14.0][IMP] cetmix_tower_server: Populate reference field

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -32,75 +32,74 @@ tied down by vendor or technology constraints.
 Why Cetmix Tower?
 =================
 
--  **Open Source:** `Cetmix Tower <http://cetmix.com/tower>`__ is
-   distributed under the AGPL-3 license
--  **Odoo Integration:** Benefit from `Odoo <https:/odoo.com>`__
-   ecosystem for server management tasks, like deploying servers in
-   response to specific Odoo-triggered events
--  **Extendability:** Build your own `Odoo <https:/odoo.com>`__ modules
-   using `Cetmix Tower <http://cetmix.com/tower>`__ to implement your
-   custom features
--  **Beyond Odoo:** While optimized for Odoo, Cetmix Tower can manage
-   virtually any instance
--  **Flexibility:** Use Cetmix Tower alongside other management methods
-   without restriction, ensuring you're not limited to a single vendor
--  **Self-Hosting:** Deploy Cetmix Tower on your own infrastructure for
-   full control over your server management.
--  **Broad Compatibility:** Execute any software that's manageable via
-   shell commands or API. From Docker or Kubernetes to direct OS package
-   installations
+- **Open Source:** `Cetmix Tower <http://cetmix.com/tower>`__ is
+  distributed under the AGPL-3 license
+- **Odoo Integration:** Benefit from `Odoo <https:/odoo.com>`__
+  ecosystem for server management tasks, like deploying servers in
+  response to specific Odoo-triggered events
+- **Extendability:** Build your own `Odoo <https:/odoo.com>`__ modules
+  using `Cetmix Tower <http://cetmix.com/tower>`__ to implement your
+  custom features
+- **Beyond Odoo:** While optimized for Odoo, Cetmix Tower can manage
+  virtually any instance
+- **Flexibility:** Use Cetmix Tower alongside other management methods
+  without restriction, ensuring you're not limited to a single vendor
+- **Self-Hosting:** Deploy Cetmix Tower on your own infrastructure for
+  full control over your server management.
+- **Broad Compatibility:** Execute any software that's manageable via
+  shell commands or API. From Docker or Kubernetes to direct OS package
+  installations
 
 Server Management
 =================
 
--  Variable based flexible configuration
--  Create servers using pre-defined templates
+- Variable based flexible configuration
+- Create servers using pre-defined templates
 
 Connectivity
 ============
 
--  Password and key based authentication for outgoing SSH connections
--  Built-in support of the Python `requests
-   library <https://pypi.org/project/requests/>`__ for outgoing API
-   calls
+- Password and key based authentication for outgoing SSH connections
+- Built-in support of the Python `requests
+  library <https://pypi.org/project/requests/>`__ for outgoing API calls
 
 Commands
 ========
 
--  Execute SSH commands on remote servers
--  Run Python code on the Tower Odoo server
--  Run Flight Plan from command
--  Render commands using variables
--  Secret keys for private data storage
+- Execute SSH commands on remote servers
+- Run Python code on the Tower Odoo server
+- Run Flight Plan from command
+- Render commands using variables
+- Secret keys for private data storage
 
 Flight Plans
 ============
 
--  Execute multiple commands in a row
--  Condition based flow:
+- Execute multiple commands in a row
+- Condition based flow:
 
-   -  Based on condition using `Python
-      syntax <https://www.w3schools.com/python/python_syntax.asp>`__
-   -  Based on the previous command exit code
+  - Based on condition using `Python
+    syntax <https://www.w3schools.com/python/python_syntax.asp>`__
+  - Based on the previous command exit code
 
 Files
 =====
 
--  Download files from remote server using SFTP
--  Upload files to remote server using SFTP
--  Support for ``text`` and ``binary`` file format
--  Manage files using pre-defined file templates
+- Download files from remote server using SFTP
+- Upload files to remote server using SFTP
+- Support for ``text`` and ``binary`` file format
+- Manage files using pre-defined file templates
 
 Support and Technical Requirements
 ==================================
 
--  Cetmix Tower with usability and simplicity in mind, though some
-   features might require a foundational understanding of server
-   management principles
--  We offer dedicated support to help with any custom setup needs or
-   questions that may arise
--  For additional details, visit our website
-   `cetmix.com <https://cetmix.com>`__
+- Cetmix Tower with usability and simplicity in mind, though some
+  features might require a foundational understanding of server
+  management principles
+- We offer dedicated support to help with any custom setup needs or
+  questions that may arise
+- For additional details, visit our website
+  `cetmix.com <https://cetmix.com>`__
 
 **Table of contents**
 
@@ -128,21 +127,21 @@ like to provide access to the Cetmix Tower.
 In the ``Cetmix Tower`` section select one of the following options in
 the ``Access Level`` field:
 
--  **User**. Members of this group have read access only to the
-   `Servers <#configure-a-server>`__ which they are added as followers.
-   They also have access to the entities such as
-   `Commands <#configure-a-command>`__, `Flight
-   Plans <#configure-a-flight-plan>`__ or `Server
-   Logs <#configure-a-server-log>`__ with ``Access Level`` set to
-   ``User``.
--  **Manager**. Members of this group can modify
-   `Servers <#configure-a-server>`__ which they are added as followers.
-   They can create new `Servers <#configure-a-server>`__ too however
-   they cannot delete them. Users of this group have access to the
-   entities with ``Access Level`` set to ``Manager`` or ``User``.
--  **Root**. Members of this group can create, modify or delete any
-   `Server <#configure-a-server>`__. They also have access to the
-   entities with any ``Access Level`` set.
+- **User**. Members of this group have read access only to the
+  `Servers <#configure-a-server>`__ which they are added as followers.
+  They also have access to the entities such as
+  `Commands <#configure-a-command>`__, `Flight
+  Plans <#configure-a-flight-plan>`__ or `Server
+  Logs <#configure-a-server-log>`__ with ``Access Level`` set to
+  ``User``.
+- **Manager**. Members of this group can modify
+  `Servers <#configure-a-server>`__ which they are added as followers.
+  They can create new `Servers <#configure-a-server>`__ too however they
+  cannot delete them. Users of this group have access to the entities
+  with ``Access Level`` set to ``Manager`` or ``User``.
+- **Root**. Members of this group can create, modify or delete any
+  `Server <#configure-a-server>`__. They also have access to the
+  entities with any ``Access Level`` set.
 
 **NB:** Please keep in mind that some of the entities can have their
 additional access management variations.
@@ -159,32 +158,32 @@ Fill the values it the tabs below:
 
 **General Settings**
 
--  **Partner**: Partner this server belongs to
--  **Operating System**: Operating system that runs on the server
--  **Tags**: User-defined search tags
--  **IPv4 Address**
--  **IPv6 Address**: Will be used if no IPv4 address is specified
--  **SSH Auth Mode**: Available options are "Password" and "Key"
--  **SSH Port**
--  **SSH Username**
--  **Use sudo**: If sudo is required by default for running all commands
-   on this server
--  **SSH Password**: Used if Auth Mode is set to "Password" and for
-   running ``sudo`` commands with password
--  **SSH Private Key**: Used for authentication is SSH Auth Mode is set
-   to "Key"
--  **Note**: Comments or user notes
+- **Partner**: Partner this server belongs to
+- **Operating System**: Operating system that runs on the server
+- **Tags**: User-defined search tags
+- **IPv4 Address**
+- **IPv6 Address**: Will be used if no IPv4 address is specified
+- **SSH Auth Mode**: Available options are "Password" and "Key"
+- **SSH Port**
+- **SSH Username**
+- **Use sudo**: If sudo is required by default for running all commands
+  on this server
+- **SSH Password**: Used if Auth Mode is set to "Password" and for
+  running ``sudo`` commands with password
+- **SSH Private Key**: Used for authentication is SSH Auth Mode is set
+  to "Key"
+- **Note**: Comments or user notes
 
 There is a special **Status** field which indicates current Server
 status. It is meant to be updated automatically using external API with
 further customizations. Following pre-defined statuses are available:
 
--  Undefined
--  Stopped
--  Starting
--  Running
--  Stopping
--  Restarting
+- Undefined
+- Stopped
+- Starting
+- Running
+- Stopping
+- Restarting
 
 Default status is 'Undefined'.
 
@@ -209,12 +208,12 @@ Log <#configure-a-server-log>`__ section for more details.
 
 Following action buttons are located in the top of the form:
 
--  **Command Logs**: Shows all `Command <#configure-a-command>`__ logs
-   for this server
--  **Flight Plan Logs**: Shows all `Flight
-   Plan <#configure-a-flight-plan>`__ logs for this server
--  **Files**: Shows all `Files <#configure-a-file>`__ that belong to
-   this server
+- **Command Logs**: Shows all `Command <#configure-a-command>`__ logs
+  for this server
+- **Flight Plan Logs**: Shows all `Flight
+  Plan <#configure-a-flight-plan>`__ logs for this server
+- **Files**: Shows all `Files <#configure-a-file>`__ that belong to this
+  server
 
 Configure a Server Template
 ---------------------------
@@ -227,18 +226,18 @@ Fill the values it the tabs below:
 
 **General Settings**
 
--  **Flight Plan**: Select a flight plan to be executed after a server
-   is created
--  **Operating System**: Default operating system for new servers
--  **Tags**: Default search tags for new servers
--  **SSH Auth Mode**: Default SSH auth mode for new servers. Available
-   options are "Password" and "Key"
--  **SSH Port**: Default SSH port for new servers
--  **SSH Username**: Default SSH username for new servers
--  **Use sudo**: Default sudo mode for new servers
--  **SSH Password**: Default SSH password for new servers
--  **SSH Private Key**: Default SSH private key for new servers
--  **Note**: Comments or user notes
+- **Flight Plan**: Select a flight plan to be executed after a server is
+  created
+- **Operating System**: Default operating system for new servers
+- **Tags**: Default search tags for new servers
+- **SSH Auth Mode**: Default SSH auth mode for new servers. Available
+  options are "Password" and "Key"
+- **SSH Port**: Default SSH port for new servers
+- **SSH Username**: Default SSH username for new servers
+- **Use sudo**: Default sudo mode for new servers
+- **SSH Password**: Default SSH password for new servers
+- **SSH Private Key**: Default SSH private key for new servers
+- **Note**: Comments or user notes
 
 **Variables**
 
@@ -257,11 +256,11 @@ Configure Variables
 To configure variables go to the ``Cetmix Tower -> Settings`` and select
 the ``Variables`` menu. Click ``Create`` and put values in the fields:
 
--  **Name**: Readable name
--  **Reference**: Unique identifier used to address variable in
-   conditions and expressions. Leave blank to generate automatically
-   based on name
--  **Note**: Put your notes here
+- **Name**: Readable name
+- **Reference**: Unique identifier used to address variable in
+  conditions and expressions. Leave blank to generate automatically
+  based on name
+- **Note**: Put your notes here
 
 Configure Tags
 --------------
@@ -269,12 +268,12 @@ Configure Tags
 To configure variables go to the ``Cetmix Tower -> Settings`` and select
 the ``Tags`` menu. Click ``Create`` and put values in the fields:
 
--  **Name**: Readable name
--  **Reference**: Unique identifier used to address the tag in
-   conditions and expressions. Leave this field blank to generate it
-   automatically based on the name
--  **Color**: Select a color for the tag
--  **Servers**: Select the servers associated with the tag.
+- **Name**: Readable name
+- **Reference**: Unique identifier used to address the tag in conditions
+  and expressions. Leave this field blank to generate it automatically
+  based on the name
+- **Color**: Select a color for the tag
+- **Servers**: Select the servers associated with the tag.
 
 Configure OSs (Operating Systems)
 ---------------------------------
@@ -283,12 +282,12 @@ To configure operating systems, go to the ``Cetmix Tower -> Settings``
 and select the ``OSs`` menu. Click ``Create`` and fill in the values for
 the following fields:
 
--  **Name**: Readable name
--  **Reference**: Unique identifier used to address the OS in conditions
-   and expressions. Leave this field blank to generate it automatically
-   based on the name.
--  **Color**: Select a color for the OS.
--  **Previous Version**: Select the previous version of the current OS.
+- **Name**: Readable name
+- **Reference**: Unique identifier used to address the OS in conditions
+  and expressions. Leave this field blank to generate it automatically
+  based on the name.
+- **Color**: Select a color for the OS.
+- **Previous Version**: Select the previous version of the current OS.
 
 Variables Applicability
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -296,15 +295,15 @@ Variables Applicability
 `Cetmix Tower <https://cetmix.com/tower>`__ supports ``jinja2`` syntax
 for variables. You can use variables to render:
 
--  Commands. Eg ``ls -lh {{ file_store_location }}``
--  Files. Eg a "Dockerfile" file can have the following text in it:
-   ``ODOO_VERSION = {{ odoo_default_version }}``
--  File Templates. You can use variables for both file name and file
-   location on server. Eg ``File Name`` value is
-   ``backup_{{ instance_name }}_{{ odoo_db_name }}`` and
-   ``Directory on server`` is ``{{ file_cron_location }}``
--  Other Variables. Eg for an ``odoo_config_location`` variable can have
-   a value of ``{{ odoo_root}}/conf``
+- Commands. Eg ``ls -lh {{ file_store_location }}``
+- Files. Eg a "Dockerfile" file can have the following text in it:
+  ``ODOO_VERSION = {{ odoo_default_version }}``
+- File Templates. You can use variables for both file name and file
+  location on server. Eg ``File Name`` value is
+  ``backup_{{ instance_name }}_{{ odoo_db_name }}`` and
+  ``Directory on server`` is ``{{ file_cron_location }}``
+- Other Variables. Eg for an ``odoo_config_location`` variable can have
+  a value of ``{{ odoo_root}}/conf``
 
 You can use any ``jinja2`` supported expressions. For example
 ``if else`` statements:
@@ -325,8 +324,8 @@ Variable Rendering Modes
 
 There are two rendering modes available:
 
--  Generic (or ssh) mode
--  Pythonic mode
+- Generic (or ssh) mode
+- Pythonic mode
 
 Let use the following code as example:
 
@@ -372,10 +371,10 @@ Variable Types
 Following types of variable values available in `Cetmix
 Tower <https://cetmix.com/tower>`__:
 
--  Local values. Those are values that are defined at a record level.
-   For example for a server or an action.
--  Global values. Those are values that are defined at the `Cetmix
-   Tower <https://cetmix.com/tower>`__ level.
+- Local values. Those are values that are defined at a record level. For
+  example for a server or an action.
+- Global values. Those are values that are defined at the `Cetmix
+  Tower <https://cetmix.com/tower>`__ level.
 
 When rendering an expression local values are used first. If no local
 value is found then global value will be used. For example default value
@@ -396,20 +395,20 @@ the ``tower`` variable unless you really need that on purpose.
 
 Following system variables are available:
 
--  Server properties
+- Server properties
 
-   -  ``tower.server.name`` Current server name
-   -  ``tower.server.reference`` Current server reference
-   -  ``tower.server.username`` Current server SSH Username​
-   -  ``tower.server.ipv4`` Current server IPv4 Address​
-   -  ``tower.server.ipv6`` Current server IPv6 Address​
-   -  ``tower.server.partner_name`` Current server partner name
+  - ``tower.server.name`` Current server name
+  - ``tower.server.reference`` Current server reference
+  - ``tower.server.username`` Current server SSH Username​
+  - ``tower.server.ipv4`` Current server IPv4 Address​
+  - ``tower.server.ipv6`` Current server IPv6 Address​
+  - ``tower.server.partner_name`` Current server partner name
 
--  Helper tools
+- Helper tools
 
-   -  ``tower.tools.uuid`` Generates a random UUID4
-   -  ``tower.tools.today`` Current date
-   -  ``tower.tools.now`` Current date time
+  - ``tower.tools.uuid`` Generates a random UUID4
+  - ``tower.tools.today`` Current date
+  - ``tower.tools.now`` Current date time
 
 Configure a Key/Secret
 ----------------------
@@ -419,28 +418,28 @@ used for rendering commands. To configure a new key or secret go to
 ``Cetmix Tower -> Settings -> Keys`` click ``Create`` and put values in
 the fields:
 
--  **Name**: Readable name
--  **Key Type**: Following values are available:
+- **Name**: Readable name
+- **Key Type**: Following values are available:
 
-   -  ``SSH Key`` is used to store SSH private keys. They are selectable
-      in `Server settings <#configure-a-server>`__
-   -  ``Secret`` used to store sensitive information that can be used
-      inline in commands. Eg a token or a password. Secrets cannot be
-      previewed in command preview and are replaced with placeholder in
-      `command <#configure-a-command>`__ logs.
+  - ``SSH Key`` is used to store SSH private keys. They are selectable
+    in `Server settings <#configure-a-server>`__
+  - ``Secret`` used to store sensitive information that can be used
+    inline in commands. Eg a token or a password. Secrets cannot be
+    previewed in command preview and are replaced with placeholder in
+    `command <#configure-a-command>`__ logs.
 
--  **Reference**: Key/secret record reference
--  **Reference Code**: Complete reference code for inline usage
--  **Value**: Key value. **IMPORTANT:** This is a write only field.
-   Please ensure that you have saved your key/secret before saving it.
-   Once saved it cannot be read from the user interface any longer.
--  **Used For**: ``SSH Key`` type only. List of
-   `Servers <#configure-a-server>`__ where this SSH key is used
--  **Partner**: ``Secret`` type only. If selected this secret is used
-   only for the `Servers <#configure-a-server>`__ of selected partner
--  **Server**: ``Secret`` type only. If selected this secret is used
-   only for selected `Server <#configure-a-server>`__
--  **Note**: Put your notes here
+- **Reference**: Key/secret record reference
+- **Reference Code**: Complete reference code for inline usage
+- **Value**: Key value. **IMPORTANT:** This is a write only field.
+  Please ensure that you have saved your key/secret before saving it.
+  Once saved it cannot be read from the user interface any longer.
+- **Used For**: ``SSH Key`` type only. List of
+  `Servers <#configure-a-server>`__ where this SSH key is used
+- **Partner**: ``Secret`` type only. If selected this secret is used
+  only for the `Servers <#configure-a-server>`__ of selected partner
+- **Server**: ``Secret`` type only. If selected this secret is used only
+  for selected `Server <#configure-a-server>`__
+- **Note**: Put your notes here
 
 Keys of type ``Secret``
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -459,9 +458,9 @@ Secrets are inserted inline in code using the following pattern:
 ``#!cxtower.secret.REFERENCE!#``. It consists of three dot separated
 parts and is terminated with a mandatory ``!#`` suffix:
 
--  ``#!cxtower`` is used to declare a special Tower construction
--  ``secret`` is used to declare its type (secret)
--  ``REFERENCE`` secret id as it's written in the **Key ID** field
+- ``#!cxtower`` is used to declare a special Tower construction
+- ``secret`` is used to declare its type (secret)
+- ``REFERENCE`` secret id as it's written in the **Key ID** field
 
 **Example:**
 
@@ -485,49 +484,49 @@ Configure a File
 file transfer operations. Based on initial file location following file
 sources are available:
 
--  Server. These are files that are initially located on remote server
-   and are fetched to `Cetmix Tower <https://cetmix.com/tower>`__. For
-   example log files.
+- Server. These are files that are initially located on remote server
+  and are fetched to `Cetmix Tower <https://cetmix.com/tower>`__. For
+  example log files.
 
--  Tower. These are files that are initially formed in `Cetmix
-   Tower <https://cetmix.com/tower>`__ and are uploaded to remote
-   server. For example configuration files. Such files are rendered
-   using variables and can be created and managed using file templates.
+- Tower. These are files that are initially formed in `Cetmix
+  Tower <https://cetmix.com/tower>`__ and are uploaded to remote server.
+  For example configuration files. Such files are rendered using
+  variables and can be created and managed using file templates.
 
 To create a new file go to ``Cetmix Tower -> Files -> Files`` click
 ``Create`` and put values in the fields:
 
--  **Name**: Filesystem filename
--  **Source**: File source. Available options are ``Server`` and
-   ``Tower``. Check above for more details.
--  **File type**: Type of file contents. Possible options:
+- **Name**: Filesystem filename
+- **Source**: File source. Available options are ``Server`` and
+  ``Tower``. Check above for more details.
+- **File type**: Type of file contents. Possible options:
 
-   -  **Text**: Regular text. Eg configuration file or log
-   -  **Binary**: Binary file. Eg file archive or pdf document
+  - **Text**: Regular text. Eg configuration file or log
+  - **Binary**: Binary file. Eg file archive or pdf document
 
--  **File**: Is used to store binary file data.
--  **Template**: File template used to render this file. If selected
-   file will be automatically updated every time template is modified.
--  **Server**: Server where this file is located
--  **Directory on Server**: This is where the file is located on the
-   remote server
--  **Full Server Path**: Full path to file on the remote server
-   including filename
--  **Auto Sync**: If enabled the file will be automatically uploaded to
-   the remote server on after it is modified in `Cetmix
-   Tower <https://cetmix.com/tower>`__. Used only with ``Tower`` source.
--  **Keep when deleted**: If enabled, file will be kept on remote server
-   after removing it in the Odoo
+- **File**: Is used to store binary file data.
+- **Template**: File template used to render this file. If selected file
+  will be automatically updated every time template is modified.
+- **Server**: Server where this file is located
+- **Directory on Server**: This is where the file is located on the
+  remote server
+- **Full Server Path**: Full path to file on the remote server including
+  filename
+- **Auto Sync**: If enabled the file will be automatically uploaded to
+  the remote server on after it is modified in `Cetmix
+  Tower <https://cetmix.com/tower>`__. Used only with ``Tower`` source.
+- **Keep when deleted**: If enabled, file will be kept on remote server
+  after removing it in the Odoo
 
 Following fields are located in the tabs below:
 
--  **Code**: Raw file content. This field is editable for the ``Tower``
-   files and readonly for ``Server`` ones. This field supports
-   `Variables <#configure-variables>`__.
--  **Preview**: This is a rendered file content as it will be uploaded
-   to server. Used only with ``Tower`` source.
--  **Server Version**: Current file content fetched from server. Used
-   only with ``Tower`` source.
+- **Code**: Raw file content. This field is editable for the ``Tower``
+  files and readonly for ``Server`` ones. This field supports
+  `Variables <#configure-variables>`__.
+- **Preview**: This is a rendered file content as it will be uploaded to
+  server. Used only with ``Tower`` source.
+- **Server Version**: Current file content fetched from server. Used
+  only with ``Tower`` source.
 
 **NB**: File operations are performed using user credentials from server
 configuration. You should take care of filesystem access rights to
@@ -543,27 +542,27 @@ To create a new file template go to
 ``Cetmix Tower -> Files -> Templates`` click ``Create`` and put values
 in the fields:
 
--  **Name**: Template name
--  **Reference**: Leave the "reference" field blank to generate a
-   reference automatically.
--  **File Name**: Filesystem name of the file(s) created from this
-   template. This field supports `Variables <#configure-variables>`__.
--  **Directory on server**: Directory on remote server where this file
-   will be stored. This field supports
-   `Variables <#configure-variables>`__.
--  **Source**: File source. Available options are ``Server`` and
-   ``Tower``. Check above for more details.
--  **File type**: Type of file contents. Possible options:
+- **Name**: Template name
+- **Reference**: Leave the "reference" field blank to generate a
+  reference automatically.
+- **File Name**: Filesystem name of the file(s) created from this
+  template. This field supports `Variables <#configure-variables>`__.
+- **Directory on server**: Directory on remote server where this file
+  will be stored. This field supports
+  `Variables <#configure-variables>`__.
+- **Source**: File source. Available options are ``Server`` and
+  ``Tower``. Check above for more details.
+- **File type**: Type of file contents. Possible options:
 
-   -  **Text**: Regular text. Eg configuration file or log
-   -  **Binary**: Binary file. Eg file archive or pdf document
+  - **Text**: Regular text. Eg configuration file or log
+  - **Binary**: Binary file. Eg file archive or pdf document
 
--  **Tags**: Make usage as search more convenient
--  **Note**: Comments or user notes
--  **Code**: Raw file content. This field supports
-   `Variables <#configure-variables>`__.
--  **Keep when deleted**: If enabled, file(s) created from this template
-   will be kept on remote server after removing it(them) in the Odoo
+- **Tags**: Make usage as search more convenient
+- **Note**: Comments or user notes
+- **Code**: Raw file content. This field supports
+  `Variables <#configure-variables>`__.
+- **Keep when deleted**: If enabled, file(s) created from this template
+  will be kept on remote server after removing it(them) in the Odoo
 
 **Hint**: If you want to create a file from template but don't want
 further template modifications to be applied to this file remove the
@@ -576,62 +575,59 @@ Command is a shell command that is executed on remote server. To create
 a new command go to ``Cetmix Tower -> Commands -> Commands`` click
 ``Create`` and put values in the fields:
 
--  **Name**: Command readable name.
+- **Name**: Command readable name.
 
--  **Reference**: Leave the "reference" field blank to generate a
-   reference automatically.
+- **Reference**: Leave the "reference" field blank to generate a
+  reference automatically.
 
--  **Allow Parallel Run**: If disabled only one copy of this command can
-   be run on the same server at the same time. Otherwise the same
-   command can be run in parallel.
+- **Allow Parallel Run**: If disabled only one copy of this command can
+  be run on the same server at the same time. Otherwise the same command
+  can be run in parallel.
 
--  **Note**: Comments or user notes.
+- **Note**: Comments or user notes.
 
--  **Servers**: List of servers this command can be run on. Leave this
-   field blank to make the command available to all servers.
+- **Servers**: List of servers this command can be run on. Leave this
+  field blank to make the command available to all servers.
 
--  **OSes**: List of operating systems this command is available. Leave
-   this field blank to make the command available for all OSes.
+- **OSes**: List of operating systems this command is available. Leave
+  this field blank to make the command available for all OSes.
 
--  **Tags**: Make usage as search more convenient.
+- **Tags**: Make usage as search more convenient.
 
--  **Action**: Action executed by the command. Possible options:
+- **Action**: Action executed by the command. Possible options:
 
-   -  ``SSH command``: Execute a shell command using ssh connection on
-      remote server.
-   -  ``Execute Python code``: Execute a Python code on the Tower
-      Server.
-   -  ``Create file using template``: Create or update a file using
-      selected file template and push / pull it to remote server /
-      tower. If the file already exists on server it will be
-      overwritten.
-   -  ``Run flight plan``: Allow to start Flight Plan execution from
-      command ().
+  - ``SSH command``: Execute a shell command using ssh connection on
+    remote server.
+  - ``Execute Python code``: Execute a Python code on the Tower Server.
+  - ``Create file using template``: Create or update a file using
+    selected file template and push / pull it to remote server / tower.
+    If the file already exists on server it will be overwritten.
+  - ``Run flight plan``: Allow to start Flight Plan execution from
+    command ().
 
--  **Default Path**: Specify path where command will be executed. This
-   field supports `Variables <#configure-variables>`__. Important:
-   ensure ssh user has access to the location even if executing command
-   using sudo.
+- **Default Path**: Specify path where command will be executed. This
+  field supports `Variables <#configure-variables>`__. Important: ensure
+  ssh user has access to the location even if executing command using
+  sudo.
 
--  **Code**: Code to execute. Can be an SSH command or Python code based
-   on selected action. This field supports
-   `Variables <#configure-variables>`__. **Important!** Variables used
-   in command are rendered in `different
-   modes <#variable-rendering-modes>`__ based on the command action.
+- **Code**: Code to execute. Can be an SSH command or Python code based
+  on selected action. This field supports
+  `Variables <#configure-variables>`__. **Important!** Variables used in
+  command are rendered in `different
+  modes <#variable-rendering-modes>`__ based on the command action.
 
--  **File Template**: File template that will be used to create or
-   update file. Check `File Templates <#file-templates>`__ for more
-   details.
+- **File Template**: File template that will be used to create or update
+  file. Check `File Templates <#file-templates>`__ for more details.
 
--  **Server Status**: Server status to be set after command execution.
-   Possible options:
+- **Server Status**: Server status to be set after command execution.
+  Possible options:
 
-   -  ``Undefined``. Default status.
-   -  ``Stopped``. Server is stopped.
-   -  ``Starting``. Server is starting.
-   -  ``Running``. Server is running.
-   -  ``Stopping``. Server is stopping.
-   -  ``Restarting``. Server is restarting.
+  - ``Undefined``. Default status.
+  - ``Stopped``. Server is stopped.
+  - ``Starting``. Server is starting.
+  - ``Running``. Server is running.
+  - ``Stopping``. Server is stopping.
+  - ``Restarting``. Server is restarting.
 
 To return result from Python assign exit code and message to the
 COMMAND_RESULT variable of type ``dict`` like this:
@@ -658,66 +654,65 @@ a flexible condition based execution flow. To create a new flight plan
 go to ``Cetmix Tower -> Commands -> Flight Plans`` click ``Create`` and
 put values in the fields:
 
--  **Name**: Flight Plan name
+- **Name**: Flight Plan name
 
--  **Reference**: Leave the "reference" field blank to generate a
-   reference automatically.
+- **Reference**: Leave the "reference" field blank to generate a
+  reference automatically.
 
--  **On Error**: Default action to execute when an error happens during
-   the flight plan execution. Possible options:
+- **On Error**: Default action to execute when an error happens during
+  the flight plan execution. Possible options:
 
-   -  ``Exit with command code``. Will terminate the flight plan
-      execution and return an exit code of the failed command.
-   -  ``Exit with custom code``. Will terminate the flight plan
-      execution and return the custom code configured in the field next
-      to this one.
-   -  ``Run next command``. Will continue flight plan execution.
+  - ``Exit with command code``. Will terminate the flight plan execution
+    and return an exit code of the failed command.
+  - ``Exit with custom code``. Will terminate the flight plan execution
+    and return the custom code configured in the field next to this one.
+  - ``Run next command``. Will continue flight plan execution.
 
--  **Note**: Comments or user notes.
+- **Note**: Comments or user notes.
 
--  **Servers**: List of servers this command can be run on. Leave this
-   field blank to make the command available to all servers.
+- **Servers**: List of servers this command can be run on. Leave this
+  field blank to make the command available to all servers.
 
--  **Tags**: Make usage as search more convenient.
+- **Tags**: Make usage as search more convenient.
 
--  **Code**: List of commands to execute. Each of the commands has the
-   following fields:
+- **Code**: List of commands to execute. Each of the commands has the
+  following fields:
 
-   -  **Sequence**: Order this command is executed. Lower value = higher
-      priority.
-   -  **Condition**: `Python
-      expression <https://www.w3schools.com/python/python_syntax.asp>`__
-      to be matched for the command to be executed. Leave this field
-      blank for unconditional command execution. This field supports
-      `Variables <#configure-variables>`__. Example:
+  - **Sequence**: Order this command is executed. Lower value = higher
+    priority.
+  - **Condition**: `Python
+    expression <https://www.w3schools.com/python/python_syntax.asp>`__
+    to be matched for the command to be executed. Leave this field blank
+    for unconditional command execution. This field supports
+    `Variables <#configure-variables>`__. Example:
 
-   .. code:: python
+  .. code:: python
 
-      {{ odoo_version }} == "17.0" and ( {{ nginx_installed }} or {{ traefik_installed }} )
+     {{ odoo_version }} == "17.0" and ( {{ nginx_installed }} or {{ traefik_installed }} )
 
-   -  **Command**: `Command <#configure-a-command>`__ to be executed.
-   -  **Path**: Specify path where command will be executed. Overrides
-      ``Default Path`` of the command. This field supports
-      `Variables <#configure-variables>`__.
-   -  **Use Sudo**: Use ``sudo`` if required to run this command.
-   -  **Post Run Actions**: List of conditional actions to be triggered
-      after the command is executed. Each of the actions has the
-      following fields:
+  - **Command**: `Command <#configure-a-command>`__ to be executed.
+  - **Path**: Specify path where command will be executed. Overrides
+    ``Default Path`` of the command. This field supports
+    `Variables <#configure-variables>`__.
+  - **Use Sudo**: Use ``sudo`` if required to run this command.
+  - **Post Run Actions**: List of conditional actions to be triggered
+    after the command is executed. Each of the actions has the following
+    fields:
 
-      -  **Sequence**: Order this actions is triggered. Lower value =
-         higher priority.
-      -  **Condition**: Uses command exit code.
-      -  **Action**: Action to execute if condition is met. Also, if
-         variables with values are specified, these variables will be
-         updated (for existing variables on the server) or added (for
-         new variables) to the server variables. Possible options:
+    - **Sequence**: Order this actions is triggered. Lower value =
+      higher priority.
+    - **Condition**: Uses command exit code.
+    - **Action**: Action to execute if condition is met. Also, if
+      variables with values are specified, these variables will be
+      updated (for existing variables on the server) or added (for new
+      variables) to the server variables. Possible options:
 
-         -  ``Exit with command code``. Will terminate the flight plan
-            execution and return an exit code of the failed command.
-         -  ``Exit with custom code``. Will terminate the flight plan
-            execution and return the custom code configured in the field
-            next to this one.
-         -  ``Run next command``. Will continue flight plan execution.
+      - ``Exit with command code``. Will terminate the flight plan
+        execution and return an exit code of the failed command.
+      - ``Exit with custom code``. Will terminate the flight plan
+        execution and return the custom code configured in the field
+        next to this one.
+      - ``Run next command``. Will continue flight plan execution.
 
 Configure a Server Log
 ----------------------
@@ -730,38 +725,36 @@ way. To configure a Server Log open the server form, navigate to the
 
 Following fields are available:
 
--  **Name**: Readable name of the log
--  **Access Level**: Minimum access level required to access this
-   record. Please check the `User Access
-   Settings <#user-access-configuration>`__ section for more details.
-   Possible options:
+- **Name**: Readable name of the log
+- **Access Level**: Minimum access level required to access this record.
+  Please check the `User Access Settings <#user-access-configuration>`__
+  section for more details. Possible options:
 
-   -  ``User``. User must have at least ``Cetmix Tower / User`` access
-      group configured in the User Settings.
-   -  ``Manager``. User must have at least ``Cetmix Tower / Manager``
-      access group configured in the User Settings.
-   -  ``Root``. User must have ``Cetmix Tower / Root`` access group
-      configured in the User Settings.
+  - ``User``. User must have at least ``Cetmix Tower / User`` access
+    group configured in the User Settings.
+  - ``Manager``. User must have at least ``Cetmix Tower / Manager``
+    access group configured in the User Settings.
+  - ``Root``. User must have ``Cetmix Tower / Root`` access group
+    configured in the User Settings.
 
--  **Log Type**: Defines the way logs are fetched. Possible options:
+- **Log Type**: Defines the way logs are fetched. Possible options:
 
-   -  ``Command``. A command is run with its output being saved to the
-      log
-   -  ``File``. Log is fetched from a file
+  - ``Command``. A command is run with its output being saved to the log
+  - ``File``. Log is fetched from a file
 
--  **Command**: A command that is used to fetched the logs. This option
-   is available only for ``Log Type`` set to ``Command``. Important:
-   please ensure that selected command can be executed multiple times in
-   parallel to avoid any potential issues.
--  **Use Sudo**: Use ``sudo`` if required to run this command.
--  **File**: A file that is used to fetch the log. This option is not
-   available when configuring a log for a `Server
-   Template <#configure-a-server-template>`__
--  **File Template**: A file template that is used to create a file when
-   a new `Server <#configure-a-server>`__ is created from a `Server
-   Template <#configure-a-server-template>`__. This option is available
-   only when configuring a log for a `Server
-   Template <#configure-a-server-template>`__
+- **Command**: A command that is used to fetched the logs. This option
+  is available only for ``Log Type`` set to ``Command``. Important:
+  please ensure that selected command can be executed multiple times in
+  parallel to avoid any potential issues.
+- **Use Sudo**: Use ``sudo`` if required to run this command.
+- **File**: A file that is used to fetch the log. This option is not
+  available when configuring a log for a `Server
+  Template <#configure-a-server-template>`__
+- **File Template**: A file template that is used to create a file when
+  a new `Server <#configure-a-server>`__ is created from a `Server
+  Template <#configure-a-server-template>`__. This option is available
+  only when configuring a log for a `Server
+  Template <#configure-a-server-template>`__
 
 **Developer hint**: log output supports HTML formatting. You can
 implement your custom log formatter by overriding the
@@ -778,9 +771,9 @@ needed. Use flight plans instead.
 
 **Why?**
 
--  Simple commands are easier to reuse across multiple flight plans.
--  Commands run with ``sudo`` with password are be split and executed
-   one by one anyway.
+- Simple commands are easier to reuse across multiple flight plans.
+- Commands run with ``sudo`` with password are be split and executed one
+  by one anyway.
 
 **Not recommended:**
 
@@ -810,8 +803,8 @@ command or ``Path`` field in flight plan line.
 
 **Why?**
 
--  Tower will automatically adjust the command to ensure it is properly
-   executed in the specified location.
+- Tower will automatically adjust the command to ensure it is properly
+  executed in the specified location.
 
 **Do not do this:**
 
@@ -821,21 +814,21 @@ command or ``Path`` field in flight plan line.
 
 **Way to go:**
 
--  Add the following value in the ``Default Path`` command field or
-   ``Path`` field of a flight plan line:
+- Add the following value in the ``Default Path`` command field or
+  ``Path`` field of a flight plan line:
 
 .. code:: bash
 
    /home/{{ tower.server.username }}/memes
 
--  Leave the command code as follows:
+- Leave the command code as follows:
 
 .. code:: bash
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -843,16 +836,16 @@ Usage
 Create a new Server from a Server Template
 ------------------------------------------
 
--  Go to the ``Cetmix Tower/Servers/Templates`` menu and select a
-   `Server Template <CONFIGURE.md/#configure-a-server-template>`__
--  Click "Create Server" button. A pop-up wizard will open with server
-   parameters populated from the template
--  Put the new server name, check the parameters and click "Confirm"
-   button
--  New server will be created
--  If a `Flight Plan <CONFIGURE.md/#configure-a-flight-plan>`__ is
-   defined in the server template it will be automatically executed
-   after a new server is created
+- Go to the ``Cetmix Tower/Servers/Templates`` menu and select a `Server
+  Template <CONFIGURE.md/#configure-a-server-template>`__
+- Click "Create Server" button. A pop-up wizard will open with server
+  parameters populated from the template
+- Put the new server name, check the parameters and click "Confirm"
+  button
+- New server will be created
+- If a `Flight Plan <CONFIGURE.md/#configure-a-flight-plan>`__ is
+  defined in the server template it will be automatically executed after
+  a new server is created
 
 You can also create a new server from template from code using a
 designated ``create_server_from_template`` function of the
@@ -909,34 +902,34 @@ server when a Sales Order is confirmed:
 Run a Command
 -------------
 
--  Select a server in the list view or open a server form view
--  Open the ``Actions`` menu and click ``Execute Command``
--  A wizard is opened with the following fields:
+- Select a server in the list view or open a server form view
+- Open the ``Actions`` menu and click ``Execute Command``
+- A wizard is opened with the following fields:
 
-   -  **Servers**: Servers on which this command will be executed
-   -  **Tags**: If selected only commands with these tags will be shown
-   -  **Sudo**: ``sudo`` option for running this command
-   -  **Command**: Command to execute
-   -  **Show shared**: By default only commands available for the
-      selected server(s) are selectable. Activate this checkbox to
-      select any command
-   -  **Path**: Directory where command will be executed. Important:
-      this field does not support variables! Ensure that user has access
-      to this location even if you run command using sudo.
-   -  **Code**: Raw command code
-   -  **Preview**: Command code rendered using server variables.
-      **IMPORTANT:** If several servers are selected preview will not be
-      rendered. However during the command execution command code will
-      be rendered for each server separately.
+  - **Servers**: Servers on which this command will be executed
+  - **Tags**: If selected only commands with these tags will be shown
+  - **Sudo**: ``sudo`` option for running this command
+  - **Command**: Command to execute
+  - **Show shared**: By default only commands available for the selected
+    server(s) are selectable. Activate this checkbox to select any
+    command
+  - **Path**: Directory where command will be executed. Important: this
+    field does not support variables! Ensure that user has access to
+    this location even if you run command using sudo.
+  - **Code**: Raw command code
+  - **Preview**: Command code rendered using server variables.
+    **IMPORTANT:** If several servers are selected preview will not be
+    rendered. However during the command execution command code will be
+    rendered for each server separately.
 
 There are two action buttons available in the wizard:
 
--  **Run**. Executes a command using server "run" method and log command
-   result into the "Command Log".
--  **Run in wizard**. Executes a command directly in the wizard and show
-   command log in a new wizard window. **IMPORTANT:** Button will be
-   show only if single server is selected. If you try to run a command
-   for several servers from code, you will get a ValidationError.
+- **Run**. Executes a command using server "run" method and log command
+  result into the "Command Log".
+- **Run in wizard**. Executes a command directly in the wizard and show
+  command log in a new wizard window. **IMPORTANT:** Button will be show
+  only if single server is selected. If you try to run a command for
+  several servers from code, you will get a ValidationError.
 
 You can check command execution logs in the
 ``Cetmix Tower/Commands/Command Logs`` menu. Important! If you want to
@@ -946,44 +939,44 @@ that.
 Run a Flight Plan
 -----------------
 
--  Select a server in the list view or open a server form view
+- Select a server in the list view or open a server form view
 
--  Open the ``Actions`` menu and click ``Execute Flight Plan``
+- Open the ``Actions`` menu and click ``Execute Flight Plan``
 
--  A wizard is opened with the following fields:
+- A wizard is opened with the following fields:
 
-   -  **Servers**: Servers on which this command will be executed
-   -  **Tags**: If selected only commands with these tags will be shown
-   -  **Plan**: Flight plan to execute
-   -  **Show shared**: By default only flight plans available for the
-      selected server(s) are selectable. Activate this checkbox to
-      select any flight plan
-   -  **Commands**: Commands that will be executed in this flight plan.
-      This field is read only
+  - **Servers**: Servers on which this command will be executed
+  - **Tags**: If selected only commands with these tags will be shown
+  - **Plan**: Flight plan to execute
+  - **Show shared**: By default only flight plans available for the
+    selected server(s) are selectable. Activate this checkbox to select
+    any flight plan
+  - **Commands**: Commands that will be executed in this flight plan.
+    This field is read only
 
-   Click the **Run** button to execute a flight plan.
+  Click the **Run** button to execute a flight plan.
 
-   You can check the flight plan results in the
-   ``Cetmix Tower/Commands/Flight Plan Logs`` menu. Important! If you
-   want to delete a command you need to delete all its logs manually
-   before doing that.
+  You can check the flight plan results in the
+  ``Cetmix Tower/Commands/Flight Plan Logs`` menu. Important! If you
+  want to delete a command you need to delete all its logs manually
+  before doing that.
 
 Check a Server Log
 ------------------
 
 To check a server log:
 
--  Navigate to the ``Server Logs`` tab on the Server form
--  Click on the log **(1)** you would like to check to open in in a pop
-   up window. Or click on the ``Open`` button **(2)** to open it in the
-   full form view
+- Navigate to the ``Server Logs`` tab on the Server form
+- Click on the log **(1)** you would like to check to open in in a pop
+  up window. Or click on the ``Open`` button **(2)** to open it in the
+  full form view
 
 |Open server log|
 
--  Click the ``Refresh`` button to update the log. You can also click
-   the ``Refresh All`` button **(3)** located above the log list in
-   order to refresh all logs at once. Log output will be displayed in
-   the HTML field below.
+- Click the ``Refresh`` button to update the log. You can also click the
+  ``Refresh All`` button **(3)** located above the log list in order to
+  refresh all logs at once. Log output will be displayed in the HTML
+  field below.
 
 |Update server log|
 
@@ -997,9 +990,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -1007,7 +1000,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -1022,6 +1015,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Cetmix Tower Server Management",
     "summary": "Flexible Server Management directly from Odoo",
-    "version": "14.0.0.3.28",
+    "version": "14.0.0.4.0",
     "category": "Productivity",
     "website": "https://cetmix.com",
     "author": "Cetmix",

--- a/cetmix_tower_server/migrations/14.0.0.4.0/post-migration.py
+++ b/cetmix_tower_server/migrations/14.0.0.4.0/post-migration.py
@@ -1,0 +1,30 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """
+    Populate the `reference` field for tables that belong to
+    models inheriting from `cx.tower.reference.mixin`.
+    This will copy the value from the `name` field to the
+    `reference` field, but only for rows where `reference`
+    is empty.
+    """
+    _logger.info("Starting SQL migration for reference field population.")
+
+    # Step 1: Identify models that have a `reference` field
+    # and belong to `cx.tower.reference.mixin` models
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    mixin_registry = env.registry["cx.tower.reference.mixin"]
+    for rec_model in env["ir.model"].search([]):
+        model = env.get(rec_model.model, False)
+        if isinstance(model, mixin_registry) and not model._abstract:
+            records = model.search([("reference", "=", False)])
+            for rec in records:
+                rec.reference = rec.name
+            _logger.info(f"Updated {len(records)} records in {rec_model.model}.")
+
+    _logger.info("SQL migration completed successfully.")

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:1427885f8ddcbec12bac847a3ee5b818180b1b4b0c69dda2eb49a1b382fd652d
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -410,8 +410,7 @@ installations</li>
 <ul class="simple">
 <li>Password and key based authentication for outgoing SSH connections</li>
 <li>Built-in support of the Python <a class="reference external" href="https://pypi.org/project/requests/">requests
-library</a> for outgoing API
-calls</li>
+library</a> for outgoing API calls</li>
 </ul>
 </div>
 <div class="section" id="commands">
@@ -470,7 +469,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting <span class="pre">-&gt;</span> Users &amp; Companies <span class="pre">-&gt;</span> Users</tt> and open a user whom you would
 like to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In the <tt class="docutils literal">Cetmix Tower</tt> section select one of the following options in
 the <tt class="docutils literal">Access Level</tt> field:</p>
 <ul class="simple">
@@ -483,9 +482,9 @@ Logs</a> with <tt class="docutils literal">Access Level</tt> set to
 <tt class="docutils literal">User</tt>.</li>
 <li><strong>Manager</strong>. Members of this group can modify
 <a class="reference external" href="#configure-a-server">Servers</a> which they are added as followers.
-They can create new <a class="reference external" href="#configure-a-server">Servers</a> too however
-they cannot delete them. Users of this group have access to the
-entities with <tt class="docutils literal">Access Level</tt> set to <tt class="docutils literal">Manager</tt> or <tt class="docutils literal">User</tt>.</li>
+They can create new <a class="reference external" href="#configure-a-server">Servers</a> too however they
+cannot delete them. Users of this group have access to the entities
+with <tt class="docutils literal">Access Level</tt> set to <tt class="docutils literal">Manager</tt> or <tt class="docutils literal">User</tt>.</li>
 <li><strong>Root</strong>. Members of this group can create, modify or delete any
 <a class="reference external" href="#configure-a-server">Server</a>. They also have access to the
 entities with any <tt class="docutils literal">Access Level</tt> set.</li>
@@ -549,8 +548,8 @@ Log</a> section for more details.</p>
 for this server</li>
 <li><strong>Flight Plan Logs</strong>: Shows all <a class="reference external" href="#configure-a-flight-plan">Flight
 Plan</a> logs for this server</li>
-<li><strong>Files</strong>: Shows all <a class="reference external" href="#configure-a-file">Files</a> that belong to
-this server</li>
+<li><strong>Files</strong>: Shows all <a class="reference external" href="#configure-a-file">Files</a> that belong to this
+server</li>
 </ul>
 </div>
 <div class="section" id="configure-a-server-template">
@@ -561,8 +560,8 @@ the “reference” field blank to generate a reference automatically.</p>
 <p>Fill the values it the tabs below:</p>
 <p><strong>General Settings</strong></p>
 <ul class="simple">
-<li><strong>Flight Plan</strong>: Select a flight plan to be executed after a server
-is created</li>
+<li><strong>Flight Plan</strong>: Select a flight plan to be executed after a server is
+created</li>
 <li><strong>Operating System</strong>: Default operating system for new servers</li>
 <li><strong>Tags</strong>: Default search tags for new servers</li>
 <li><strong>SSH Auth Mode</strong>: Default SSH auth mode for new servers. Available
@@ -600,9 +599,9 @@ based on name</li>
 the <tt class="docutils literal">Tags</tt> menu. Click <tt class="docutils literal">Create</tt> and put values in the fields:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name</li>
-<li><strong>Reference</strong>: Unique identifier used to address the tag in
-conditions and expressions. Leave this field blank to generate it
-automatically based on the name</li>
+<li><strong>Reference</strong>: Unique identifier used to address the tag in conditions
+and expressions. Leave this field blank to generate it automatically
+based on the name</li>
 <li><strong>Color</strong>: Select a color for the tag</li>
 <li><strong>Servers</strong>: Select the servers associated with the tag.</li>
 </ul>
@@ -692,8 +691,8 @@ example will be rendered the following way:</p>
 <p>Following types of variable values available in <a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower</a>:</p>
 <ul class="simple">
-<li>Local values. Those are values that are defined at a record level.
-For example for a server or an action.</li>
+<li>Local values. Those are values that are defined at a record level. For
+example for a server or an action.</li>
 <li>Global values. Those are values that are defined at the <a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower</a> level.</li>
 </ul>
@@ -757,8 +756,8 @@ Once saved it cannot be read from the user interface any longer.</li>
 <a class="reference external" href="#configure-a-server">Servers</a> where this SSH key is used</li>
 <li><strong>Partner</strong>: <tt class="docutils literal">Secret</tt> type only. If selected this secret is used
 only for the <a class="reference external" href="#configure-a-server">Servers</a> of selected partner</li>
-<li><strong>Server</strong>: <tt class="docutils literal">Secret</tt> type only. If selected this secret is used
-only for selected <a class="reference external" href="#configure-a-server">Server</a></li>
+<li><strong>Server</strong>: <tt class="docutils literal">Secret</tt> type only. If selected this secret is used only
+for selected <a class="reference external" href="#configure-a-server">Server</a></li>
 <li><strong>Note</strong>: Put your notes here</li>
 </ul>
 <div class="section" id="keys-of-type-secret">
@@ -803,9 +802,9 @@ sources are available:</p>
 and are fetched to <a class="reference external" href="https://cetmix.com/tower">Cetmix Tower</a>. For
 example log files.</li>
 <li>Tower. These are files that are initially formed in <a class="reference external" href="https://cetmix.com/tower">Cetmix
-Tower</a> and are uploaded to remote
-server. For example configuration files. Such files are rendered
-using variables and can be created and managed using file templates.</li>
+Tower</a> and are uploaded to remote server.
+For example configuration files. Such files are rendered using
+variables and can be created and managed using file templates.</li>
 </ul>
 <p>To create a new file go to <tt class="docutils literal">Cetmix Tower <span class="pre">-&gt;</span> Files <span class="pre">-&gt;</span> Files</tt> click
 <tt class="docutils literal">Create</tt> and put values in the fields:</p>
@@ -819,13 +818,13 @@ using variables and can be created and managed using file templates.</li>
 </ul>
 </li>
 <li><strong>File</strong>: Is used to store binary file data.</li>
-<li><strong>Template</strong>: File template used to render this file. If selected
-file will be automatically updated every time template is modified.</li>
+<li><strong>Template</strong>: File template used to render this file. If selected file
+will be automatically updated every time template is modified.</li>
 <li><strong>Server</strong>: Server where this file is located</li>
 <li><strong>Directory on Server</strong>: This is where the file is located on the
 remote server</li>
-<li><strong>Full Server Path</strong>: Full path to file on the remote server
-including filename</li>
+<li><strong>Full Server Path</strong>: Full path to file on the remote server including
+filename</li>
 <li><strong>Auto Sync</strong>: If enabled the file will be automatically uploaded to
 the remote server on after it is modified in <a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower</a>. Used only with <tt class="docutils literal">Tower</tt> source.</li>
@@ -837,8 +836,8 @@ after removing it in the Odoo</li>
 <li><strong>Code</strong>: Raw file content. This field is editable for the <tt class="docutils literal">Tower</tt>
 files and readonly for <tt class="docutils literal">Server</tt> ones. This field supports
 <a class="reference external" href="#configure-variables">Variables</a>.</li>
-<li><strong>Preview</strong>: This is a rendered file content as it will be uploaded
-to server. Used only with <tt class="docutils literal">Tower</tt> source.</li>
+<li><strong>Preview</strong>: This is a rendered file content as it will be uploaded to
+server. Used only with <tt class="docutils literal">Tower</tt> source.</li>
 <li><strong>Server Version</strong>: Current file content fetched from server. Used
 only with <tt class="docutils literal">Tower</tt> source.</li>
 </ul>
@@ -890,8 +889,8 @@ a new command go to <tt class="docutils literal">Cetmix Tower <span class="pre">
 <li><strong>Reference</strong>: Leave the “reference” field blank to generate a
 reference automatically.</li>
 <li><strong>Allow Parallel Run</strong>: If disabled only one copy of this command can
-be run on the same server at the same time. Otherwise the same
-command can be run in parallel.</li>
+be run on the same server at the same time. Otherwise the same command
+can be run in parallel.</li>
 <li><strong>Note</strong>: Comments or user notes.</li>
 <li><strong>Servers</strong>: List of servers this command can be run on. Leave this
 field blank to make the command available to all servers.</li>
@@ -901,28 +900,25 @@ this field blank to make the command available for all OSes.</li>
 <li><strong>Action</strong>: Action executed by the command. Possible options:<ul>
 <li><tt class="docutils literal">SSH command</tt>: Execute a shell command using ssh connection on
 remote server.</li>
-<li><tt class="docutils literal">Execute Python code</tt>: Execute a Python code on the Tower
-Server.</li>
+<li><tt class="docutils literal">Execute Python code</tt>: Execute a Python code on the Tower Server.</li>
 <li><tt class="docutils literal">Create file using template</tt>: Create or update a file using
-selected file template and push / pull it to remote server /
-tower. If the file already exists on server it will be
-overwritten.</li>
+selected file template and push / pull it to remote server / tower.
+If the file already exists on server it will be overwritten.</li>
 <li><tt class="docutils literal">Run flight plan</tt>: Allow to start Flight Plan execution from
 command ().</li>
 </ul>
 </li>
 <li><strong>Default Path</strong>: Specify path where command will be executed. This
-field supports <a class="reference external" href="#configure-variables">Variables</a>. Important:
-ensure ssh user has access to the location even if executing command
-using sudo.</li>
+field supports <a class="reference external" href="#configure-variables">Variables</a>. Important: ensure
+ssh user has access to the location even if executing command using
+sudo.</li>
 <li><strong>Code</strong>: Code to execute. Can be an SSH command or Python code based
 on selected action. This field supports
-<a class="reference external" href="#configure-variables">Variables</a>. <strong>Important!</strong> Variables used
-in command are rendered in <a class="reference external" href="#variable-rendering-modes">different
+<a class="reference external" href="#configure-variables">Variables</a>. <strong>Important!</strong> Variables used in
+command are rendered in <a class="reference external" href="#variable-rendering-modes">different
 modes</a> based on the command action.</li>
-<li><strong>File Template</strong>: File template that will be used to create or
-update file. Check <a class="reference external" href="#file-templates">File Templates</a> for more
-details.</li>
+<li><strong>File Template</strong>: File template that will be used to create or update
+file. Check <a class="reference external" href="#file-templates">File Templates</a> for more details.</li>
 <li><strong>Server Status</strong>: Server status to be set after command execution.
 Possible options:<ul>
 <li><tt class="docutils literal">Undefined</tt>. Default status.</li>
@@ -965,11 +961,10 @@ reference automatically.</p>
 <li><p class="first"><strong>On Error</strong>: Default action to execute when an error happens during
 the flight plan execution. Possible options:</p>
 <ul class="simple">
-<li><tt class="docutils literal">Exit with command code</tt>. Will terminate the flight plan
-execution and return an exit code of the failed command.</li>
-<li><tt class="docutils literal">Exit with custom code</tt>. Will terminate the flight plan
-execution and return the custom code configured in the field next
-to this one.</li>
+<li><tt class="docutils literal">Exit with command code</tt>. Will terminate the flight plan execution
+and return an exit code of the failed command.</li>
+<li><tt class="docutils literal">Exit with custom code</tt>. Will terminate the flight plan execution
+and return the custom code configured in the field next to this one.</li>
 <li><tt class="docutils literal">Run next command</tt>. Will continue flight plan execution.</li>
 </ul>
 </li>
@@ -987,8 +982,8 @@ following fields:</p>
 priority.</li>
 <li><strong>Condition</strong>: <a class="reference external" href="https://www.w3schools.com/python/python_syntax.asp">Python
 expression</a>
-to be matched for the command to be executed. Leave this field
-blank for unconditional command execution. This field supports
+to be matched for the command to be executed. Leave this field blank
+for unconditional command execution. This field supports
 <a class="reference external" href="#configure-variables">Variables</a>. Example:</li>
 </ul>
 <pre class="code python literal-block">
@@ -1001,15 +996,15 @@ blank for unconditional command execution. This field supports
 <a class="reference external" href="#configure-variables">Variables</a>.</li>
 <li><strong>Use Sudo</strong>: Use <tt class="docutils literal">sudo</tt> if required to run this command.</li>
 <li><strong>Post Run Actions</strong>: List of conditional actions to be triggered
-after the command is executed. Each of the actions has the
-following fields:<ul>
+after the command is executed. Each of the actions has the following
+fields:<ul>
 <li><strong>Sequence</strong>: Order this actions is triggered. Lower value =
 higher priority.</li>
 <li><strong>Condition</strong>: Uses command exit code.</li>
 <li><strong>Action</strong>: Action to execute if condition is met. Also, if
 variables with values are specified, these variables will be
-updated (for existing variables on the server) or added (for
-new variables) to the server variables. Possible options:<ul>
+updated (for existing variables on the server) or added (for new
+variables) to the server variables. Possible options:<ul>
 <li><tt class="docutils literal">Exit with command code</tt>. Will terminate the flight plan
 execution and return an exit code of the failed command.</li>
 <li><tt class="docutils literal">Exit with custom code</tt>. Will terminate the flight plan
@@ -1029,14 +1024,13 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
-<li><strong>Access Level</strong>: Minimum access level required to access this
-record. Please check the <a class="reference external" href="#user-access-configuration">User Access
-Settings</a> section for more details.
-Possible options:<ul>
+<li><strong>Access Level</strong>: Minimum access level required to access this record.
+Please check the <a class="reference external" href="#user-access-configuration">User Access Settings</a>
+section for more details. Possible options:<ul>
 <li><tt class="docutils literal">User</tt>. User must have at least <tt class="docutils literal">Cetmix Tower / User</tt> access
 group configured in the User Settings.</li>
 <li><tt class="docutils literal">Manager</tt>. User must have at least <tt class="docutils literal">Cetmix Tower / Manager</tt>
@@ -1046,8 +1040,7 @@ configured in the User Settings.</li>
 </ul>
 </li>
 <li><strong>Log Type</strong>: Defines the way logs are fetched. Possible options:<ul>
-<li><tt class="docutils literal">Command</tt>. A command is run with its output being saved to the
-log</li>
+<li><tt class="docutils literal">Command</tt>. A command is run with its output being saved to the log</li>
 <li><tt class="docutils literal">File</tt>. Log is fetched from a file</li>
 </ul>
 </li>
@@ -1078,8 +1071,8 @@ needed. Use flight plans instead.</p>
 <p><strong>Why?</strong></p>
 <ul class="simple">
 <li>Simple commands are easier to reuse across multiple flight plans.</li>
-<li>Commands run with <tt class="docutils literal">sudo</tt> with password are be split and executed
-one by one anyway.</li>
+<li>Commands run with <tt class="docutils literal">sudo</tt> with password are be split and executed one
+by one anyway.</li>
 </ul>
 <p><strong>Not recommended:</strong></p>
 <pre class="code bash literal-block">
@@ -1131,16 +1124,16 @@ cat<span class="w"> </span>my_doge_memes.txt
 <div class="section" id="create-a-new-server-from-a-server-template">
 <h2>Create a new Server from a Server Template</h2>
 <ul class="simple">
-<li>Go to the <tt class="docutils literal">Cetmix Tower/Servers/Templates</tt> menu and select a
-<a class="reference external" href="CONFIGURE.md/#configure-a-server-template">Server Template</a></li>
+<li>Go to the <tt class="docutils literal">Cetmix Tower/Servers/Templates</tt> menu and select a <a class="reference external" href="CONFIGURE.md/#configure-a-server-template">Server
+Template</a></li>
 <li>Click “Create Server” button. A pop-up wizard will open with server
 parameters populated from the template</li>
 <li>Put the new server name, check the parameters and click “Confirm”
 button</li>
 <li>New server will be created</li>
 <li>If a <a class="reference external" href="CONFIGURE.md/#configure-a-flight-plan">Flight Plan</a> is
-defined in the server template it will be automatically executed
-after a new server is created</li>
+defined in the server template it will be automatically executed after
+a new server is created</li>
 </ul>
 <p>You can also create a new server from template from code using a
 designated <tt class="docutils literal">create_server_from_template</tt> function of the
@@ -1164,7 +1157,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1199,17 +1192,17 @@ server when a Sales Order is confirmed:</p>
 <li><strong>Tags</strong>: If selected only commands with these tags will be shown</li>
 <li><strong>Sudo</strong>: <tt class="docutils literal">sudo</tt> option for running this command</li>
 <li><strong>Command</strong>: Command to execute</li>
-<li><strong>Show shared</strong>: By default only commands available for the
-selected server(s) are selectable. Activate this checkbox to
-select any command</li>
-<li><strong>Path</strong>: Directory where command will be executed. Important:
-this field does not support variables! Ensure that user has access
-to this location even if you run command using sudo.</li>
+<li><strong>Show shared</strong>: By default only commands available for the selected
+server(s) are selectable. Activate this checkbox to select any
+command</li>
+<li><strong>Path</strong>: Directory where command will be executed. Important: this
+field does not support variables! Ensure that user has access to
+this location even if you run command using sudo.</li>
 <li><strong>Code</strong>: Raw command code</li>
 <li><strong>Preview</strong>: Command code rendered using server variables.
 <strong>IMPORTANT:</strong> If several servers are selected preview will not be
-rendered. However during the command execution command code will
-be rendered for each server separately.</li>
+rendered. However during the command execution command code will be
+rendered for each server separately.</li>
 </ul>
 </li>
 </ul>
@@ -1218,9 +1211,9 @@ be rendered for each server separately.</li>
 <li><strong>Run</strong>. Executes a command using server “run” method and log command
 result into the “Command Log”.</li>
 <li><strong>Run in wizard</strong>. Executes a command directly in the wizard and show
-command log in a new wizard window. <strong>IMPORTANT:</strong> Button will be
-show only if single server is selected. If you try to run a command
-for several servers from code, you will get a ValidationError.</li>
+command log in a new wizard window. <strong>IMPORTANT:</strong> Button will be show
+only if single server is selected. If you try to run a command for
+several servers from code, you will get a ValidationError.</li>
 </ul>
 <p>You can check command execution logs in the
 <tt class="docutils literal">Cetmix Tower/Commands/Command Logs</tt> menu. Important! If you want to
@@ -1240,8 +1233,8 @@ that.</p>
 <li><strong>Tags</strong>: If selected only commands with these tags will be shown</li>
 <li><strong>Plan</strong>: Flight plan to execute</li>
 <li><strong>Show shared</strong>: By default only flight plans available for the
-selected server(s) are selectable. Activate this checkbox to
-select any flight plan</li>
+selected server(s) are selectable. Activate this checkbox to select
+any flight plan</li>
 <li><strong>Commands</strong>: Commands that will be executed in this flight plan.
 This field is read only</li>
 </ul>
@@ -1262,14 +1255,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
-<li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click
-the <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in
-order to refresh all logs at once. Log output will be displayed in
-the HTML field below.</li>
+<li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click the
+<tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in order to
+refresh all logs at once. Log output will be displayed in the HTML
+field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1286,7 +1279,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1299,7 +1292,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>


### PR DESCRIPTION
This migration script uses SQL to safely populate the `reference` field for models inheriting from `cx.tower.reference.mixin`, while handling models without a `name` field and skipping abstract models without a table.

Task: 4045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated version references in the README and index files to reflect the transition from `14.0-dev` to `14.0`.
	- Corrected badge links, image sources, and feedback links for accuracy.

- **New Features**
	- Introduced a migration function to populate the `reference` field in relevant database tables.

- **Bug Fixes**
	- Ensured all documentation links point to the correct resources for the stable version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->