### PR TITLE
[IMP] cetmix_tower_server: Server from Template

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -68,6 +68,14 @@ class CxTowerServerTemplate(models.Model):
         domain="[('server_ids', '=', False)]",
     )
 
+    # ---- Delete plan
+    plan_delete_id = fields.Many2one(
+        "cx.tower.plan",
+        string="On Delete Plan",
+        groups="cetmix_tower_server.group_manager",
+        help="This Flightplan will be executed when the server is deleted",
+    )
+
     # --- Created Servers
     server_ids = fields.One2many(
         comodel_name="cx.tower.server",
@@ -102,6 +110,7 @@ class CxTowerServerTemplate(models.Model):
                 "default_ssh_password": self.ssh_password,
                 "default_ssh_key_id": self.ssh_key_id.id,
                 "default_ssh_auth_mode": self.ssh_auth_mode,
+                "default_plan_delete_id": self.plan_delete_id.id,
             }
         )
         if self.variable_value_ids:
@@ -250,6 +259,7 @@ class CxTowerServerTemplate(models.Model):
             "use_sudo",
             "color",
             "os_id",
+            "plan_delete_id",
             "tag_ids",
             "variable_value_ids",
             "server_log_ids",
@@ -475,6 +485,10 @@ class CxTowerServerTemplate(models.Model):
                     - ip_v6_address (str, optional): Parsed IPv6 address.
         """
         values = {}
+
+        # This field is always populated from Server Template and
+        # cannot be altered with function params.
+        config_values.pop("plan_delete_id", None)
 
         partner = config_values.pop("partner", None)
         if partner:

--- a/cetmix_tower_server/readme/CONFIGURE.md
+++ b/cetmix_tower_server/readme/CONFIGURE.md
@@ -85,6 +85,7 @@ Fill the values it the tabs below:
 **General Settings**
 
 - **Flight Plan**: Select a flight plan to be executed after a server is created
+- **On Delete Plan**: Default ondelete Flight Plan for new servers
 - **Operating System**: Default operating system for new servers
 - **Tags**: Default search tags for new servers
 - **SSH Auth Mode**: Default SSH auth mode for new servers. Available options are "Password" and "Key"

--- a/cetmix_tower_server/tests/test_server_template.py
+++ b/cetmix_tower_server/tests/test_server_template.py
@@ -24,6 +24,9 @@ class TestTowerServerTemplate(TestTowerCommon):
             }
         )
 
+        # add delete flight plan
+        self.server_template_sample.plan_delete_id = self.plan_1.id
+
         # add server logs to template
         command_for_log = self.Command.create(
             {"name": "Get system info", "code": "uname -a"}
@@ -51,7 +54,7 @@ class TestTowerServerTemplate(TestTowerCommon):
         new_server = self.ServerTemplate.create_server_from_template(
             self.server_template_sample.reference,
             "server_from_template",
-            ip_v4_address="0.0.0.0",
+            ipv4="0.0.0.0",
         )
 
         server = self.Server.search(
@@ -85,6 +88,11 @@ class TestTowerServerTemplate(TestTowerCommon):
             len(self.variable_version.value_ids),
             2,
             "The variable must have two value only",
+        )
+        self.assertEqual(
+            new_server.plan_delete_id,
+            self.plan_1,
+            "Server On Delete Plan must be 'Test plan 1'",
         )
 
         server_log = self.ServerLog.search([("command_id", "=", command_for_log.id)])
@@ -166,9 +174,10 @@ class TestTowerServerTemplate(TestTowerCommon):
         self.ServerTemplate.create_server_from_template(
             self.server_template_sample.reference,
             "server from template",
-            ip_v4_address="localhost",
+            ipv4="localhost",
             ssh_username="test",
             ssh_password="test",
+            plan_delete_id=self.plan_1.id,
             configuration_variables={
                 self.variable_version.reference: "test server version",
                 "new_variable": "new_value",
@@ -180,6 +189,8 @@ class TestTowerServerTemplate(TestTowerCommon):
         new_server = self.Server.search([("name", "=", name)])
 
         self.assertTrue(new_server, "Server must exist!")
+        self.assertFalse(new_server.plan_delete_id, "On Delete Plan must be empty!")
+
         self.assertEqual(
             len(new_server.variable_value_ids), 3, "Should be 3 variable values!"
         )

--- a/cetmix_tower_server/views/cx_tower_server_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_template_view.xml
@@ -152,6 +152,7 @@
                             <group name="root">
                                 <group name="main">
                                     <field name="flight_plan_id" />
+                                    <field name="plan_delete_id" />
                                     <field name="os_id" />
                                     <field name="active" invisible='1' />
                                     <field


### PR DESCRIPTION
- Add default ondelete Flight Plan for new servers from Server Template

Task: 4293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added an "On Delete Plan" configuration option for server templates
	- Introduced ability to specify a default flight plan to execute when a server is deleted

- **Documentation**
	- Updated configuration guide to explain new deletion plan feature

- **Tests**
	- Enhanced test coverage for server template creation and deletion plan functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->