### PR TITLE
[14.0][FIX] cetmix_tower_server: Variable value access

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -222,14 +222,15 @@ class CxTowerServerTemplate(models.Model):
         # We validate mandatory variables
         self._validate_required_variables(configuration_variables)
 
+        # We are using sudo to ensure all values are copied
         servers = (
             self.env["cx.tower.server"]
             .with_context(skip_ssh_settings_check=True)
             .create(
-                self._prepare_server_values(
+                self.sudo()._prepare_server_values(
                     name=name,
-                    server_template_id=self.id,
-                    **kwargs,  # pylint: disable=no-member
+                    server_template_id=self.id,  # pylint: disable=no-member
+                    **kwargs,
                 ),
             )
         )

--- a/cetmix_tower_server/security/cx_tower_server_log_security.xml
+++ b/cetmix_tower_server/security/cx_tower_server_log_security.xml
@@ -18,8 +18,11 @@
         <field name="name">Server log: manager access rule</field>
         <field name="model_id" ref="model_cx_tower_server_log" />
         <field name="domain_force">[
+            ('access_level', '&lt;=', '2'),
+            '|', '|',
+            ('create_uid', '=', user.id),
             ('server_id.message_partner_ids', 'in', [user.partner_id.id]),
-            ('access_level', '&lt;=', '2')
+            ('server_template_id.message_partner_ids', 'in', [user.partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
 

--- a/cetmix_tower_server/security/cx_tower_variable_value_security.xml
+++ b/cetmix_tower_server/security/cx_tower_variable_value_security.xml
@@ -7,12 +7,15 @@
     >
         <field name="name">Tower variable value: user and manager access rule</field>
         <field name="model_id" ref="model_cx_tower_variable_value" />
-        <field name="domain_force">['|', ('is_global', '=', True),
+        <field
+            name="domain_force"
+        >['|', '|', ('is_global', '=', True), ('create_uid', '=', user.id),
             ('server_id.message_partner_ids', 'in', [user.partner_id.id])]</field>
         <field
             name="groups"
             eval="[(4, ref('cetmix_tower_server.group_user')), (4, ref('cetmix_tower_server.group_manager'))]"
         />
+        <field name="perm_unlink" eval="0" />
     </record>
 
     <record id="cx_tower_variable_value_action_rule_group_user_access" model="ir.rule">

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -63,8 +63,12 @@ class CxTowerYamlMixin(models.AbstractModel):
 
     @api.constrains("yaml_code")
     def _check_yaml_code_write_access(self):
-        """Check if user has access to create records from YAML"""
-        if (
+        """
+        Check if user has access to create records from YAML.
+        This is checked only when user already has access to export YAML.
+        Otherwise, the field is not accessible due to security group.
+        """
+        if self.env.user.has_group("cetmix_tower_yaml.group_export") and (
             not self.env.user.has_group("cetmix_tower_yaml.group_import")
             and not self.env.user._is_superuser()
         ):


### PR DESCRIPTION
## Variable Values

Currently "Manager" group members can only create variable values for servers they are followers of.
However, partners are added as followers of servers when they are created.
This commit adds access to variable values created by users.

NB: this is a temporary fix. To be replaced by a more generic access control system.

## Server Templates

Use `sudo` when preparing server values to ensure
that all values are copied.

## Server Logs

Add security rules to allow users to access their own logs and
logs of servers/server templates they have access to.

# Cetmix Tower YAML

Remove constraint on `yaml_code` field because it raises exception
even when user is not accessing the field explicitly.
This blocked non members of `cetmix_tower_yaml.group_import` group
from creating and modifying records in models inheriting from
`cx.tower.yaml.mixin`.

Task: 4323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Security**
	- Enhanced access control for variable values.
	- Users can now access variables they created, in addition to global variables.
	- Improved permission management for user and manager roles, including new unlinking permissions.
	- Refined access logic for manager group permissions.
- **New Features**
	- Elevated permission context for server creation.
	- Updated access checks for YAML code writing based on user permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->