### PR TITLE
[14.0][IMP] cetmix_tower_server: use checkbox for sudo mode

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -852,13 +852,10 @@ class CxTowerServer(models.Model):
             )
 
         # Populate `sudo` value from the server settings if not provided explicitly
-        if sudo is None:
-            if self.sudo().ssh_username != "root" and self.sudo().use_sudo:
-                sudo = self.sudo().use_sudo
-
-        # Disable `sudo` if user is root
-        elif sudo and self.sudo().ssh_username == "root":
-            sudo = None
+        if self.sudo().ssh_username == "root":
+            sudo = False
+        elif sudo is None or sudo:
+            sudo = self.sudo().use_sudo
 
         # Check if no log record should be created
 

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -688,6 +688,7 @@ COMMAND_RESULT = {
         # Check with all available "sudo" option
         for sudo in [False, "n", "p"]:
             # Add label to track command log
+            self.server_test_1.use_sudo = sudo
             command_label = f"Test Command {x}"
             custom_values = {"log": {"label": command_label}}
 

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard.py
@@ -44,10 +44,10 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
         column2="tag_id",
         string="Tags",
     )
-    use_sudo = fields.Selection(
+    use_sudo = fields.Boolean(
         string="Use sudo",
-        selection=[("n", "Sudo without password"), ("p", "Sudo with password")],
-        help="Run commands using 'sudo'",
+        help="Will use sudo based on server settings."
+        "If no sudo is configured will run without sudo",
     )
     code = fields.Text(compute="_compute_code", readonly=False, store=True)
     applicability = fields.Selection(
@@ -177,7 +177,6 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
 
     def execute_command_on_server(self):
         """Render selected command rendered using server method"""
-
         # Check if command is selected
         if not self.command_id:
             raise ValidationError(_("Please select a command to execute"))
@@ -272,7 +271,7 @@ class CxTowerCommandExecuteWizard(models.TransientModel):
                     server._get_ssh_client(raise_on_error=True),
                     self.rendered_code,
                     self.path or None,
-                    sudo=self.use_sudo if self.use_sudo else None,
+                    sudo=self.use_sudo,
                     **kwargs,
                 )
             command_error = command_result["error"]

--- a/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_execute_wizard_view.xml
@@ -52,10 +52,12 @@
                     <div class="o_row" attrs="{'invisible': [('result', '!=', False)]}">
 
                         <field name="action" nolabel="1" />
+                        <span
+                            attrs="{'invisible': [('action', '!=', 'ssh_command')]}"
+                        >sudo</span>
                         <field
                             name="use_sudo"
-                            attrs="{'invisible': [('action', '=', 'python_code')]}"
-                            placeholder="No sudo"
+                            attrs="{'invisible': [('action', '!=', 'ssh_command')]}"
                         />
                         <field
                             name="command_id"


### PR DESCRIPTION
Replace the sudo selector with a checkbox in the command wizard to ensure the sudo mode is determined by the server settings. This change avoids mismatches between the user selection and server configuration by validating the sudo mode before command execution.

Task: 4403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the handling of elevated privileges during command execution, ensuring they now follow the server’s configured settings.
  - Updated the command execution interface with a streamlined on/off option for elevated privileges and conditional display of status labels based on the selected command action.
- **Bug Fixes**
  - Simplified the logic for determining the use of `sudo` permissions, improving command execution flow.
- **Documentation**
  - Updated help text for the `use_sudo` field to clarify its dependency on server settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->