### PR TITLE
[ADD] pyproject.toml

### DIFF
--- a/cetmix_tower_server/pyproject.toml
+++ b/cetmix_tower_server/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/cetmix_tower_server_notify_backend/pyproject.toml
+++ b/cetmix_tower_server_notify_backend/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/cetmix_tower_server_queue/pyproject.toml
+++ b/cetmix_tower_server_queue/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/cetmix_tower_yaml/pyproject.toml
+++ b/cetmix_tower_yaml/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"


### PR DESCRIPTION
Add `pyproject.toml` to install each module as a python module according to the OCA demo (see [repo](https://github.com/sbidoul/ocadays2024-odoo-project-demo), [slides](https://docs.google.com/presentation/d/e/2PACX-1vSfjuY0ahd9e0Xid6HE4Ly5mrVQKlDEj_FnjDhlyT3yu9A6C6YUaAZWVCKdIQGpf4f9XuhhjxO3DSZ1/pub?start=false&loop=false&delayms=3000&slide=id.p) and [talk](https://youtu.be/oQbrZoVttt8?t=1793)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Configuration**
  - Updated `pyproject.toml` files across multiple projects to add a new `[build-system]` section
  - Specified `whool` as the required package and `whool.buildapi` as the build backend
  - Standardized build configuration across project repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->