### PR TITLE
[14.0][IMP] cetmix_tower_server: Access rules for keys

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -830,8 +830,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -996,9 +996,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -1006,7 +1006,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -1021,6 +1021,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -34,6 +34,7 @@
         "security/cx_tower_variable_security.xml",
         "security/cx_tower_variable_value_security.xml",
         "security/cx_tower_variable_option_security.xml",
+        "security/cx_tower_key_security.xml",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",
         "wizards/cx_tower_command_execute_wizard_view.xml",

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -67,9 +67,11 @@ class CxTowerFileTemplate(models.Model):
     )
 
     # ---- Access. Add relation for mixin fields
-
     user_ids = fields.Many2many(
         relation="cx_tower_file_template_user_rel",
+        domain=lambda self: [
+            ("groups_id", "in", [self.env.ref("cetmix_tower_server.group_manager").id])
+        ],
     )
     manager_ids = fields.Many2many(
         relation="cx_tower_file_template_manager_rel",

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -12,7 +12,7 @@ class CxTowerKey(models.Model):
 
     _name = "cx.tower.key"
     _description = "Cetmix Tower private key storage"
-    _inherit = ["cx.tower.reference.mixin"]
+    _inherit = ["cx.tower.reference.mixin", "cx.tower.access.role.mixin"]
 
     KEY_PREFIX = "#!cxtower"
     KEY_TERMINATOR = "!#"
@@ -47,6 +47,17 @@ class CxTowerKey(models.Model):
         comodel_name="res.partner", help="Leave blank to use for any partner"
     )
     note = fields.Text()
+
+    # ---- Access. Add relation for mixin fields
+    user_ids = fields.Many2many(
+        relation="cx_tower_key_user_rel",
+        domain=lambda self: [
+            ("groups_id", "in", [self.env.ref("cetmix_tower_server.group_manager").id])
+        ],
+    )
+    manager_ids = fields.Many2many(
+        relation="cx_tower_key_manager_rel",
+    )
 
     def init(self):
         """
@@ -259,7 +270,9 @@ class CxTowerKey(models.Model):
     def _read(self, fields):
         """Substitute fields based on api"""
         super()._read(fields)
-        if not self.env.is_superuser() and ("secret_value" in fields or fields == []):
+        if not self.env.context.get("show_secret_value") and (
+            "secret_value" in fields or fields == []
+        ):
             # Public user used for substitution
             for record in self:
                 try:
@@ -476,7 +489,7 @@ class CxTowerKey(models.Model):
             )
 
         # Fetch keys
-        keys = self.search(key_domain).sudo()
+        keys = self.sudo().search(key_domain)
         if not keys:
             return
 
@@ -493,7 +506,12 @@ class CxTowerKey(models.Model):
             # Fallback to a global key
             key = keys
 
-        key_value = key[0].secret_value
+        # Read the first key secret value. Use context to show secret value
+        key_value = (
+            key.with_context(show_secret_value=True)
+            .read(["secret_value"])[0]
+            .get("secret_value")
+        )
         return key_value
 
     def _replace_with_spoiler(self, code, key_values):

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -339,6 +339,7 @@ class CxTowerServer(models.Model):
         comodel_name="cx.tower.key",
         inverse_name="server_id",
         domain=[("key_type", "=", "s")],
+        groups="cetmix_tower_server.group_manager",
     )
 
     # ---- Attributes
@@ -611,8 +612,16 @@ class CxTowerServer(models.Model):
             Char: SSH private key
         """
         self.ensure_one()
+        # To ensure that key will be read
+        # regardless of access rights
+        self = self.sudo()
         if self.ssh_key_id:
-            ssh_key = self.ssh_key_id.sudo().secret_value
+            # Use context key to read secret value
+            ssh_key = (
+                self.ssh_key_id.sudo()
+                .with_context(show_secret_value=True)
+                .read(["secret_value"])[0]["secret_value"]
+            )
         else:
             ssh_key = None
         return ssh_key

--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -100,6 +100,9 @@ class CxTowerServerTemplate(models.Model):
     # ---- Access. Add relation for mixin fields
     user_ids = fields.Many2many(
         relation="cx_tower_server_template_user_rel",
+        domain=lambda self: [
+            ("groups_id", "in", [self.env.ref("cetmix_tower_server.group_manager").id])
+        ],
     )
     manager_ids = fields.Many2many(
         relation="cx_tower_server_template_manager_rel",

--- a/cetmix_tower_server/security/cx_tower_key_security.xml
+++ b/cetmix_tower_server/security/cx_tower_key_security.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Manager Read Rules -->
+    <record id="rule_tower_key_manager_read_any_type" model="ir.rule">
+        <field name="name">Tower Key: Manager Read Assigned Secrets</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">['|',
+            ('user_ids', 'in', [user.id]),
+            ('manager_ids', 'in', [user.id])
+        ]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_tower_key_manager_read_ssh" model="ir.rule">
+        <field name="name">Tower Key: Manager Read SSH Keys</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[('key_type', '=', 'k'), '|',
+            ('server_ssh_ids.user_ids', 'in', [user.id]),
+            ('server_ssh_ids.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_tower_key_manager_read_secret" model="ir.rule">
+        <field name="name">Tower Key: Manager Read Secrets</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[('key_type', '=', 's'), '|',
+            ('server_id.user_ids', 'in', [user.id]),
+            ('server_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+
+    <!-- Manager Write/Create Rules -->
+    <record id="rule_tower_key_manager_write_any_type" model="ir.rule">
+        <field name="name">Tower Key: Manager Write/Create</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[
+            ('manager_ids', 'in', [user.id])
+        ]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="0" />
+
+    </record><record id="rule_tower_key_manager_write_ssh" model="ir.rule">
+        <field name="name">Tower Key: Manager Write/Create SSH Keys</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[('key_type', '=', 'k'),
+            ('server_ssh_ids.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_tower_key_manager_write_secret" model="ir.rule">
+        <field name="name">Tower Key: Manager Write/Create Secrets</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[('key_type', '=', 's'),
+            ('server_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <!-- Manager Delete Rules -->
+    <record id="rule_tower_key_manager_unlink_any_type" model="ir.rule">
+        <field name="name">Tower Key: Manager Delete</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[
+            ('manager_ids', 'in', [user.id]),
+            ('create_uid', '=', user.id)]
+        </field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+    <!-- Root Access Rule -->
+    <record id="rule_tower_key_root" model="ir.rule">
+        <field name="name">Tower Key: Root Full Access</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_root'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+</odoo>

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -19,8 +19,8 @@ access_command_manager,Command->Manager,model_cx_tower_command,group_manager,1,1
 access_command_root,Command->Root,model_cx_tower_command,group_root,1,1,1,1
 access_execute_command_user,Execute Command->User,model_cx_tower_command_execute_wizard,group_user,1,1,1,1
 access_execute_plan_user,Execute Plan->User,model_cx_tower_plan_execute_wizard,group_user,1,1,1,1
-access_key_user,Key->User,model_cx_tower_key,group_user,1,0,0,0
-access_key_manager,Key->Manager,model_cx_tower_key,group_manager,1,1,1,0
+access_key_user,Key->User,model_cx_tower_key,group_user,0,0,0,0
+access_key_manager,Key->Manager,model_cx_tower_key,group_manager,1,1,1,1
 access_key_root,Key->Root,model_cx_tower_key,group_root,1,1,1,1
 access_command_log_user,Command Log->User,model_cx_tower_command_log,group_user,1,0,0,0
 access_command_log_root,Command Log->User,model_cx_tower_command_log,group_root,1,1,1,1

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:2874708da606d835703152f10b6a137a1d695f0fb4155aa75ea8c9b8c038832d
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -469,7 +469,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting <span class="pre">-&gt;</span> Users &amp; Companies <span class="pre">-&gt;</span> Users</tt> and open a user whom you would
 like to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In the <tt class="docutils literal">Cetmix Tower</tt> section select one of the following options in
 the <tt class="docutils literal">Access Level</tt> field:</p>
 <ul class="simple">
@@ -1026,7 +1026,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1163,7 +1163,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1261,14 +1261,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click the
 <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in order to
 refresh all logs at once. Log output will be displayed in the HTML
 field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1285,7 +1285,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1298,7 +1298,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -76,7 +76,10 @@ v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
                 "code": """
 server_name = {{ tower.server.name }}
 if server_name and #!cxtower.secret.FOLDER!# == "secretFolder":
-    command = env["cx.tower.command"].create({"name": {{ test_path_ }}})
+    # We don't actually create a new command because it will raise
+    # access error if user doesn't have access to 'create' operation.
+    # Instead we just return a dummy command result.
+    command = "new command"
     COMMAND_RESULT = {"exit_code": 0, "message": "New command was created"}
 else:
     COMMAND_RESULT = {"exit_code": -1, "message": "error"}
@@ -1064,7 +1067,10 @@ COMMAND_RESULT = {
         rendered_code_pythonic = f"""
 server_name = "{self.server_test_1.name}"
 if server_name and #!cxtower.secret.FOLDER!# == "secretFolder":
-    command = env["cx.tower.command"].create({{"name": "/opt/tower"}})
+    # We don't actually create a new command because it will raise
+    # access error if user doesn't have access to 'create' operation.
+    # Instead we just return a dummy command result.
+    command = "new command"
     COMMAND_RESULT = {{"exit_code": 0, "message": "New command was created"}}
 else:
     COMMAND_RESULT = {{"exit_code": -1, "message": "error"}}
@@ -1134,14 +1140,28 @@ else:
         """
         Test command execution without setting server status
         """
+        # Set command access level to "user"
+        self.command_create_new_command.write({"access_level": "1"})
+
+        # Add user to command
+        self.write_and_invalidate(
+            self.server_test_1, **{"user_ids": [(4, self.user.id)]}
+        )
+
+        # Reset access rule cache
+        self.env["ir.rule"].invalidate_cache()
+
         # Execute command
         server_status = self.server_test_1.status
 
-        self.server_test_1.with_context(no_log=True).execute_command(
-            self.command_create_new_command
+        result = (
+            self.server_test_1.with_context(no_log=True)
+            .with_user(self.user)
+            .execute_command(self.command_create_new_command)
         )
 
         # Check command result
+        self.assertEqual(result["status"], 0, "Command status must be 0")
         self.assertEqual(
             self.server_test_1.status, server_status, "Server status must be 'running'"
         )

--- a/cetmix_tower_server/tests/test_key.py
+++ b/cetmix_tower_server/tests/test_key.py
@@ -4,8 +4,43 @@ from .common import TestTowerCommon
 
 
 class TestTowerKey(TestTowerCommon):
+    """Test class for tower key."""
+
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
+        # Create another manager for testing
+        self.manager_2 = self.Users.create(
+            {
+                "name": "Second Manager",
+                "login": "manager2",
+                "email": "manager2@test.com",
+                "groups_id": [
+                    (4, self.env.ref("cetmix_tower_server.group_manager").id)
+                ],
+            }
+        )
+
+        # Create test servers
+        self.server_1 = self.Server.create(
+            {
+                "name": "Test Server 1",
+                "ip_v4_address": "192.168.1.1",
+                "ssh_port": "22",
+                "ssh_username": "admin",
+                "ssh_password": "password",
+                "ssh_auth_mode": "p",
+            }
+        )
+        self.server_2 = self.Server.create(
+            {
+                "name": "Test Server 2",
+                "ip_v4_address": "192.168.1.2",
+                "ssh_port": "22",
+                "ssh_username": "admin",
+                "ssh_password": "password",
+                "ssh_auth_mode": "p",
+            }
+        )
 
     def test_key_creation(self):
         """
@@ -34,7 +69,9 @@ class TestTowerKey(TestTowerCommon):
         SECRET_VALUE_PLACEHOLDER = self.Key.SECRET_VALUE_PLACEHOLDER
 
         # Store key value
-        self.write_and_invalidate(self.key_1, **{"secret_value": "pepe"})
+        self.write_and_invalidate(
+            self.key_1, **{"secret_value": "pepe", "key_type": "s"}
+        )
 
         # Get key value as Bob
         key_bob = self.key_1.with_user(self.user_bob)
@@ -43,7 +80,11 @@ class TestTowerKey(TestTowerCommon):
             key_value = key_bob.secret_value
 
         # Add user to group
-        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        # Add user to server
+        self.server_test_1.write({"user_ids": [(4, self.user_bob.id)]})
+        # Add server to key
+        self.write_and_invalidate(self.key_1, **{"server_id": self.server_test_1.id})
 
         # Get value
         key_value = key_bob.secret_value
@@ -59,22 +100,14 @@ class TestTowerKey(TestTowerCommon):
         with self.assertRaises(AccessError):
             self.write_and_invalidate(key_bob, **{"secret_value": "frog"})
 
-        # Add Bob to Manager group and test write again
-        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
-        self.write_and_invalidate(key_bob, **{"secret_value": "frog"})
-
-        # Read as sudo and check if the value is updated
-        key_sudo = self.key_1.sudo()
-        key_value = key_sudo.secret_value
-        self.assertEqual(key_value, "frog", msg="Must return key value 'frog'")
-
-        # Try deleting key. Should raise access error
-        with self.assertRaises(AccessError):
-            key_bob.unlink()
-
         # Add Bob to Root group and test write again
         self.add_to_group(self.user_bob, "cetmix_tower_server.group_root")
-        key_bob.unlink()
+        self.write_and_invalidate(key_bob, **{"secret_value": "frog"})
+
+        # Read with context and check if secret value is returned
+        key_with_context = self.key_1.with_context(show_secret_value=True)
+        key_value = key_with_context.secret_value
+        self.assertEqual(key_value, "frog", msg="Must return key value 'frog'")
 
     def test_extract_key_strings(self):
         """Check if key strings are extracted properly"""
@@ -417,3 +450,253 @@ class TestTowerKey(TestTowerCommon):
         key_values = ["Wow much", "No like"]
         result = self.Key._replace_with_spoiler(code, key_values)
         self.assertEqual(result, code, "Result doesn't match expected code")
+
+    def test_user_access(self):
+        """Test that regular users have no access"""
+        Key = self.env["cx.tower.key"].with_user(self.user)
+
+        # Try to read - should fail with access error
+        with self.assertRaises(AccessError):
+            Key.search([])
+
+        # Try to create - should fail
+        with self.assertRaises(AccessError):
+            Key.create(
+                {
+                    "name": "User Key",
+                    "key_type": "k",
+                    "secret_value": "user_key",
+                }
+            )
+
+        # Try to write - should fail
+        with self.assertRaises(AccessError):
+            self.key_1.with_user(self.user).write({"name": "New Name"})
+
+        # Try to unlink - should fail
+        with self.assertRaises(AccessError):
+            self.key_1.with_user(self.user).unlink()
+
+    def test_manager_read_ssh_key(self):
+        """Test manager read access for SSH keys"""
+        Key = self.env["cx.tower.key"].with_user(self.manager)
+
+        # Create SSH key with server reference
+        ssh_key = self.Key.create(
+            {
+                "name": "Test SSH Key",
+                "key_type": "k",
+                "secret_value": "test_key",
+            }
+        )
+        # Link SSH key to server
+        self.server_test_1.write({"ssh_key_id": ssh_key.id})
+
+        # No access initially
+        self.assertFalse(Key.search([("id", "=", ssh_key.id)]))
+
+        # Add as user - should read
+        self.server_test_1.write({"user_ids": [(4, self.manager.id)]})
+        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+
+        # Remove user, add as manager - should read
+        self.server_test_1.write(
+            {
+                "user_ids": [(3, self.manager.id)],
+                "manager_ids": [(4, self.manager.id)],
+            }
+        )
+        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+
+        # Remove manager, add as user to key - should read
+        ssh_key.write({"user_ids": [(4, self.manager.id)]})
+        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+
+        # Remove  user, add as manager to key - should read
+        ssh_key.write(
+            {"manager_ids": [(4, self.manager.id)], "user_ids": [(3, self.manager.id)]}
+        )
+        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+
+    def test_manager_read_secret(self):
+        """Test manager read access for secrets"""
+        Key = self.env["cx.tower.key"].with_user(self.manager)
+
+        # Create secret
+        secret = self.Key.create(
+            {
+                "name": "Test Secret",
+                "key_type": "s",
+                "secret_value": "test_secret",
+                "server_id": self.server_1.id,
+            }
+        )
+
+        # No access initially
+        self.assertFalse(Key.search([("id", "=", secret.id)]))
+
+        # Add as user - should read
+        self.server_1.write({"user_ids": [(4, self.manager.id)]})
+        self.assertTrue(Key.search([("id", "=", secret.id)]))
+
+        # Remove user, add as manager - should read
+        self.server_1.write(
+            {
+                "user_ids": [(3, self.manager.id)],
+                "manager_ids": [(4, self.manager.id)],
+            }
+        )
+        self.assertTrue(Key.search([("id", "=", secret.id)]))
+
+    def test_manager_write_ssh_key(self):
+        """Test manager write/create access for SSH keys"""
+        Key = self.env["cx.tower.key"].with_user(self.manager)
+
+        # Try create without server access - should fail
+        with self.assertRaises(AccessError):
+            Key.create(
+                {
+                    "name": "Manager SSH Key",
+                    "key_type": "k",
+                    "secret_value": "manager_key",
+                    "user_ids": [],
+                    "manager_ids": [],
+                }
+            )
+
+        # Add manager to server
+        self.server_test_1.write({"manager_ids": [(4, self.manager.id)]})
+
+        # Create SSH key and link to server - should succeed
+        ssh_key = Key.create(
+            {
+                "name": "Manager SSH Key",
+                "key_type": "k",
+                "secret_value": "manager_key",
+            }
+        ).with_context(show_secret_value=True)
+        self.server_test_1.write({"ssh_key_id": ssh_key.id})
+
+        # Write - should succeed
+        self.write_and_invalidate(ssh_key, **{"secret_value": "updated_key"})
+        self.assertEqual(ssh_key.secret_value, "updated_key")
+
+        # Remove manager from server and add as manager to key
+        # Should succeed
+        self.server_test_1.write({"manager_ids": [(3, self.manager.id)]})
+        ssh_key.write({"manager_ids": [(4, self.manager.id)]})
+        self.write_and_invalidate(ssh_key, **{"secret_value": "updated_key_2"})
+        self.assertEqual(ssh_key.secret_value, "updated_key_2")
+
+    def test_manager_write_secret(self):
+        """Test manager write/create access for secrets"""
+        Key = self.env["cx.tower.key"].with_user(self.manager)
+
+        # Add manager to server
+        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
+
+        # Create secret - should succeed
+        secret = Key.create(
+            {
+                "name": "Manager Secret",
+                "key_type": "s",
+                "secret_value": "manager_secret",
+                "server_id": self.server_1.id,
+            }
+        ).with_context(show_secret_value=True)
+        self.assertTrue(secret.exists())
+
+        # Write - should succeed
+        self.write_and_invalidate(secret, **{"secret_value": "updated_secret"})
+        self.assertEqual(secret.secret_value, "updated_secret")
+
+        # Try write to secret of another server - should fail
+        other_secret = self.Key.create(
+            {
+                "name": "Other Secret",
+                "key_type": "s",
+                "secret_value": "other_secret",
+                "server_id": self.server_2.id,
+            }
+        ).with_context(show_secret_value=True)
+        with self.assertRaises(AccessError):
+            other_secret.with_user(self.manager).write({"secret_value": "try_update"})
+
+    def test_manager_unlink(self):
+        """Test manager unlink access"""
+        # Add manager_2 to server first
+        self.server_test_1.write({"manager_ids": [(4, self.manager_2.id)]})
+
+        # Create keys as manager_2
+        Key = self.env["cx.tower.key"].with_user(self.manager_2)
+
+        # Create SSH key and link to server
+        ssh_key = Key.create(
+            {
+                "name": "Manager SSH Key",
+                "key_type": "k",
+                "secret_value": "manager_ssh_key",
+            }
+        )
+        self.server_test_1.write({"ssh_key_id": ssh_key.id})
+
+        # Create secret
+        secret = Key.create(
+            {
+                "name": "Manager Secret",
+                "key_type": "s",
+                "secret_value": "manager_secret",
+                "server_id": self.server_test_1.id,
+            }
+        )
+
+        # Try delete as different manager - should fail
+        self.server_test_1.write({"manager_ids": [(4, self.manager.id)]})
+        with self.assertRaises(AccessError):
+            ssh_key.with_user(self.manager).unlink()
+        with self.assertRaises(AccessError):
+            secret.with_user(self.manager).unlink()
+
+        # Delete own keys - should succeed
+        ssh_key.with_user(self.manager_2).unlink()
+        secret.with_user(self.manager_2).unlink()
+        self.assertFalse(ssh_key.exists())
+        self.assertFalse(secret.exists())
+
+    def test_root_access(self):
+        """Test root access"""
+        Key = self.env["cx.tower.key"].with_user(self.root)
+
+        # Create
+        ssh_key = Key.create(
+            {
+                "name": "Root SSH Key",
+                "key_type": "k",
+                "secret_value": "root_ssh_key",
+            }
+        )
+        secret = Key.create(
+            {
+                "name": "Root Secret",
+                "key_type": "s",
+                "secret_value": "root_secret",
+                "server_id": self.server_1.id,
+            }
+        )
+        self.assertTrue(ssh_key.exists())
+        self.assertTrue(secret.exists())
+
+        # Read
+        self.assertTrue(Key.search([]))
+
+        # Write
+        ssh_key.write({"secret_value": "updated_ssh_key"})
+        secret.write({"secret_value": "updated_secret"})
+        self.assertEqual(ssh_key.secret_value, "updated_ssh_key")
+        self.assertEqual(secret.secret_value, "updated_secret")
+
+        # Delete
+        ssh_key.unlink()
+        secret.unlink()
+        self.assertFalse(ssh_key.exists())
+        self.assertFalse(secret.exists())

--- a/cetmix_tower_server/views/cx_tower_key_view.xml
+++ b/cetmix_tower_server/views/cx_tower_key_view.xml
@@ -54,6 +54,26 @@
                                 </form>
                             </field>
                         </page>
+                        <page
+                            name="access"
+                            string="Access"
+                            groups="cetmix_tower_server.group_manager"
+                        >
+                            <group name="access">
+                                <field
+                                    name="user_ids"
+                                    widget="many2many_tags"
+                                    placeholder="users who can view this record"
+                                    options="{'no_create': True}"
+                                />
+                                <field
+                                    name="manager_ids"
+                                    widget="many2many_tags"
+                                    placeholder="managers who can modify this record"
+                                    options="{'no_create': True}"
+                                />
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
             </form>

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -273,6 +273,7 @@
                                     <field
                                         name="ssh_key_id"
                                         attrs="{'required': [('ssh_auth_mode', '=', 'k')]}"
+                                        context="{'default_key_type': 'k'}"
                                     />
                                 </group>
                                 <group name="extra">


### PR DESCRIPTION
Implement access rules for keys.
Check the task and documentation for more details.

Task: 4300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated version references and external resource links in project documentation and public pages to reflect the stable release.

- **New Features**
  - Introduced enhanced security configurations for key management.
  - Added a new "Access" page in the key management view for user and manager role assignments.

- **Refactor**
  - Improved secret handling and access permissions using a more flexible, context-based approach.
  - Added default context for `ssh_key_id` in the server view configuration.
  - Restricted user associations in file and server templates to specific user groups.

- **Tests**
  - Expanded test coverage to validate the updated access controls and command execution behavior, including new tests for user roles and permissions related to key management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->