### PR TITLE
[14.0][IMP] cetmix_tower_server: New system variables and YAML import updates

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_variable_mixin.py
@@ -171,8 +171,8 @@ class TowerVariableMixin(models.AbstractModel):
         Returns:
             dict(): `server` values of the `tower` variable.
         """
-        today = str(fields.Date.today())
-        now = str(fields.Datetime.now())
+        today = fields.Date.to_string(fields.Date.today())
+        now = fields.Datetime.to_string(fields.Datetime.now())
         values = {
             "uuid": uuid.uuid4(),
             "today": today,

--- a/cetmix_tower_yaml/models/cx_tower_command.py
+++ b/cetmix_tower_yaml/models/cx_tower_command.py
@@ -21,6 +21,8 @@ class CxTowerCommand(models.Model):
             "file_template_id",
             "flight_plan_id",
             "code",
+            "server_status",
             "variable_ids",
+            "secret_ids",
         ]
         return res

--- a/cetmix_tower_yaml/models/cx_tower_file_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_file_template.py
@@ -20,5 +20,6 @@ class CxTowerFileTemplate(models.Model):
             "note",
             "code",
             "variable_ids",
+            "secret_ids",
         ]
         return res

--- a/cetmix_tower_yaml/tests/test_command.py
+++ b/cetmix_tower_yaml/tests/test_command.py
@@ -29,7 +29,9 @@ flight_plan_id: false
 code: |-
   cd /home/{{ tower.server.ssh_username }} \\
   && ls -lha
+server_status: false
 variable_ids: false
+secret_ids: false
 """
 
         # YAML content translated into Python dict
@@ -253,7 +255,9 @@ path: false
 file_template_id: my_custom_test_template
 flight_plan_id: false
 code: false
+server_status: false
 variable_ids: false
+secret_ids: false
 """
         # Add file template
         file_template = self.env["cx.tower.file.template"].create(
@@ -311,9 +315,12 @@ file_template_id:
   note: Hey!
   code: false
   variable_ids: false
+  secret_ids: false
 flight_plan_id: false
 code: false
+server_status: false
 variable_ids: false
+secret_ids: false
 """
         command_with_template.invalidate_cache(["yaml_code"])
         self.assertEqual(

--- a/cetmix_tower_yaml/tests/test_file_template.py
+++ b/cetmix_tower_yaml/tests/test_file_template.py
@@ -30,6 +30,7 @@ code: |-
   # Let's go!
   USER odoo
 variable_ids: false
+secret_ids: false
 """  # noqa
 
         # Expected YAML content of the test file template

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -1,5 +1,7 @@
 import base64
 
+import yaml
+
 from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase
@@ -361,3 +363,101 @@ class TestTowerYamlImportWizUpload(TransactionCase):
                 new_server_template.server_log_ids,
                 "New Server Log must be created instead of updating existing one",
             )
+
+    def test_extract_secret_names(self):
+        """Test extract secret names from YAML data"""
+
+        # NB: this is not a real model, it's just for testing
+        yaml_code = """cetmix_tower_yaml_version: 1
+cetmix_tower_model: test_model
+access_level: manager
+reference: such_much_test_record
+name: Such Much Command
+action: file_using_template
+allow_parallel_run: false
+note: Just a note
+os_ids: false
+tag_ids: false
+path: false
+ssh_key_id:
+  reference: test_ssh_key
+  name: Test SSH Key
+  key_type: k
+  note: false
+record_with_the_same_ssh_key:
+  reference: such_much_test_record_2
+  name: Such Much Test Record 2
+  note: Just a note 2
+  ssh_key_id:
+    reference: test_ssh_key
+    name: Test SSH Key
+    key_type: k
+    note: false
+    secret_ids:
+    - reference: secret_2
+      name: Secret 2
+      key_type: s
+      note: false
+    - reference: secret_3
+      name: Secret 3
+      key_type: s
+      note: false
+record_with_another_ssh_key:
+  reference: such_much_test_record_3
+  name: Such Much Test Record 3
+  note: Just a note 3
+  ssh_key_id:
+    reference: another_ssh_key
+    name: Another SSH Key
+  sub_record:
+    reference: such_much_test_record_4
+    name: Such Much Test Record 4
+    note: Just a note 4
+    secret_ids:
+    - reference: secret_1
+      name: Secret 3
+      key_type: s
+      note: false
+    - reference: secret_2
+      name: Secret 4
+      key_type: s
+      note: false
+file_template_id:
+  reference: my_custom_test_template
+  name: Such much demo
+  source: tower
+  file_type: text
+  server_dir: /var/log/my/files
+  file_name: much_logs.txt
+  keep_when_deleted: false
+  tag_ids: false
+  note: Hey!
+  code: false
+  variable_ids: false
+  secret_ids: false
+flight_plan_id: false
+code: false
+variable_ids: false
+secret_ids:
+- reference: secret_1
+  name: Secret 1
+  key_type: s
+  note: false
+- reference: secret_2
+  name: Secret 2
+  key_type: s
+  note: false
+"""
+        secret_list = self.env["cx.tower.yaml.import.wiz"]._extract_secret_names(
+            yaml.safe_load(yaml_code)
+        )
+        # We expect 6 secrets in the list:
+        # 2 keys: 'Test SSH Key', 'Another SSH Key'
+        # 4 secrets: 'Secret 3', 'Secret 4', 'Secret 1', 'Secret 2'
+        self.assertEqual(len(secret_list), 6, "Secret list length is not correct")
+        self.assertIn("Test SSH Key", secret_list, "Key is not in the list")
+        self.assertIn("Another SSH Key", secret_list, "Key is not in the list")
+        self.assertIn("Secret 3", secret_list, "Key is not in the list")
+        self.assertIn("Secret 4", secret_list, "Key is not in the list")
+        self.assertIn("Secret 1", secret_list, "Key is not in the list")
+        self.assertIn("Secret 2", secret_list, "Key is not in the list")

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -1,6 +1,6 @@
 import yaml
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class CxTowerYamlImportWiz(models.TransientModel):
@@ -21,12 +21,31 @@ class CxTowerYamlImportWiz(models.TransientModel):
         help="If enabled, existing records will be updated with the new data."
         " Otherwise, new records will be created.",
     )
+    secret_list = fields.Char(
+        readonly=True,
+        help="List of secrets present in the YAML file",
+        compute="_compute_secret_list",
+    )
 
     @api.depends("model_name")
     def _compute_model_description(self):
         """Compute model description"""
         for record in self:
             record.model_description = self.env[record.model_name]._description
+
+    @api.depends("yaml_code")
+    def _compute_secret_list(self):
+        """Compute list of secrets present in the YAML file"""
+        for record in self:
+            secret_list = self._extract_secret_names(yaml.safe_load(record.yaml_code))
+            if secret_list:
+                record.secret_list = _(
+                    "After import, please check and provide secret values"
+                    " if needed for the following secrets: %(secrets)s",
+                    secrets=", ".join(secret_list),
+                )
+            else:
+                record.secret_list = False
 
     def action_import_yaml(self):
         """Process YAML data and create records in Odoo"""
@@ -77,3 +96,37 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 "view_type": "form",
                 "target": "current",
             }
+
+    def _extract_secret_names(self, data: dict) -> list:
+        """Extract names of secrets from YAML data.
+
+        Args:
+            data (dict): YAML data.
+
+        Returns:
+            list: List of unique secret names.
+        """
+        secret_names = set()
+
+        def _recursive_extract(node):
+            """Recursively extract secret names from nested structures."""
+            if isinstance(node, dict):
+                if "secret_ids" in node and isinstance(node["secret_ids"], list):
+                    for item in node["secret_ids"]:
+                        if isinstance(item, dict) and "name" in item:
+                            secret_names.add(item["name"])
+
+                if "ssh_key_id" in node and isinstance(node["ssh_key_id"], dict):
+                    if "name" in node["ssh_key_id"]:
+                        secret_names.add(node["ssh_key_id"]["name"])
+
+                # Recursively process the rest of the dictionary
+                for value in node.values():
+                    _recursive_extract(value)
+
+            elif isinstance(node, list):
+                for item in node:
+                    _recursive_extract(item)
+
+        _recursive_extract(data)
+        return list(secret_names)

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
@@ -48,6 +48,10 @@
                     />
                 </group>
                 <field
+                    name="secret_list"
+                    attrs="{'invisible': [('secret_list', '=', False)]}"
+                />
+                <field
                     name="yaml_code"
                     widget="ace"
                     options="{'mode': 'yaml'}"


### PR DESCRIPTION
## Cetmix Tower

Currently {{ tower.tools.now }} with return date as date time string, eg '2025-02-28 21:58:31'.
Such string is not so usable inline because it contains various symbols including spaces.
Same story with the {{ tower.tools.date }} variable.

Add new system variables:

- {{ tower.tools.now_underscore }}
- {{ tower.tools.today_underscore }}

They return date and datetime values with underscores as separators. Eg '2025_02_28_21_58_31'.

## Cetmix Tower YAML

Export related secrets in order to recreate them on import.
NB: secret value is not exported.
Show list of secrets used in code in order to make user aware of possible actions (add secret value manually).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - YAML exports now include additional `secret_ids` and `server_status` fields, expanding configuration options.
  - The YAML Import Wizard has been enhanced with a computed field that displays a list of secrets extracted from imported data.
  - A new field for `secret_list` has been added to the import wizard form, which is conditionally visible.

- **Bug Fixes**
  - Improved date and datetime formatting in the system variable tools.

- **Tests**
  - Added tests for the extraction of secret names from YAML data structures.
  - Updated test cases to include the new `secret_ids` and `server_status` fields in expected YAML outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->