### PR TITLE
[IMP] cetmix_tower_server: Access to server fields

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -43,6 +43,7 @@ class CxTowerFile(models.Model):
     name = fields.Char(help="File name WITHOUT path. Eg 'test.txt'")
     rendered_name = fields.Char(
         compute="_compute_render",
+        compute_sudo=True,
     )
     template_id = fields.Many2one(
         "cx.tower.file.template",
@@ -57,6 +58,7 @@ class CxTowerFile(models.Model):
     )
     rendered_server_dir = fields.Char(
         compute="_compute_render",
+        compute_sudo=True,
     )
     full_server_path = fields.Char(
         compute="_compute_full_server_path",
@@ -117,6 +119,7 @@ class CxTowerFile(models.Model):
     )
     rendered_code = fields.Char(
         compute="_compute_render",
+        compute_sudo=True,
         help="File content with variables rendered",
     )
     keep_when_deleted = fields.Boolean(
@@ -644,7 +647,7 @@ class CxTowerFile(models.Model):
                     )
                 else:
                     return False
-                file.server_response = "ok"
+                file.sudo().server_response = "ok"
             except Exception as error:
                 if raise_error:
                     raise ValidationError(
@@ -698,4 +701,4 @@ class CxTowerFile(models.Model):
                 )
             if file.server_response == "ok":
                 vals.update({"sync_date_last": last_sync_date})
-            file.write(vals)
+            file.sudo().write(vals)

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -40,6 +40,8 @@ Fill the values it the tabs below:
 - **SSH Private Key**: Used for authentication is SSH Auth Mode is set to "Key"
 - **Note**: Comments or user notes
 
+Note: Some fields are visible based on the current user access level.
+
 There is a special **Status** field which indicates current Server status. It is meant to be updated automatically using external API with further customizations.
 Following pre-defined statuses are available:
 

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -220,7 +220,17 @@ class TestTowerCommon(TransactionCase):
         # Patch methods for testing
         def _get_ssh_client_patch(self, raise_on_error=True, timeout=5000):
             """Mock method for connection"""
-            return MagicMock()
+            # The original method uses sudo
+            self = self.sudo()
+            return MagicMock(
+                host=self.ip_v4_address or self.ip_v6_address,
+                port=self.ssh_port,
+                username=self.ssh_username,
+                mode=self.ssh_auth_mode,
+                password=self._get_password(),
+                ssh_key=self._get_ssh_key(),
+                timeout=timeout,
+            )
 
         def _execute_command_using_ssh_patch(
             self,

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -535,6 +535,17 @@ COMMAND_RESULT = {
         # Ensure that user can access the command
         command_name = test_command_1_as_bob.name
         self.assertEqual(command_name, "Test command", msg="Must return 'Test command'")
+
+        # Check that user with "cetmix_tower_server.group_user" can execute ssh command
+        test_command.write(
+            {
+                "code": "ls -l",
+            }
+        )
+        self.server_test_1.with_user(self.user_bob).execute_command(
+            test_command,
+        )
+
         # Add user to group_manager
         self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
         # Create a new command with access_level 1

--- a/cetmix_tower_server/tests/test_file.py
+++ b/cetmix_tower_server/tests/test_file.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from odoo import exceptions
 from odoo.exceptions import AccessError
 
@@ -37,29 +35,16 @@ class TestTowerFile(TestTowerCommon):
         """
         Upload file from tower to server
         """
-        cx_tower_server_obj = self.registry["cx.tower.server"]
-
-        def upload_file(this, file, remote_path):
-            if file == "Hello, world!" and remote_path == "/var/tmp":
-                return "ok"
-
-        with patch.object(cx_tower_server_obj, "upload_file", upload_file):
-            self.file.action_push_to_server()
-            self.assertEqual(self.file.server_response, "ok")
+        self.file.action_push_to_server()
+        self.assertEqual(self.file.server_response, "ok")
 
     def test_delete_file(self):
         """
         Delete file remotely from server
         """
-        cx_tower_server_obj = self.registry["cx.tower.server"]
-
-        def delete_file(this, remote_path):
-            if remote_path == "/var/tmp":
-                return "ok"
-
-        with patch.object(cx_tower_server_obj, "delete_file", delete_file):
-            self.file.action_delete_from_server()
-            self.assertEqual(self.file.server_response, "ok")
+        result = self.file.action_delete_from_server()
+        self.assertTrue(isinstance(result, dict))
+        self.assertEqual(result["params"]["message"], "File deleted!")
 
     def test_delete_file_access(self):
         """
@@ -72,50 +57,28 @@ class TestTowerFile(TestTowerCommon):
         """
         Download file from server to tower
         """
+        self.file_2.action_pull_from_server()
+        self.assertEqual(self.file_2.code, "ok")
 
-        def download_file(this, remote_path):
-            if remote_path == "/var/tmp/test.txt":
-                return b"Hello, world!"
-            elif remote_path == "/var/tmp/binary.zip":
-                return b"Hello, world!\x00"
-
-        cx_tower_server_obj = self.registry["cx.tower.server"]
-
-        with patch.object(cx_tower_server_obj, "download_file", download_file):
-            self.file_2.action_pull_from_server()
-            self.assertEqual(self.file_2.code, "Hello, world!")
-
-            self.file_2.name = "binary.zip"
-            res = self.file_2.action_pull_from_server()
-            self.assertTrue(
-                isinstance(res, dict) and res["tag"] == "display_notification",
-                msg=(
-                    "If file type is 'text', then the result must be a dict "
-                    "representing the display_notification action."
-                ),
-            )
+        self.file_2.name = "binary.zip"
+        res = self.file_2.action_pull_from_server()
+        self.assertTrue(
+            isinstance(res, dict) and res["tag"] == "display_notification",
+            msg=(
+                "If file type is 'text', then the result must be a dict "
+                "representing the display_notification action."
+            ),
+        )
 
     def test_get_current_server_code(self):
         """
         Download file from server to tower
         """
-        cx_tower_server_obj = self.registry["cx.tower.server"]
+        self.file.action_push_to_server()
+        self.assertEqual(self.file.server_response, "ok")
 
-        def upload_file(this, file, remote_path):
-            if file == "Hello, world!" and remote_path == "/var/tmp":
-                return "ok"
-
-        with patch.object(cx_tower_server_obj, "upload_file", upload_file):
-            self.file.action_push_to_server()
-            self.assertEqual(self.file.server_response, "ok")
-
-        def download_file(this, remote_path):
-            if remote_path == "/var/tmp/test.txt":
-                return b"Hello, world!"
-
-        with patch.object(cx_tower_server_obj, "download_file", download_file):
-            self.file.action_get_current_server_code()
-            self.assertEqual(self.file.code_on_server, "Hello, world!")
+        self.file.action_get_current_server_code()
+        self.assertEqual(self.file.code_on_server, "ok")
 
     def test_modify_template_code(self):
         """Test how template code modification affects related files"""
@@ -150,36 +113,30 @@ class TestTowerFile(TestTowerCommon):
         )
 
     def test_modify_template_related_files(self):
-        # Create side effect for file write method
-        # to track if method was called during
-        # the test
+        """
+        Check that after change file template
+        all related files will update
+        """
+        self.assertEqual(self.file_template.file_name, "test.txt")
+        # related files
+        self.assertTrue(
+            all(file.name == "test.txt" for file in self.file_template.file_ids)
+        )
 
-        side_effect_target = {"write_called": False}
+        # update file template name
+        self.file_template.file_name = "new_test.txt"
+        # Related files must updated
+        self.assertTrue(
+            all(file.name == "new_test.txt" for file in self.file_template.file_ids)
+        )
 
-        def side_effect(this, vals):
-            side_effect_target["write_called"] = True
-            return False
-
-        # patch file write method with side effect
-        with patch.object(self.registry["cx.tower.file"], "write", side_effect):
-            # Modify template name to see if it won't trigger
-            # write method of the file
-            self.file_template.name = "New name"
-            self.assertFalse(
-                side_effect_target["write_called"],
-                msg=(
-                    "File write method should not be called "
-                    "after modifying template name."
-                ),
-            )
-
-            # Modify template code to see if it will trigger
-            # write method of the file
-            self.file_template.code = "New code"
-            self.assertTrue(
-                side_effect_target["write_called"],
-                msg="File write method should be called after modifying template code.",
-            )
+        self.assertEqual(self.file_template.code, "Hello, world!")
+        # update file template code
+        self.file_template.code = "New code"
+        # Related files must updated
+        self.assertTrue(
+            all(file.code == "New code" for file in self.file_template.file_ids)
+        )
 
     def test_create_file_with_template(self):
         """
@@ -420,5 +377,6 @@ class TestTowerFile(TestTowerCommon):
         # Add bob as subscriber of the server to allow upload file
         self.server_test_1.message_subscribe([self.user_bob.partner_id.id])
         # Upload file to server
+        self.assertTrue(file.server_response != "ok")
         file.with_user(self.user_bob).action_push_to_server()
         self.assertEqual(file.server_response, "ok")

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -1060,26 +1060,12 @@ class TestTowerPlan(TestTowerCommon):
         )
         self.assertEqual(len(plan_log_records), 0, "Plan logs should be empty")
 
-        cx_tower_plan_obj = self.registry["cx.tower.plan"]
-        _execute_single_super = cx_tower_plan_obj._execute_single
+        # Simulate a failed Plan 1. To achieve this, we need to update the command
+        # associated with Plan 1 to apply the desired side effect.
+        self.plan_1.line_ids.command_id[0].code = "fail"
 
-        def _execute_single(this, *args, **kwargs):
-            if this == self.plan_1:
-                # simulate error for child plan
-                kwargs.update(
-                    {
-                        "simulated_result": {
-                            "status": -1,
-                            "response": None,
-                            "error": ["error"],
-                        }
-                    }
-                )
-            return _execute_single_super(this, *args, **kwargs)
-
-        with patch.object(cx_tower_plan_obj, "_execute_single", _execute_single):
-            # Execute plan
-            self.plan_2._execute_single(self.server_test_1)
+        # Execute plan
+        self.plan_2._execute_single(self.server_test_1)
 
         # Check plan logs after execute command with plan action
         plan_log_records = self.PlanLog.search(
@@ -1133,16 +1119,9 @@ class TestTowerPlan(TestTowerCommon):
                 .plan_line_executed_id
                 == line
             ):
-                # simulate error for child plan
-                kwargs.update(
-                    {
-                        "simulated_result": {
-                            "status": -1,
-                            "response": None,
-                            "error": ["error"],
-                        }
-                    }
-                )
+                # Simulate a failed Plan 1. To achieve this, we need to update
+                # the command associated with Plan 1 to apply the desired side effect.
+                self.plan_1.line_ids.command_id[0].code = "fail"
             return _execute_single_super(this, *args, **kwargs)
 
         with patch.object(cx_tower_plan_obj, "_execute_single", _execute_single):

--- a/cetmix_tower_server/tests/test_variable_option.py
+++ b/cetmix_tower_server/tests/test_variable_option.py
@@ -1,5 +1,3 @@
-from psycopg2 import IntegrityError
-
 from odoo.exceptions import ValidationError
 
 from .common import TestTowerCommon
@@ -35,23 +33,6 @@ class TestTowerVariableOption(TestTowerCommon):
                 "variable_id": self.variable_odoo_versions.id,
             }
         )
-
-    def test_unique_constraint(self):
-        """Test the unique constraint on name and variable_id."""
-
-        # Test that creating another option with the same
-        # 'name' and 'variable_id' raises an IntegrityError
-        with self.assertRaises(
-            IntegrityError,
-            msg="The combination of name and variable_id must be unique.",
-        ):
-            self.env["cx.tower.variable.option"].create(
-                {
-                    "name": "17.0",
-                    "value_char": "17.0",
-                    "variable_id": self.variable_odoo_versions.id,
-                }
-            )
 
     def test_variable_value_set_from_option(self):
         """Test that a variable value can be set from an option."""

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -81,24 +81,6 @@
                                             <strong>Partner:</strong>
                                             <field name="partner_id" />
                                         </div>
-                                        <div
-                                            attrs="{'invisible': [('os_id', '=', False)]}"
-                                        >
-                                            <strong>Operating System:</strong>
-                                            <field name="os_id" />
-                                        </div>
-                                        <div
-                                            attrs="{'invisible': [('ip_v4_address', '=', False)]}"
-                                        >
-                                            <strong>IPv4 Address:</strong>
-                                            <field name="ip_v4_address" />
-                                        </div>
-                                        <div
-                                            attrs="{'invisible': [('ip_v6_address', '=', False)]}"
-                                        >
-                                            <strong>IPv6 Address:</strong>
-                                            <field name="ip_v6_address" />
-                                        </div>
                                     </div>
                                 </div>
                                 <div class="o_kanban_record_bottom">
@@ -122,6 +104,36 @@
             </kanban>
         </field>
     </record>
+
+    <record id="cx_tower_server_view_kanban_manager" model="ir.ui.view">
+        <field name="name">cx.tower.server.view.kanban</field>
+        <field name="model">cx.tower.server</field>
+        <field
+            name="inherit_id"
+            ref="cetmix_tower_server.cx_tower_server_view_kanban"
+        />
+        <field
+            name="groups_id"
+            eval="[(4, ref('cetmix_tower_server.group_manager'))]"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
+                <div attrs="{'invisible': [('os_id', '=', False)]}">
+                    <strong>Operating System:</strong>
+                    <field name="os_id" />
+                </div>
+                <div attrs="{'invisible': [('ip_v4_address', '=', False)]}">
+                    <strong>IPv4 Address:</strong>
+                    <field name="ip_v4_address" />
+                </div>
+                <div attrs="{'invisible': [('ip_v6_address', '=', False)]}">
+                    <strong>IPv6 Address:</strong>
+                    <field name="ip_v6_address" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+
 
     <record id="cx_tower_server_view_tree" model="ir.ui.view">
         <field name="name">cx.tower.server.view.tree</field>
@@ -389,6 +401,7 @@
                         name="group_by_os"
                         domain="[]"
                         context="{'group_by': 'os_id'}"
+                        groups="cetmix_tower_server.group_manager"
                     />
                     <filter
                         string="Partner"

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -53,6 +53,7 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
     any_server = fields.Boolean(default=True)
     rendered_code = fields.Text(
         compute="_compute_rendered_code",
+        compute_sudo=True,
     )
     result = fields.Text()
     show_servers = fields.Boolean(


### PR DESCRIPTION
Limit access to the following fields of the `cx.tower.server` ​model to Manager and Root:
- OS
- IP v4 Address
- IP v6 Address
- SSH username 
- SSH Port
- SSS auth mode
- SSH key
- Use sudo

Task: 4116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
	- Added group-based access control for server connection settings.
	- Restricted sensitive server configuration fields to the manager group.
	- Made SSH password field optional.

- **User Interface**
	- Introduced a new kanban view for the manager group with restricted field access.
	- Updated search view to reflect new access controls and visibility based on user roles.

- **Documentation**
	- Added note about user access levels in the configuration guide.

- **Testing**
	- Enhanced test coverage for user access and command execution, including sensitive variables.
	- Removed a test for unique constraint validation on variable options.
	- Streamlined test cases by removing unnecessary mocks and directly testing functionality.
	- Added new tests for verifying user access to files with sensitive variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->