### PR TITLE
[14.0][FIX] related record creation

### DIFF
--- a/cetmix_tower_git/models/cx_tower_git_project.py
+++ b/cetmix_tower_git/models/cx_tower_git_project.py
@@ -21,6 +21,10 @@ class CxTowerGitProject(models.Model):
         "cx.tower.access.role.mixin",
     ]
 
+    def _get_post_create_fields(self):
+        res = super()._get_post_create_fields()
+        return res + ["source_ids", "git_project_rel_ids"]
+
     active = fields.Boolean(default=True)
     # IMPORTANT: This field may contain duplicates because of the relation nature!
     server_ids = fields.Many2many(

--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -24,3 +24,4 @@ from . import cx_tower_server_log
 from . import cx_tower_server_template
 from . import cetmix_tower
 from . import cx_tower_variable_option
+from . import ir_actions_server

--- a/cetmix_tower_server/models/cx_tower_access_role_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_access_role_mixin.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CxTowerAccessRoleMixin(models.AbstractModel):
@@ -58,3 +58,42 @@ class CxTowerAccessRoleMixin(models.AbstractModel):
         help="Managers who can modify this record",
         copy=False,
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Create records with post-create fields.
+        """
+        post_create_fields = self._get_post_create_fields()
+        post_create_vals_list = []
+        for vals in vals_list:
+            post_create_vals = {}
+            for key in post_create_fields:
+                if key in vals:
+                    post_create_vals[key] = vals.pop(key)
+            post_create_vals_list.append(post_create_vals)
+
+        # Create records without post-create fields
+        res = super().create(vals_list)
+        if post_create_vals_list:
+            # Create related records with post-create field
+            for post_create_vals, record in zip(post_create_vals_list, res):
+                if post_create_vals:
+                    record.write(post_create_vals)
+
+        return res
+
+    def _get_post_create_fields(self):
+        """
+        Get post-create fields.
+
+        Some records may create related records which use rules
+        that depend on `user_ids` and `manager_ids` fields.
+        However at the moment of record creation, these fields are not yet set.
+        So first we create the record without these fields, then we create
+        the related records to avoid access violations.
+
+        Returns:
+            list: List of fields to be set after record creation.
+        """
+        return []

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -25,6 +25,10 @@ class CxTowerPlan(models.Model):
     ]
     _order = "name asc"
 
+    def _get_post_create_fields(self):
+        res = super()._get_post_create_fields()
+        return res + ["line_ids"]
+
     active = fields.Boolean(default=True)
     allow_parallel_run = fields.Boolean(
         help="If enabled flightplan can be run on the same server "

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -270,6 +270,10 @@ class CxTowerServer(models.Model):
     _description = "Cetmix Tower Server"
     _order = "name asc"
 
+    def _get_post_create_fields(self):
+        res = super()._get_post_create_fields()
+        return res + ["variable_value_ids", "server_log_ids", "secret_ids"]
+
     # ---- Main
     active = fields.Boolean(default=True)
     color = fields.Integer(help="For better visualization in views")
@@ -334,7 +338,7 @@ class CxTowerServer(models.Model):
         string="Secrets",
         comodel_name="cx.tower.key",
         inverse_name="server_id",
-        domain=[("key_type", "!=", "k")],
+        domain=[("key_type", "=", "s")],
     )
 
     # ---- Attributes

--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -17,6 +17,10 @@ class CxTowerServerTemplate(models.Model):
     ]
     _description = "Cetmix Tower Server Template"
 
+    def _get_post_create_fields(self):
+        res = super()._get_post_create_fields()
+        return res + ["variable_value_ids", "server_log_ids"]
+
     active = fields.Boolean(default=True)
 
     # --- Connection

--- a/cetmix_tower_server/models/ir_actions_server.py
+++ b/cetmix_tower_server/models/ir_actions_server.py
@@ -1,0 +1,24 @@
+from odoo import _, models
+from odoo.exceptions import AccessError
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    def run(self):
+        """
+        We override this method to return more
+        user friendly error messages.
+        """
+        if self.sudo().model_name == "cx.tower.server":
+            try:
+                res = super().run()
+                return res
+            except AccessError as e:
+                raise AccessError(
+                    _(
+                        "You need to have 'write' access to all servers "
+                        "you want to run this action on."
+                    )
+                ) from e
+        return super().run()


### PR DESCRIPTION
When a record is created, some related records are created as well.
Some of them use rules that depend on `user_ids` and `manager_ids` fields.
However at the moment of record creation, these fields are not yet set.
So first we create the record without these related records, then we create the related records to avoid access violations.

Task: 4369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved record creation processes across multiple components. New updates ensure that, after creating projects, roles, plans, servers, and templates, additional configuration settings are automatically applied, including specific field retrievals such as `"source_ids"`, `"git_project_rel_ids"`, `"line_ids"`, `"variable_value_ids"`, and `"server_log_ids"`. This enhancement streamlines setup workflows and promotes more consistent behavior during record initialization.
  - Introduced a new class `IrActionsServer` with enhanced error handling for server actions, providing clearer feedback on access requirements.
  
- **Bug Fixes**
  - Updated the filtering criteria for the `secret_ids` field to improve record retrieval accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->