### PR TITLE
[14.0] cetmix_tower_server: add files access rules

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -30,6 +30,7 @@
         "security/cx_tower_server_log_security.xml",
         "security/cx_tower_command_log_security.xml",
         "security/cx_tower_server_template_security.xml",
+        "security/cx_tower_file_security.xml",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",
         "wizards/cx_tower_command_execute_wizard_view.xml",

--- a/cetmix_tower_server/security/cx_tower_file_security.xml
+++ b/cetmix_tower_server/security/cx_tower_file_security.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="cx_tower_file_rule_group_user_and_manager_access" model="ir.rule">
+        <field name="name">Tower file: user and manager access rule</field>
+        <field name="model_id" ref="model_cx_tower_file" />
+        <field name="domain_force">[
+            ('server_id.message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field
+            name="groups"
+            eval="[(4, ref('cetmix_tower_server.group_user')), (4, ref('cetmix_tower_server.group_manager'))]"
+        />
+    </record>
+
+
+    <record id="cx_tower_file_rule_group_root_access" model="ir.rule">
+        <field name="name">Tower file: root access rule</field>
+        <field name="model_id" ref="model_cx_tower_file" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('cetmix_tower_server.group_root'))]" />
+    </record>
+
+</odoo>

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -13,6 +13,7 @@
                         type="object"
                         class="oe_highlight"
                         attrs="{'invisible': [('source', '!=', 'tower')]}"
+                        groups="cetmix_tower_server.group_manager"
                     />
                     <button
                         name="action_pull_from_server"
@@ -20,6 +21,7 @@
                         type="object"
                         class="oe_highlight"
                         attrs="{'invisible': [('source', '!=', 'server')]}"
+                        groups="cetmix_tower_server.group_manager"
                     />
                 </header>
                 <sheet>


### PR DESCRIPTION
Before this PR
------------------

- Members of groups User and Manager have access to all files in the system.
    
After this PR
 ----------------- 

- Members of groups User and Manager have access only to files related to servers on
     which they are subscribers.
-  Since members of group_user do not have access to modify the file, hide the push/pull button


task: 3695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new security configuration for file management within the Cetmix Tower Server Management module.
	- Added access control rules to manage user permissions for file access based on their roles, including specific rules for users, managers, and root access.
	- Updated visibility of "Push to Server" and "Pull from Server" buttons to restrict access to authorized users.

- **Tests**
	- Implemented tests to validate access rules for files, ensuring users can only access files they are authorized to based on their group memberships.

- **Chores**
	- Updated the manifest file to include the new security configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->