### PR TITLE
[FIX] cetmix_tower_server: Remove demo data usage in tests

### DIFF
--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -15,6 +15,11 @@ class TestTowerCommon(TransactionCase):
         # Cetmix Tower helper model
         self.CetmixTower = self.env["cetmix.tower"]
 
+        # Tags
+        self.Tag = self.env["cx.tower.tag"]
+        self.tag_test_staging = self.Tag.create({"name": "Test Staging"})
+        self.tag_test_production = self.Tag.create({"name": "Test Production"})
+
         # Users
         self.Users = self.env["res.users"].with_context(no_reset_password=True)
         self.user_bob = self.Users.create(
@@ -150,9 +155,7 @@ class TestTowerCommon(TransactionCase):
             {
                 "name": "Test plan 1",
                 "note": "Create directory and list its content",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_staging").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_staging.id])],
             }
         )
         self.plan_line_1 = self.plan_line.create(

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -274,9 +274,7 @@ class TestTowerPlan(TestTowerCommon):
             {
                 "name": "Test plan 2",
                 "note": "Create directory and list its content",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_staging").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_staging.id])],
             }
         )
         # Ensure that defaulf command access_level is equal to 2
@@ -315,9 +313,7 @@ class TestTowerPlan(TestTowerCommon):
             {
                 "name": "Test plan 3",
                 "note": "Create directory and list its content",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_staging").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_staging.id])],
             }
         )
         self.assertTrue(
@@ -431,23 +427,17 @@ class TestTowerPlan(TestTowerCommon):
             {
                 "name": "Test Plan 1",
                 "note": "Plan 1 Note",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_staging").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_staging.id])],
             },
             {
                 "name": "Test Plan 2",
                 "note": "Plan 2 Note",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_production").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_production.id])],
             },
             {
                 "name": "Test Plan 3",
                 "note": "Plan 3 Note",
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_staging").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_staging.id])],
             },
         ]
         created_plans = self.Plan.create(plans_data)

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -7,6 +7,7 @@ class TestTowerServer(TestTowerCommon):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
         self.os_ubuntu_20_04 = self.env["cx.tower.os"].create({"name": "Ubuntu 20.04"})
+
         self.server_test_2 = self.Server.create(
             {
                 "name": "Test Server #2",
@@ -38,9 +39,7 @@ class TestTowerServer(TestTowerCommon):
                         },
                     ),
                 ],
-                "tag_ids": [
-                    (6, 0, [self.env.ref("cetmix_tower_server.tag_production").id])
-                ],
+                "tag_ids": [(6, 0, [self.tag_test_production.id])],
             }
         )
         # Files


### PR DESCRIPTION
Replaced all occurrences of demo data usage (`self.env.ref`) in tests with locally created records. Updated `common.py` to define reusable test data (e.g., `tag_staging`) in the `setUp` method. Refactored individual tests to use the pre-created data, improving test stability and removing dependency on demo data.

Key changes:
- Created `tag_staging` in `common.py` and reused it in relevant tests.
- Removed references to `demo` data, such as `cetmix_tower_server.tag_staging`.
- Enhanced test readability and maintainability.

This ensures the tests are independent of `demo` data and aligned with best practices.

Task: 4212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new tag entities for staging and production across various test classes to enhance tagging flexibility.
	- Updated test plans and server instances to utilize the new tag variables, ensuring consistent tag usage.

- **Bug Fixes**
	- Corrected references to ensure plans and servers are associated with the appropriate tags, improving test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->