### PR TITLE
[14.0][FIX] cetmix_tower_server: Create server from template

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -265,7 +265,13 @@ class CxTowerServerTemplate(models.Model):
         context.pop("default_server_template_id", None)
 
         # Create server
-        server = self.env["cx.tower.server"].with_context(context).create(server_values)
+        server = (
+            self.env["cx.tower.server"]
+            .sudo()
+            .with_context(context)
+            .create(server_values)
+            .sudo()
+        )
 
         # Add variable values
         if variable_values:
@@ -273,7 +279,7 @@ class CxTowerServerTemplate(models.Model):
 
         # Create server logs
         logs = server.server_log_ids.filtered(lambda rec: rec.log_type == "file")
-        for log in logs:
+        for log in logs.sudo():
             log.file_id = log.file_template_id.create_file(
                 server=server, raise_if_exists=False
             ).id


### PR DESCRIPTION
This PR fixes the following issue:
```
Error is raised if user doesn't have access to a file template used is Server Template logs.
```

Task: 4386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced server provisioning to reliably bypass permission restrictions, ensuring smoother operations.
  - Improved log access handling for a more robust execution in environments with limited permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->