### PR TITLE
[REF] cetmix_tower_server: Refactor variable handling with mixin

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -117,33 +117,34 @@ class CxTowerCommand(models.Model):
     flight_plan_id = fields.Many2one(
         comodel_name="cx.tower.plan",
     )
-    variable_ids = fields.Many2many(
-        comodel_name="cx.tower.variable",
-        relation="cx_tower_command_variable_rel",
-        column1="command_id",
-        column2="variable_id",
-        string="Variables",
-        compute="_compute_variable_ids",
-        store=True,
-    )
-
-    @api.depends("code", "path")
-    def _compute_variable_ids(self):
-        """
-        Compute variable_ids based on code and path fields.
-        """
-        for record in self:
-            record.variable_ids = record._prepare_variable_commands(["code", "path"])
-
-    # TODO: move this up
     server_status = fields.Selection(
         selection=lambda self: self.env["cx.tower.server"]._selection_status(),
         string="Server Status",
-        help=(
-            "Set the following status if command is executed successfully."
-            " Leave 'Undefined' if you don't need to update the status"
-        ),
+        help="Set the following status if command is executed successfully. "
+        "Leave 'Undefined' if you don't need to update the status",
     )
+    variable_ids = fields.Many2many(
+        comodel_name="cx.tower.variable",
+        relation="cx_tower_command_variable_rel",
+    )
+
+    @classmethod
+    def _get_depends_fields(cls):
+        """
+        Define dependent fields for computing `variable_ids` in command-related models.
+
+        This implementation specifies that the fields `code` and `path`
+        are used to determine the variables associated with a command.
+
+        Returns:
+            list: A list of field names (str) representing the dependencies.
+
+        Example:
+            The following fields trigger recomputation of `variable_ids`:
+            - `code`: The command's script or execution logic.
+            - `path`: The default execution path for the command.
+        """
+        return ["code", "path"]
 
     # Depend on related servers and partners
     @api.depends(

--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -133,22 +133,26 @@ class CxTowerFile(models.Model):
     variable_ids = fields.Many2many(
         comodel_name="cx.tower.variable",
         relation="cx_tower_file_variable_rel",
-        column1="file_id",
-        column2="variable_id",
-        string="Variables",
-        compute="_compute_variable_ids",
-        store=True,
     )
 
-    @api.depends("code", "server_dir", "name")
-    def _compute_variable_ids(self):
+    @classmethod
+    def _get_depends_fields(cls):
         """
-        Compute variable_ids based on code, server_dir, and name fields.
+        Define dependent fields for computing `variable_ids` in file-related models.
+
+        This implementation specifies that the fields `code`, `server_dir`,
+        and `name` are used to compute the variables associated with a file.
+
+        Returns:
+            list: A list of field names (str) representing the dependencies.
+
+        Example:
+            The following fields trigger recomputation of `variable_ids`:
+            - `code`: The content of the file.
+            - `server_dir`: The directory on the server where the file is located.
+            - `name`: The name of the file.
         """
-        for record in self:
-            record.variable_ids = record._prepare_variable_commands(
-                ["code", "server_dir", "name"]
-            )
+        return ["code", "server_dir", "name"]
 
     def _selection_file_type(self):
         """Available file types

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -85,6 +85,14 @@
                             />
                             <field name="access_level" />
                             <field name="server_status" widget="server_status" />
+                            <field
+                                name="variable_ids"
+                                widget="many2many_tags"
+                                readonly="1"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('variable_ids', '=', False)]}"
+                                optional="hide"
+                            />
                         </group>
                     </group>
                     <notebook>

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -55,6 +55,14 @@
                             />
                             <field name="file_type" />
                             <field name="note" />
+                            <field
+                                name="variable_ids"
+                                widget="many2many_tags"
+                                readonly="1"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('variable_ids', '=', False)]}"
+                                optional="hide"
+                            />
                         </group>
                     </group>
                     <notebook>

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -85,6 +85,14 @@
                                 attrs="{'invisible': ['|', ('auto_sync', '=', False), ('source', '!=', 'server')]}"
                             />
                                 <field name="sync_date_last" />
+                                <field
+                                name="variable_ids"
+                                widget="many2many_tags"
+                                readonly="1"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('variable_ids', '=', False)]}"
+                                optional="hide"
+                            />
                             </group>
                         </group>
                     <notebook>


### PR DESCRIPTION
This commit refactors the handling of variables in the `cetmix_tower_server` module by moving `variable_ids` and related logic to a reusable mixin. This enhances code maintainability and provides consistent behavior across multiple models.

Key Changes:
- Added `TowerVariableMixin` to centralize variable handling logic.
- Moved `variable_ids` field and related logic to the mixin.
- Implemented `has_available_variables` in the mixin to control visibility of the "Variables" field in UI.
- Updated `cx.tower.command`, `cx.tower.file`, and `cx.tower.file.template` models to inherit from `TowerVariableMixin`.
- Removed redundant logic from individual models to reduce duplication.
- Ensured the "Variables" field in the form view is displayed only when related variables are available and visible to users with "Manager" or "Root" roles.

Why this change?
This refactor simplifies the codebase, reduces redundancy, and ensures consistent handling of variables across models. It also aligns with the project's goal of better modularity and scalability.

Backward Compatibility:
- Existing Many2many relationships (`variable_ids`) remain intact. No data migration is required as table relations, column names, and logic for linking variables are preserved.

Task: 4167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field, `server_status`, in the command model to track server status post-command execution.
	- Added `variable_ids` field as a read-only many-to-many tag widget in multiple views, enhancing interactivity and user experience.

- **Bug Fixes**
	- Removed outdated computation methods for `variable_ids`, streamlining its management across different models.

- **Documentation**
	- Updated view definitions to reflect the addition of new fields and their configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->