### PR TITLE
[14.0][FIX] cetmix_tower_server: Link secrets to records

### DIFF
--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -4,6 +4,7 @@ from . import cx_tower_variable_mixin
 from . import cx_tower_template_mixin
 from . import cx_tower_access_mixin
 from . import cx_tower_reference_mixin
+from . import cx_tower_key_mixin
 from . import cx_tower_variable
 from . import cx_tower_variable_value
 from . import cx_tower_file

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -43,6 +43,7 @@ class CxTowerCommand(models.Model):
         "cx.tower.template.mixin",
         "cx.tower.reference.mixin",
         "cx.tower.access.mixin",
+        "cx.tower.key.mixin",
     ]
     _description = "Cetmix Tower Command"
     _order = "name"

--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -30,7 +30,12 @@ INTERVAL_TYPES = {
 
 class CxTowerFile(models.Model):
     _name = "cx.tower.file"
-    _inherit = ["cx.tower.template.mixin", "mail.thread", "mail.activity.mixin"]
+    _inherit = [
+        "cx.tower.template.mixin",
+        "mail.thread",
+        "mail.activity.mixin",
+        "cx.tower.key.mixin",
+    ]
     _description = "Cx Tower File"
     _order = "name"
 

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -347,20 +347,33 @@ class CxTowerKey(models.Model):
             str: key value or None if not able to parse
         """
 
+        key_parts = self._extract_key_parts(key_string)
+        if key_parts is None:
+            return None
+
+        key_type, reference = key_parts
+        key_value = self._resolve_key(key_type, reference, **kwargs)
+
+        return key_value
+
+    def _extract_key_parts(self, key_string):
+        """Extract and validate key parts from the key string.
+
+        Args:
+            key_string (str): key string
+
+        Returns:
+            tuple: (key_type, reference) if valid, else None
+        """
         key_parts = (
             key_string.replace(" ", "").replace(self.KEY_TERMINATOR, "").split(".")
         )
 
         # Must be 3 parts including pre!
-        if len(key_parts) != 3 or key_parts[0] != self.KEY_PREFIX:
-            return
+        if len(key_parts) == 3 and key_parts[0] == self.KEY_PREFIX:
+            return key_parts[1], key_parts[2]
 
-        key_type = key_parts[1]
-        reference = key_parts[2]
-
-        key_value = self._resolve_key(key_type, reference, **kwargs)
-
-        return key_value
+        return None
 
     def _resolve_key(self, key_type, reference, **kwargs):
         """Resolve key

--- a/cetmix_tower_server/models/cx_tower_key_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_key_mixin.py
@@ -1,0 +1,61 @@
+from odoo import api, fields, models
+
+
+class CxTowerKeyMixin(models.AbstractModel):
+    _name = "cx.tower.key.mixin"
+    _description = "Mixin for managing secrets"
+
+    secret_ids = fields.Many2many(
+        comodel_name="cx.tower.key",
+        compute="_compute_secret_ids",
+        compute_sudo=True,
+        readonly=True,
+        store=True,
+        string="Secrets",
+    )
+
+    @api.depends("code")
+    def _compute_secret_ids(self):
+        """
+        Compute the secret IDs based on the references found in the code field.
+
+        This method updates the secret_ids Many2many field by extracting secret
+        references from the code field. If no code is present, the field is cleared.
+        It ensures updates are only triggered when there are differences between
+        the current and new secret IDs.
+        """
+        for record in self:
+            if record.code:
+                new_secrets = self._extract_secret_ids(record.code)
+
+                # This will create a recordset that contains the difference
+                if record.secret_ids != new_secrets:
+                    record.secret_ids = new_secrets
+            else:
+                record.secret_ids = [(5, 0, 0)]
+
+    @api.model
+    def _extract_secret_ids(self, code):
+        """
+        Extract secret IDs based on references found in the given `code`.
+
+        Args:
+            code: Text containing potential secret references.
+
+        Returns:
+            list: List of secret IDs corresponding to the references in `code`.
+        """
+        key_model = self.env["cx.tower.key"]
+        key_strings = key_model._extract_key_strings(code)
+
+        key_refs = []
+        for key_string in key_strings:
+            key_parts = key_model._extract_key_parts(key_string)
+            if key_parts:
+                key_refs.append(key_parts[1])
+
+        return key_model.search(
+            [
+                ("reference", "in", key_refs),
+            ]
+        )

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -74,6 +74,11 @@
                                 options="{'color_field': 'color'}"
                             />
                             <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                            />
+                            <field
                                 name="tag_ids"
                                 widget="many2many_tags"
                                 options="{'color_field': 'color'}"
@@ -172,6 +177,12 @@
                     name="os_ids"
                     widget="many2many_tags"
                     options="{'color_field': 'color'}"
+                    optional="hide"
+                />
+                <field
+                    name="secret_ids"
+                    widget="many2many_tags"
+                    groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
                     optional="hide"
                 />
                 <field name="allow_parallel_run" optional="hide" />

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -68,6 +68,11 @@
                                 name="keep_when_deleted"
                                 attrs="{'invisible': [('source', '!=', 'tower')]}"
                             />
+                            <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                            />
                             </group>
                             <group>
                                 <field name="auto_sync" />
@@ -158,7 +163,12 @@
                 <field name="full_server_path" optional="hide" />
                 <field name="sync_date_last" />
                 <field name="template_id" optional="show" />
-
+                <field
+                    name="secret_ids"
+                    widget="many2many_tags"
+                    groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                    optional="hide"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
This commit adds m2m field(secret) to Files and Commands.

Changes

Add field to Files and Commands models
Add field to Files and Commands views

Task: 4042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `secret_ids` field in both `CxTowerCommand` and `CxTowerFile` models, allowing for the association of multiple secrets with commands and files.
	- Enhanced views to include the `secret_ids` field in form and tree displays, with visibility controlled by user permissions.
	- Added a new abstract model `CxTowerKeyMixin` for managing secret relationships and access control.

- **Bug Fixes**
	- Improved error handling and validation for key extraction and resolution processes.

- **Tests**
	- Added new tests to verify the functionality of secret management within commands and files, ensuring proper linking and removal of secret references.

- **Documentation**
	- Updated comments and docstrings for clarity in new methods and classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->