### PR TITLE
[FIX] cetmix_tower_server: Server creation

### DIFF
--- a/cetmix_tower_server/readme/USAGE.md
+++ b/cetmix_tower_server/readme/USAGE.md
@@ -24,6 +24,11 @@ This function takes the following arguments:
       'variable_reference': 'variable_value_char'
       eg:
       {'branch': 'prod', 'odoo_version': '16.0'}
+  - configuration_variable_options (Dict, optional): Custom configuration variable options.
+    Following format is used:
+      'variable_reference': 'option_reference'
+      eg:
+      {'language': 'language_variable_option_1'}
 ```
 
 Here is a short example of an Odoo automated action that creates a new server when a Sales Order is confirmed:


### PR DESCRIPTION
- Fix incorrect creation of server variables when generating a server from a template.
- Enable the creation of servers from a template with either a full copy of variables or only the specified ones.
- Allow the creation of servers with specific variable options.
- Optimize search of existing variables and creation of new ones

Task: 4253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced server creation functionality with the option to include existing template variables.
  - Introduced new mapping for configuration variable options.
  - Added a new test to verify server creation with partial variable removal.

- **Refactor**
  - Restructured how server parameters are prepared for creation.
  - Simplified the handling of template variable options during server creation.

- **Bug Fixes**
  - Improved validation and error handling for missing required configuration variables.

- **Documentation**
  - Updated documentation to include examples for new configuration variable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->