### PR TITLE
[14.0][FIX] cetmix_tower_server_notify_backend On delete flight plan issue

### DIFF
--- a/cetmix_tower_server_notify_backend/README.rst
+++ b/cetmix_tower_server_notify_backend/README.rst
@@ -17,18 +17,15 @@ Cetmix Tower Server Notify Backend
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server_notify_backend
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server_notify_backend
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
 
 This module implements backend notifications for Cetmix Tower.
-Notifications will be shown when a command or a flight plan finishes
-execution.
 
-Important: this module depends on the OCA
-`web_notify <https://github.com/OCA/web/tree/14.0/web_notify>`__ module.
-Please ensure it's available in your system.
+Please check the official documentation for more information:
+https://cetmix.com/tower
 
 **Table of contents**
 
@@ -45,13 +42,18 @@ Usage
 
 Just install this module.
 
+Changelog
+=========
+
+
+
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server_notify_backend%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server_notify_backend%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -66,6 +68,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server_notify_backend>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server_notify_backend>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server_notify_backend/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_notify_backend/models/cx_tower_command_log.py
@@ -14,9 +14,14 @@ class CxTowerCommandLog(models.Model):
         )
 
         for rec in self:
-            if rec.plan_log_id:  # type: ignore
+            # Record might be deleted before we get here.
+            # Eg in case Flight Plan is run on server deletion.
+            #
+            # Also do not send notification if command is run
+            # from a Flight Plan.
+            if not rec.exists() or rec.plan_log_id:  # type: ignore
                 continue
-            elif rec.command_status == 0:
+            if rec.command_status == 0:
                 rec.create_uid.notify_success(
                     message=_(
                         "%(timestamp)s<br/>" "Command '%(name)s' finished successfully",

--- a/cetmix_tower_server_notify_backend/readme/.newsfragments/4320.bugfix
+++ b/cetmix_tower_server_notify_backend/readme/.newsfragments/4320.bugfix
@@ -1,0 +1,1 @@
+Error when deleting a Server with an "On Delete Plan" set.

--- a/cetmix_tower_server_notify_backend/readme/DESCRIPTION.md
+++ b/cetmix_tower_server_notify_backend/readme/DESCRIPTION.md
@@ -1,3 +1,3 @@
-This module implements backend notifications for Cetmix Tower. Notifications will be shown when a command or a flight plan finishes execution.
+This module implements backend notifications for Cetmix Tower.
 
-Important: this module depends on the OCA [web_notify](https://github.com/OCA/web/tree/14.0/web_notify) module. Please ensure it's available in your system.
+Please check the official documentation for more information: https://cetmix.com/tower

--- a/cetmix_tower_server_notify_backend/static/description/index.html
+++ b/cetmix_tower_server_notify_backend/static/description/index.html
@@ -369,22 +369,20 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:54ea0e3b01668069420b1c5f1a99715bebf722f62de2cfd0082f18e3a609df53
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server_notify_backend"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
-<p>This module implements backend notifications for Cetmix Tower.
-Notifications will be shown when a command or a flight plan finishes
-execution.</p>
-<p>Important: this module depends on the OCA
-<a class="reference external" href="https://github.com/OCA/web/tree/14.0/web_notify">web_notify</a> module.
-Please ensure it’s available in your system.</p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server_notify_backend"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p>This module implements backend notifications for Cetmix Tower.</p>
+<p>Please check the official documentation for more information:
+<a class="reference external" href="https://cetmix.com/tower">https://cetmix.com/tower</a></p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -397,25 +395,28 @@ Please ensure it’s available in your system.</p>
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>Just install this module.</p>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#toc-entry-3">Changelog</a></h1>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server_notify_backend%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server_notify_backend%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Cetmix</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server_notify_backend">cetmix/cetmix-tower</a> project on GitHub.</p>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server_notify_backend">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>


### PR DESCRIPTION
When a Server is deleted an on delete Flight Plan is triggered. As soon as this Flight Plan finishes with success, the Server is deleted too. All related records are deleted with it.

This creates an issue when notification is sent for a log record that is already deleted.

This commit fixes this issue by checking if the record exists before sending a notification.

Task: 4320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification logic for command completion to handle edge cases.
  - Enhanced record validation before sending notifications.
  - Refined status checking mechanism to prevent potential notification errors.
  - Added a new error message for scenarios where a server is deleted with an "On Delete Plan" set.

- **Documentation**
  - Updated URLs and added a "Changelog" section in the README.
  - Simplified documentation content regarding module functionality and dependencies.
  - Reorganized HTML documentation structure and updated links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->