### PR TITLE
[14.0][FIX] cetmix_tower_server: Key creation

### DIFF
--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -81,10 +81,25 @@ class CxTowerKey(models.Model):
             Records: The created record(s).
         """
         for vals in vals_list:
-            vals["name"] = vals["name"].strip()
+            # Remove leading and trailing whitespaces from name
+            vals_name = vals.get("name")
+            name = vals_name.strip() if vals_name else vals_name
+
+            # Remove leading and trailing whitespaces from reference
+            vals_reference = vals.get("reference")
+            reference = vals_reference.strip() if vals_reference else vals_reference
+
+            # Nothing can be done if no name or reference is provided
+            if not name and not reference:
+                continue
+
+            # Update the 'name' with the cleaned one
+            if name != vals_name:
+                vals.update({"name": name})
+
             # Generate reference
             reference = self._generate_or_fix_reference(
-                vals.get("reference") or vals.get("name"),
+                reference or name,
                 vals.get("partner_id"),
                 vals.get("server_id"),
             )

--- a/cetmix_tower_server/tests/test_key.py
+++ b/cetmix_tower_server/tests/test_key.py
@@ -1,3 +1,5 @@
+from psycopg2.errors import NotNullViolation
+
 from odoo.exceptions import AccessError
 
 from .common import TestTowerCommon
@@ -6,6 +8,37 @@ from .common import TestTowerCommon
 class TestTowerKey(TestTowerCommon):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
+
+    def test_key_creation(self):
+        """
+        Test key creation.
+        We override create method so need to check if reference is generated properly
+        """
+
+        # -- 1--
+        #  Check new key values
+        key = self.Key.create(
+            {"name": " test key meme   ", "secret_value": "test value", "key_type": "s"}
+        )
+        self.assertEqual(
+            key.reference, "test_key_meme", "Reference must be 'test_key_meme'"
+        )
+        self.assertEqual(
+            key.name,
+            "test key meme",
+            "Trailing and leading whitespaces must be removed from name",
+        )
+
+        # -- 2 --
+        # Test if key without a name cannot be created
+        with self.assertRaises(NotNullViolation):
+            self.Key.create(
+                {
+                    "reference": "test_key_meme",
+                    "secret_value": "test value",
+                    "key_type": "s",
+                }
+            )
 
     def test_key_access_rights(self):
         """Test private key security features"""


### PR DESCRIPTION
Before this commit
------------------

Creation of a key without a name raised a validation error. This was due to incorrect handling of empty 'name' field values.

After this commit
-----------------

Creation of a key without a name raises a NotNullViolation. This is a normal Odoo behavior for required fields.

Task: 4074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of `name` and `reference` fields during key creation, ensuring leading and trailing whitespaces are removed.
	- Improved reference generation logic to prevent conflicts and ensure adherence to specified patterns.

- **Bug Fixes**
	- Implemented safeguards to ensure that keys are not created without necessary fields, raising appropriate exceptions.

- **Tests**
	- Added a new test method to verify key creation functionality and enforce the requirement that the name field cannot be null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->