### PR TITLE
[14.0][FIX] cetmix_tower_server: File access rules

### DIFF
--- a/cetmix_tower_server/security/cx_tower_file_security.xml
+++ b/cetmix_tower_server/security/cx_tower_file_security.xml
@@ -13,14 +13,14 @@
     </record>
 
     <!-- Manager: Write and Create access rule: Allow update and creation when current user is in related Server's manager_ids -->
-    <record id="rule_cx_tower_file_group_manager_write" model="ir.rule">
+    <record id="rule_cx_tower_file_group_manager_read_write" model="ir.rule">
         <field
             name="name"
         >File: Manager write &amp; create via related server (manager_ids)</field>
         <field name="model_id" ref="model_cx_tower_file" />
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="domain_force">[('server_id.manager_ids', 'in', [user.id])]</field>
-        <field name="perm_read" eval="0" />
+        <field name="perm_read" eval="1" />
         <field name="perm_write" eval="1" />
         <field name="perm_create" eval="1" />
         <field name="perm_unlink" eval="0" />


### PR DESCRIPTION
Manager cannot read files if added only to "Managers" in the related server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Managers now have enhanced file access, with the ability to read files added to their existing write and create permissions. This update provides a more balanced and comprehensive file management experience for users with manager-level privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->