### PR TITLE
[FIX] cetmix_tower_server: Fix duplication error

### DIFF
--- a/cetmix_tower_server/models/cx_tower_reference_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_reference_mixin.py
@@ -223,17 +223,20 @@ class CxTowerReferenceMixin(models.AbstractModel):
             vals.update({"reference": reference})
         return super().write(vals)
 
-    def _get_copied_name(self):
+    def _get_copied_name(self, force_name=None):
         """
         Return a copied name of the record
         by adding the suffix (copy) at the end
         and counter until the name is unique.
 
+        Args:
+            force_name (str): Used to use force name instead of record name.
+
         Returns:
             An unique name for the copied record
         """
         self.ensure_one()
-        original_name = self.name
+        original_name = force_name or self.name
         copy_name = _("%(name)s (copy)", name=original_name)
 
         counter = 1
@@ -267,7 +270,7 @@ class CxTowerReferenceMixin(models.AbstractModel):
         # skip copy name because this function use in models
         # where it field name non store
         if not self.env.context.get("reference_mixin_skip_copy"):
-            default["name"] = self._get_copied_name()
+            default["name"] = self._get_copied_name(force_name=default.get("name"))
         if "reference" not in default:
             default["reference"] = self._generate_or_fix_reference(default["name"])
         return super().copy(default=default)

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -70,9 +70,9 @@ class CxTowerServerLog(models.Model):
             CxTowerServerLog, self.with_context(reference_mixin_skip_self=True)
         ).copy(default)
 
-    def _get_copied_name(self):
+    def _get_copied_name(self, force_name=None):
         # Original name is preserved when log is duplicated
-        return self.name
+        return force_name or self.name
 
     def _format_log_text(self, log_text):
         """Formats log text to prior to display it.

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -84,6 +84,15 @@ class TestTowerServer(TestTowerCommon):
                 "file_id": file_for_log.id,
             }
         )
+        # Add variable values to server
+        self.env["cx.tower.variable.value"].create(
+            {
+                "server_id": self.server_test_2.id,
+                "variable_id": self.variable_dir.id,
+                "value_char": "test",
+            }
+        )
+
         # Copy server 2
         server_test_2_copy = self.server_test_2.copy()
 
@@ -178,6 +187,28 @@ class TestTowerServer(TestTowerCommon):
                     for var_src, var_copy in zip(
                         self.server_test_2.variable_value_ids,
                         server_test_2_copy.variable_value_ids,
+                    )
+                ]
+            ),
+            msg=(
+                "Variable names and values in server copy "
+                "should be the same as in source server!"
+            ),
+        )
+
+        # Copy copied server
+        server_test_2_new_copy = server_test_2_copy.copy()
+        # Variable names and values in server copy should be the same
+        # as in source server
+        self.assertTrue(
+            all(
+                [
+                    var_copy.variable_reference == var_src.variable_reference
+                    and var_copy.value_char == var_src.value_char
+                    and var_copy.reference == f"{var_src.reference}_copy"
+                    for var_src, var_copy in zip(
+                        server_test_2_copy.variable_value_ids,
+                        server_test_2_new_copy.variable_value_ids,
                     )
                 ]
             ),


### PR DESCRIPTION
Before this commit:
===================
Duplicating a server multiple times caused a uniqueness error for the 'reference' field in 'cx.tower.variable.value' due to duplicate 'name' values.

After this commit:
==================
The existing 'reference' is used as 'name' during duplication, ensuring unique references.

Task: 4115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced server duplication process to ensure uniqueness of variable references during copying.
	- Added methods for file operations: delete, upload, and download, improving file management capabilities.
	- Improved flexibility in naming copied records through enhanced reference management.

- **Bug Fixes**
	- Improved error handling and connection management for file operations.

- **Tests**
	- Introduced new test cases to validate the server copying functionality and ensure consistency of variable references, including checks for appended suffixes in copied references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->