### PR TITLE
[14.0][IMP] cetmix_tower_server: Server Logs refs

### DIFF
--- a/cetmix_tower_server/views/cx_tower_server_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_log_view.xml
@@ -20,23 +20,39 @@
                         <h1 class="d-flex flex-grow justify-content-between">
                             <field name="name" />
                         </h1>
+                        <h3>
+                            <field
+                                name="reference"
+                                placeholder="Can contain English letters, digits and '_'. Leave blank to autogenerate"
+                                groups="cetmix_tower_server.group_manager"
+                            />
+                        </h3>
                     </div>
                     <group>
                         <field name="server_id" invisible="1" />
                         <field name="server_template_id" invisible="1" />
-                        <field name="access_level" />
-                        <field name="log_type" />
+                        <field
+                            name="access_level"
+                            groups="cetmix_tower_server.group_manager"
+                        />
+                        <field
+                            name="log_type"
+                            groups="cetmix_tower_server.group_manager"
+                        />
                         <field
                             name="command_id"
                             attrs="{'required':[('log_type', '=', 'command')], 'invisible':[('log_type', '!=', 'command')]}"
+                            groups="cetmix_tower_server.group_manager"
                         />
                         <field
                             name="use_sudo"
                             attrs="{'invisible':[('log_type', '!=', 'command')]}"
+                            groups="cetmix_tower_server.group_manager"
                         />
                         <field
                             name="file_id"
                             attrs="{'required':[('log_type', '=', 'file')], 'invisible':[('log_type', '!=', 'file')]}"
+                            groups="cetmix_tower_server.group_manager"
                         />
                     </group>
                     <field name="log_text" />


### PR DESCRIPTION
Implement references for Server Logs.
Show "logs is empty" message if log is empty.

Task: 4076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced log management capabilities with new methods for copying logs and preserving names.
	- Added a new header and field for reference in the log view, improving user experience.

- **Bug Fixes**
	- Improved error handling for log retrieval, providing clearer messages when logs are unavailable.

- **Access Control**
	- Updated visibility and access restrictions for several fields based on user group membership, ensuring better security and user-specific access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->