### PR TITLE
[IMP] cetmix_tower_server: Enhance UI/UX and add functionalities

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -23,6 +23,7 @@ class CxTowerPlanLine(models.Model):
         string="Flight Plan", comodel_name="cx.tower.plan", auto_join=True
     )
     command_id = fields.Many2one(comodel_name="cx.tower.command", required=True)
+    note = fields.Text(related="command_id.note", readonly=True)
     path = fields.Char(
         help="Location where command will be executed. Overrides command default path. "
         "You can use {{ variables }} in path",

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -18,6 +18,11 @@
                                 name="command_id"
                                 context="{'command_show_server_names': True}"
                             />
+                            <field
+                                name="note"
+                                readonly="1"
+                                attrs="{'invisible': [('note', '=', False)]}"
+                            />
                             <field name="use_sudo" />
                             <field
                                 name="path"

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -158,14 +158,22 @@
                     <button
                         name="action_execute_command"
                         type="object"
+                        class="btn-primary"
                         string="Run command"
                         icon="fa-code"
                     />
                     <button
                         name="action_execute_plan"
                         type="object"
+                        class="btn-primary"
                         string="Run Flight Plan"
                         icon="fa-plane"
+                    />
+                    <button
+                        name="test_ssh_connection"
+                        type="object"
+                        string="Test Connection"
+                        groups="cetmix_tower_server.group_manager"
                     />
                 </header>
                 <sheet>
@@ -232,14 +240,6 @@
                                     />
                                     <field name="ip_v4_address" />
                                     <field name="ip_v6_address" />
-                                    <br />
-                                    <button
-                                        name="test_ssh_connection"
-                                        type="object"
-                                        string="Test Connection"
-                                        class="btn-primary"
-                                        groups="cetmix_tower_server.group_manager"
-                                    />
                                 </group>
                                 <group name="ssh">
                                     <field name="ssh_auth_mode" />

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -40,7 +40,11 @@
                             attrs="{'invisible': [('action', '=', 'python_code')]}"
                             placeholder="No sudo"
                         />
-                        <field name="command_id" domain="command_domain" />
+                        <field
+                            name="command_id"
+                            domain="command_domain"
+                            default_focus="1"
+                        />
                         <field name="command_domain" invisible="1" />
                         <span>show shared</span>
                         <field name="any_server" />

--- a/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_plan_execute_wizard_view.xml
@@ -16,7 +16,7 @@
                     <field name="tag_ids" widget="many2many_tags" />
                     <label for="plan_id" />
                     <div class="o_row">
-                        <field name="plan_id" domain="plan_domain" />
+                        <field name="plan_id" domain="plan_domain" default_focus="1" />
                         <field name="plan_domain" invisible="1" />
                         <span>show shared</span>
                         <field name="any_server" />


### PR DESCRIPTION
Update Button Styles:
Made all buttons "primary" to highlight them consistently, similar to the existing "Test Connection" button.
Relocate "Test Connection" Button:
Moved the "Test Connection" button to the header, positioned as the last button, and updated it to NOT be primary.

Set Default Focus:
Added autofocus to the "Command" field 

Set Default Focus:
Added autofocus to the "Plan" field 

Add Read-Only "Note" Field:
Introduced a new read-only "Note" field to display the selected command’s note in the flight plan line.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a read-only "note" field to the `CxTowerPlanLine` model for enhanced data visibility.
	- Introduced a "Test Connection" button for SSH in the server form view, improving accessibility.

- **Improvements**
	- Enhanced form views to conditionally display the "note" field only when content is present.
	- Updated the server status field with visual indicators for better user experience.
	- Added default focus to command and plan ID fields in wizards to streamline user interaction.

These updates aim to enhance the user interface and improve overall usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->