### PR TITLE
[FIX] cetmix_tower_server: Secrets in Python code

### DIFF
--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -309,6 +309,11 @@ class CxTowerKey(models.Model):
                 if pythonic_mode:
                     # save key value as string in pythonic mode
                     key_value = f'"{key_value}"'
+                    # Escape newline characters to ensure the key value remains
+                    # a valid single-line string. This prevents syntax errors
+                    # when the string is used in contexts where unescaped
+                    # newlines would break Python syntax or evaluation logic.
+                    key_value = key_value.replace("\n", "\\n")
 
                 code = code.replace(key_string, key_value)
 
@@ -515,6 +520,8 @@ class CxTowerKey(models.Model):
         for key_value in key_values:
             # If key_value includes quotes, remove them for the replacement
             key_value = key_value.strip('"')
+            # If key_value contains an escaped line break replace then remove escaping
+            key_value = key_value.replace("\\n", "\n")
             # Replace key including key terminator
             code = code.replace(key_value, self.SECRET_VALUE_SPOILER)
 

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -38,11 +38,17 @@ class TestTowerCommand(TestTowerCommon):
             }
         )
 
+        # secret value as multi line string
         self.python_ssh_key = self.Key.create(
             {
                 "name": "Test Python SSH Key",
+                "reference": "test_python_ssh_key",
                 "key_type": "k",
-                "secret_value": "Python much key",
+                "secret_value": """
+                Python
+                much
+                key
+                """,
             }
         )
 


### PR DESCRIPTION
Python code execution fails when using a secret with a multi-line value.

Task: 4024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of newline characters in key value processing to ensure valid single-line strings and preserve formatting.
- **Tests**
	- Updated representation of the `secret_value` attribute in test cases for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->