### PR TITLE
[FIX] cetmix_tower_server: revert relation fields

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -126,6 +126,8 @@ class CxTowerCommand(models.Model):
     variable_ids = fields.Many2many(
         comodel_name="cx.tower.variable",
         relation="cx_tower_command_variable_rel",
+        column1="command_id",
+        column2="variable_id",
     )
 
     @classmethod

--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -133,6 +133,8 @@ class CxTowerFile(models.Model):
     variable_ids = fields.Many2many(
         comodel_name="cx.tower.variable",
         relation="cx_tower_file_variable_rel",
+        column1="file_id",
+        column2="variable_id",
     )
 
     @classmethod

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -60,6 +60,8 @@ class CxTowerFileTemplate(models.Model):
     variable_ids = fields.Many2many(
         comodel_name="cx.tower.variable",
         relation="cx_tower_file_template_variable_rel",
+        column1="file_template_id",
+        column2="variable_id",
     )
 
     @classmethod

--- a/cetmix_tower_server/models/cx_tower_template_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_template_mixin.py
@@ -23,38 +23,6 @@ class CxTowerTemplateMixin(models.AbstractModel):
         store=True,
     )
 
-    def _get_relation_params(self):
-        """
-        Retrieve metadata for the Many2many field `variable_ids`.
-
-        This method dynamically extracts and returns the `relation`,
-        `column1`, and `column2` parameters from the field definition
-        in the model. These parameters are used for defining and managing
-        Many2many relationships in Odoo.
-
-        Returns:
-            dict: A dictionary containing the following keys:
-                - `relation` (str): Name of the Many2many relationship table.
-                - `column1` (str): Name of the column representing the source model.
-                - `column2` (str): Name of the column representing the target model.
-                If the metadata is unavailable, all values will be `None`.
-
-        Example:
-            >>> params = self._get_relation_params()
-            >>> print(params)
-            {'relation': 'cx_tower_command_variable_rel',
-             'column1': 'command_id',
-             'column2': 'variable_id'}
-        """
-        field = self._fields.get("variable_ids")
-        if field and hasattr(field, "relation"):
-            return {
-                "relation": field.relation,
-                "column1": field.column1,
-                "column2": field.column2,
-            }
-        return {"relation": None, "column1": None, "column2": None}
-
     @classmethod
     def _get_depends_fields(cls):
         """
@@ -85,8 +53,7 @@ class CxTowerTemplateMixin(models.AbstractModel):
 
         This method retrieves the dependent fields using `_get_depends_fields`
         and dynamically calculates the values of `variable_ids` using the
-        `_prepare_variable_commands` method. The Many2many relation is managed
-        based on parameters returned by `_get_relation_params`.
+        `_prepare_variable_commands` method.
 
         If no dependent fields or relation parameters are defined, the field
         is reset to an empty list.

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -74,11 +74,6 @@
                                 options="{'color_field': 'color'}"
                             />
                             <field
-                                name="secret_ids"
-                                widget="many2many_tags"
-                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                            />
-                            <field
                                 name="tag_ids"
                                 widget="many2many_tags"
                                 options="{'color_field': 'color'}"
@@ -90,8 +85,13 @@
                                 widget="many2many_tags"
                                 readonly="1"
                                 groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                                attrs="{'invisible': [('variable_ids', '=', False)]}"
-                                optional="hide"
+                                attrs="{'invisible': [('variable_ids', '=', [])]}"
+                            />
+                            <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('secret_ids', '=', [])]}"
                             />
                         </group>
                     </group>

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -47,12 +47,6 @@
                                 name="keep_when_deleted"
                                 attrs="{'invisible': [('source', '=', 'server')]}"
                             />
-                            <field
-                                name="secret_ids"
-                                widget="many2many_tags"
-                                attrs="{'invisible': [('secret_ids', '=', False)]}"
-                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                            />
                             <field name="file_type" />
                             <field name="note" />
                             <field
@@ -60,8 +54,13 @@
                                 widget="many2many_tags"
                                 readonly="1"
                                 groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                                attrs="{'invisible': [('variable_ids', '=', False)]}"
-                                optional="hide"
+                                attrs="{'invisible': [('variable_ids', '=', [])]}"
+                            />
+                            <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                attrs="{'invisible': [('secret_ids', '=', [])]}"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
                             />
                         </group>
                     </group>

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -68,11 +68,6 @@
                                 name="keep_when_deleted"
                                 attrs="{'invisible': [('source', '!=', 'tower')]}"
                             />
-                            <field
-                                name="secret_ids"
-                                widget="many2many_tags"
-                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                            />
                             </group>
                             <group>
                                 <field name="auto_sync" />
@@ -88,10 +83,14 @@
                                 <field
                                 name="variable_ids"
                                 widget="many2many_tags"
-                                readonly="1"
                                 groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
-                                attrs="{'invisible': [('variable_ids', '=', False)]}"
-                                optional="hide"
+                                attrs="{'invisible': [('variable_ids', '=', [])]}"
+                            />
+                                <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('secret_ids', '=', [])]}"
                             />
                             </group>
                         </group>


### PR DESCRIPTION
- Restore relation field keys removed in https://github.com/cetmix/cetmix-tower/pull/160/files
- Hide variables and secrets in views if they are empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced data management for commands, files, and file templates by adding support for multiple variables.
	- Improved field visibility logic in user interfaces.

- **Improvements**
	- Updated many-to-many relationship definitions to provide more explicit column mappings.
	- Refined visibility conditions for secret and variable fields in forms.

- **User Interface**
	- Adjusted form views to dynamically show/hide fields based on content presence.
	- Removed readonly attribute from the variable_ids field to allow user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->