### PR TITLE
[14.0][IMP] cetmix_tower_server: On delete flight plan

### DIFF
--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -258,8 +258,13 @@
                                         attrs="{'required': [('ssh_auth_mode', '=', 'k')]}"
                                     />
                                 </group>
-
-
+                                <group extra="delete">
+                                    <field
+                                        name="server_template_id"
+                                        attrs="{'invisible': [('server_template_id', '=', False)]}"
+                                    />
+                                    <field name="plan_delete_id" />
+                                </group>
                                 <field name="note" placeholder="Put your notes here" />
                             </group>
                         </page>


### PR DESCRIPTION
Execute flight plan when server is deleted.

Set "Deleting" status when flight plan is started. Delete server if plan is successful.
Set "Delete Error" status when flight plan fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added ability to define a deletion plan for servers.
  - Introduced new server deletion statuses: "deleting" and "delete_error".

- **Improvements**
  - Enhanced server management with a more controlled deletion process.
  - Implemented a flight plan mechanism for server deletion.
  - Added structured error handling for server deletion scenarios.

- **UI Changes**
  - Updated server form view to include new deletion-related fields.
  - Added conditional visibility for the server template field.

These changes provide more robust server management capabilities with improved deletion workflows and error tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->