### PR TITLE
[14.0][IMP] cetmix_tower_server: Update record deletion flow

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -12,7 +12,7 @@ class CxTowerCommandLog(models.Model):
     name = fields.Char(compute="_compute_name", compute_sudo=True, store=True)
     label = fields.Char(help="Custom label. Can be used for search/tracking")
     server_id = fields.Many2one(
-        comodel_name="cx.tower.server", required=True, index=True, ondelete="restrict"
+        comodel_name="cx.tower.server", required=True, index=True, ondelete="cascade"
     )
 
     # -- Time

--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -103,7 +103,9 @@ class CxTowerFile(models.Model):
         "Default value if no error happened is 'ok'.\n"
         "Otherwise there will be a server error message logged."
     )
-    server_id = fields.Many2one(comodel_name="cx.tower.server", required=True)
+    server_id = fields.Many2one(
+        comodel_name="cx.tower.server", required=True, ondelete="cascade"
+    )
     code_on_server = fields.Text(
         readonly=True,
         help="Latest version of file content on server",

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -40,6 +40,7 @@ class CxTowerKey(models.Model):
     server_id = fields.Many2one(
         comodel_name="cx.tower.server",
         help="Used for selected server only. Leave blank to use globally",
+        ondelete="cascade",
     )
     partner_id = fields.Many2one(
         comodel_name="res.partner", help="Leave blank to use for any partner"

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -20,7 +20,10 @@ class CxTowerPlanLine(models.Model):
     sequence = fields.Integer(default=10)
     name = fields.Char(related="command_id.name", readonly=True)
     plan_id = fields.Many2one(
-        string="Flight Plan", comodel_name="cx.tower.plan", auto_join=True
+        string="Flight Plan",
+        comodel_name="cx.tower.plan",
+        auto_join=True,
+        ondelete="cascade",
     )
     command_id = fields.Many2one(comodel_name="cx.tower.command", required=True)
     path = fields.Char(

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -12,7 +12,9 @@ class CxTowerPlanLineAction(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(compute="_compute_name")
     sequence = fields.Integer(default=10)
-    line_id = fields.Many2one(comodel_name="cx.tower.plan.line", auto_join=True)
+    line_id = fields.Many2one(
+        comodel_name="cx.tower.plan.line", auto_join=True, ondelete="cascade"
+    )
     condition = fields.Selection(
         selection=[
             ("==", "=="),

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -14,14 +14,14 @@ class CxTowerPlanLog(models.Model):
     name = fields.Char(compute="_compute_name", compute_sudo=True, store=True)
     label = fields.Char(help="Custom label. Can be used for search/tracking")
     server_id = fields.Many2one(
-        comodel_name="cx.tower.server", required=True, index=True, ondelete="restrict"
+        comodel_name="cx.tower.server", required=True, index=True, ondelete="cascade"
     )
     plan_id = fields.Many2one(
         string="Flight Plan",
         comodel_name="cx.tower.plan",
         required=True,
         index=True,
-        ondelete="restrict",
+        ondelete="cascade",
     )
 
     # -- Time

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -17,7 +17,10 @@ class TowerVariableValue(models.Model):
     _order = "variable_reference"
 
     variable_id = fields.Many2one(
-        string="Variable", comodel_name="cx.tower.variable", required=True
+        string="Variable",
+        comodel_name="cx.tower.variable",
+        required=True,
+        ondelete="cascade",
     )
     name = fields.Char(related="variable_id.name", readonly=True)
     variable_reference = fields.Char(

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -1261,3 +1261,23 @@ class TestTowerPlan(TestTowerCommon):
             plan_log_records.command_log_ids.command_status,
             "Command status should be skipped",
         )
+
+    def test_plan_unlink(self):
+        plan = self.plan_1.copy()
+        plan_id = plan.id
+        plan_line_ids = plan.line_ids
+        plan_line_action_ids = plan.mapped("line_ids.action_ids")
+
+        plan.unlink()
+
+        self.assertFalse(
+            self.Plan.search([("id", "=", plan_id)]), msg="Plan should be deleted"
+        )
+        self.assertFalse(
+            self.plan_line.search([("id", "in", plan_line_ids.ids)]),
+            msg="Plan line should be deleted when Plan is deleted",
+        )
+        self.assertFalse(
+            self.plan_line_action.search([("id", "in", plan_line_action_ids.ids)]),
+            msg="Plan line action should be deleted when Plan line is deleted",
+        )


### PR DESCRIPTION
Ensuring complete deletion of data in the Tower and maintaining data integrity by cascading deletion of relevant data, if necessary.

- Delete flight plan -> Delete related lines
- Delete flight plan line -> Delete related line actions
- Delete related line actions -> Delete relate variable values
- Delete flight plan log -> Delete related command logs
- Delete server -> Delete related files, secret_ids  and variable values

Task: 4048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Implemented cascading deletions for various models, ensuring that related records are automatically removed when a parent record is deleted, enhancing data integrity.

- **Bug Fixes**
  - Improved referential integrity across multiple models by updating deletion behaviors.

- **Tests**
  - Added new tests to verify the correct deletion of associated records when a flight plan or server is deleted, ensuring the integrity of the deletion process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->