### PR TITLE
[14.0][IMP][BREAKING] cx_tower_server: Refactor secrets

### DIFF
--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -17,7 +17,7 @@ Cetmix Tower Server Management
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
-    :target: https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server
+    :target: https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server
     :alt: cetmix/cetmix-tower
 
 |badge1| |badge2| |badge3|
@@ -836,8 +836,8 @@ command or ``Path`` field in flight plan line.
 
    cat my_doge_memes.txt
 
-.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png
-.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png
+.. |User profile| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png
+.. |Server logs tab| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png
 
 Usage
 =====
@@ -1002,9 +1002,9 @@ are located in a special abstract model "cetmix.tower". You can check
 those functions in the source code in the following file:
 ``models/cetmix_tower.py``
 
-.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
-.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png
-.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png
+.. |Automatic action| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png
+.. |Open server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png
+.. |Update server log| image:: https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png
 
 Bug Tracker
 ===========
@@ -1012,7 +1012,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/cetmix/cetmix-tower/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -1027,6 +1027,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server>`_ project on GitHub.
+This module is part of the `cetmix/cetmix-tower <https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Cetmix Tower Server Management",
     "summary": "Flexible Server Management directly from Odoo",
-    "version": "14.0.0.4.16",
+    "version": "14.0.0.4.17",
     "category": "Productivity",
     "website": "https://cetmix.com",
     "author": "Cetmix",
@@ -35,6 +35,7 @@
         "security/cx_tower_variable_value_security.xml",
         "security/cx_tower_variable_option_security.xml",
         "security/cx_tower_key_security.xml",
+        "security/cx_tower_key_value_security.xml",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",
         "wizards/cx_tower_command_execute_wizard_view.xml",

--- a/cetmix_tower_server/migrations/14.0.0.4.17/post-migration.py
+++ b/cetmix_tower_server/migrations/14.0.0.4.17/post-migration.py
@@ -1,0 +1,69 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """
+    Convert all partner and server related keys to secret values
+    """
+    _logger.info("Starting SQL migration for partner and server related keys.")
+
+    # Get all keys that are related to a server or a partner
+    cr.execute(
+        """
+        SELECT k.id, k.reference, k.secret_value, k.server_id, k.partner_id
+        FROM cx_tower_key k
+        WHERE k.key_type = 's'
+        AND (k.server_id IS NOT NULL OR k.partner_id IS NOT NULL)
+    """
+    )
+    keys_to_merge = cr.fetchall()
+
+    for key_id, reference, secret_value, server_id, partner_id in keys_to_merge:
+        # Find or use current key as main key
+        cr.execute(
+            """
+            SELECT id FROM cx_tower_key
+            WHERE reference = %s AND server_id IS NULL AND partner_id IS NULL
+            LIMIT 1
+        """,
+            (reference,),
+        )
+        main_key = cr.fetchone()
+        main_key_id = main_key[0] if main_key else key_id
+
+        # Create key value
+        cr.execute(
+            """
+            INSERT INTO cx_tower_key_value
+            (key_id, server_id, partner_id, secret_value,
+            create_uid, create_date, write_uid, write_date)
+            VALUES (%s, %s, %s, %s, 1, now(), 1, now())
+        """,
+            (main_key_id, server_id, partner_id, secret_value),
+        )
+
+    # Remove migrated keys that don't have values
+    cr.execute(
+        """
+        DELETE FROM cx_tower_key k
+        WHERE k.key_type = 's'
+        AND (k.server_id IS NOT NULL OR k.partner_id IS NOT NULL)
+        AND NOT EXISTS (
+            SELECT 1 FROM cx_tower_key_value v WHERE v.key_id = k.id
+        )
+    """
+    )
+
+    # Recompute all computed fields
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    model = env["cx.tower.key"]
+    env.add_to_compute(
+        model._fields["secret_value"], model.search([("key_type", "=", "s")])
+    )
+    model.recompute()
+
+    _logger.info("SQL migration completed successfully.")

--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -15,6 +15,7 @@ from . import cx_tower_os
 from . import cx_tower_tag
 from . import cx_tower_command
 from . import cx_tower_key
+from . import cx_tower_key_value
 from . import cx_tower_command_log
 from . import cx_tower_plan
 from . import cx_tower_plan_line

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -183,17 +183,6 @@ class CxTowerCommand(models.Model):
         """
         return ["code", "path"]
 
-    # Depend on related servers and partners
-    @api.depends(
-        "code",
-        "server_ids",
-        "server_ids.partner_id",
-        "secret_ids.server_id",
-        "secret_ids.partner_id",
-    )
-    def _compute_secret_ids(self):
-        return super()._compute_secret_ids()
-
     @api.depends("action")
     def _compute_code(self):
         """
@@ -255,16 +244,3 @@ class CxTowerCommand(models.Model):
         )
         action["domain"] = [("command_id", "=", self.id)]
         return action
-
-    def _compose_secret_search_domain(self, key_refs):
-        # Check server anb partner specific secrets
-        return [
-            ("reference", "in", key_refs),
-            "|",
-            "|",
-            ("server_id", "in", self.server_ids.ids),
-            ("partner_id", "in", self.server_ids.partner_id.ids),
-            "&",
-            ("server_id", "=", False),
-            ("partner_id", "=", False),
-        ]

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -1,10 +1,7 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import re
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
-from odoo.osv.expression import OR
+from odoo import api, fields, models
 
 
 class CxTowerKey(models.Model):
@@ -30,21 +27,23 @@ class CxTowerKey(models.Model):
         compute="_compute_reference_code",
         help="Key reference for inline usage",
     )
-    secret_value = fields.Text(string="SSH Private Key")
+    secret_value = fields.Text(
+        string="SSH Private Key",
+        compute="_compute_secret_value",
+        inverse="_inverse_secret_value",
+        store=True,
+    )
+    value_ids = fields.One2many(
+        string="Values",
+        comodel_name="cx.tower.key.value",
+        inverse_name="key_id",
+    )
     server_ssh_ids = fields.One2many(
         string="Used as SSH Key",
         comodel_name="cx.tower.server",
         inverse_name="ssh_key_id",
         readonly=True,
         help="Used as SSH key in the following servers",
-    )
-    server_id = fields.Many2one(
-        comodel_name="cx.tower.server",
-        help="Used for selected server only. Leave blank to use globally",
-        ondelete="cascade",
-    )
-    partner_id = fields.Many2one(
-        comodel_name="res.partner", help="Leave blank to use for any partner"
     )
     note = fields.Text()
 
@@ -58,50 +57,6 @@ class CxTowerKey(models.Model):
     manager_ids = fields.Many2many(
         relation="cx_tower_key_manager_rel",
     )
-
-    def init(self):
-        """
-        Remove constraint defined from the mixin
-        """
-        self._cr.execute(
-            """
-            DO $$
-            BEGIN
-                IF EXISTS (
-                    SELECT 1
-                    FROM information_schema.table_constraints
-                    WHERE table_name = 'cx_tower_key' AND
-                    constraint_name = 'cx_tower_key_reference_unique'
-                ) THEN
-                    ALTER TABLE cx_tower_key
-                    DROP CONSTRAINT cx_tower_key_reference_unique;
-                END IF;
-            END$$;
-            """
-        )
-
-    @api.constrains("reference", "partner_id", "server_id")
-    def _check_reference_unique(self):
-        """ORM constraint to ensure uniqueness"""
-
-        # Need to check archive records as well
-        for rec in self.with_context(active_test=False):
-            if (
-                self.search_count(
-                    [
-                        ("reference", "=", rec.reference),
-                        ("partner_id", "=", rec.partner_id.id),
-                        ("server_id", "=", rec.server_id.id),
-                    ]
-                )
-                > 1
-            ):
-                raise ValidationError(
-                    _(
-                        "Reference must be unique for the combination of partner"
-                        " and server"
-                    )
-                )
 
     def _compute_reference_code(self):
         """Compute key reference
@@ -117,135 +72,46 @@ class CxTowerKey(models.Model):
             else:
                 rec.reference_code = None
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        """
-        Overrides create to ensure 'reference' is auto-corrected
-        or validated for each record.
+    @api.depends(
+        "key_type",
+        "value_ids",
+        "value_ids.secret_value",
+        "value_ids.server_id",
+        "value_ids.partner_id",
+    )
+    def _compute_secret_value(self):
+        for rec in self.with_context(show_secret_value=True):
+            if rec.key_type == "s":
+                # General value
+                general_value = rec.value_ids.filtered(lambda x: not x.server_id)
+                if general_value:
+                    rec.secret_value = general_value[0].secret_value
+                else:
+                    rec.secret_value = None
 
-        Args:
-            vals_list (list[dict]): List of dictionaries with record values.
-
-        Returns:
-            Records: The created record(s).
-        """
-        for vals in vals_list:
-            # Remove leading and trailing whitespaces from name
-            vals_name = vals.get("name")
-            name = vals_name.strip() if vals_name else vals_name
-
-            # Remove leading and trailing whitespaces from reference
-            vals_reference = vals.get("reference")
-            reference = vals_reference.strip() if vals_reference else vals_reference
-
-            # Nothing can be done if no name or reference is provided
-            if not name and not reference:
-                continue
-
-            # Update the 'name' with the cleaned one
-            if name != vals_name:
-                vals.update({"name": name})
-
-            # Generate reference
-            reference = self._generate_or_fix_reference(
-                reference or name,
-                vals.get("partner_id"),
-                vals.get("server_id"),
-            )
-            vals.update({"reference": reference})
-        return super(
-            CxTowerKey, self.with_context(reference_mixin_override=True)
-        ).create(vals_list)
-
-    def write(self, vals):
-        """
-        Updates record, auto-correcting or validating 'reference'
-        based on 'name' or existing value.
-
-        Args:
-            vals (dict): Values to update, may include 'reference'.
-
-        Returns:
-            Result of the super `write` call.
-        """
-        if "reference" in vals:
-            reference = vals.get("reference", vals.get("name"))
-            server_id = vals.get("server_id")
-            partner_id = vals.get("partner_id")
-            for record in self:
-                record_vals = vals.copy()
-                record_vals.update(
-                    {
-                        "reference": self._generate_or_fix_reference(
-                            reference or record.name,
-                            partner_id or record.partner_id.id
-                            if record.partner_id
-                            else None,
-                            server_id or record.server_id.id
-                            if record.server_id
-                            else None,
-                        )
-                    }
+    def _inverse_secret_value(self):
+        key_value_obj = self.env["cx.tower.key.value"]
+        for rec in self.with_context(show_secret_value=True):
+            if rec.key_type == "s" and rec.secret_value:
+                # General value
+                general_value = rec.value_ids.filtered(
+                    lambda x: not x.server_id and not x.partner_id and x.id
                 )
-                super(
-                    CxTowerKey, record.with_context(reference_mixin_override=True)
-                ).write(record_vals)
-                return
-        return super().write(vals)
+                if general_value:
+                    general_value.secret_value = rec.secret_value
+                else:
+                    key_value_obj.create(
+                        {
+                            "key_id": rec.id,
+                            "secret_value": rec.secret_value,
+                        }
+                    )
 
     def _get_reference_pattern(self):
         """
         Override mixin method
         """
         return "[a-zA-Z0-9_]"
-
-    def _generate_or_fix_reference(
-        self, reference_source, partner_id=False, server_id=False
-    ):
-        """Generate a new reference of fix an existing one.
-
-
-        Args:
-            reference_source (Char): original reference
-            partner_id (Int, optional): partner id of the key. Defaults to False.
-            server_id (bool, optional): server id of the key. Defaults to False.
-
-        Returns:
-            str: Generated or fixed reference.
-        """
-        # Check if reference matches the pattern
-        reference_pattern = self._get_reference_pattern()
-
-        if re.fullmatch(rf"{reference_pattern}+", reference_source):
-            reference = reference_source
-
-        # Fix reference if it doesn't match
-        else:
-            # Modify the pattern to be used in `sub`
-            inner_pattern = reference_pattern[1:-1]
-            reference = re.sub(
-                rf"[^{inner_pattern}]",
-                "",
-                reference_source.strip().replace(" ", "_").lower(),
-            )
-
-        # Check if the same reference already exists and add a suffix if yes
-        counter = 1
-        final_reference = reference
-        while (
-            self.search_count(
-                [
-                    ("reference", "=", final_reference),
-                    ("partner_id", "=", partner_id),
-                    ("server_id", "=", server_id),
-                ]
-            )
-            > 0
-        ):
-            counter += 1
-            final_reference = _(f"{reference}_{counter}")
-
-        return final_reference
 
     def _compose_key_prefix(self, key_type):
         """Compose key prefix based on key type.
@@ -461,58 +327,60 @@ class CxTowerKey(models.Model):
         # Compose domain used to fetch keys
         #
         # Keys are checked in the following order:
-        # 1. Server specific
-        # 2. Partner specific
-        # 3. General (no server or partner specified)
+        # 1. Partner and Server specific
+        # 2. Server specific
+        # 3. Partner specific
+        # 4. General (no server or partner specified)
         server_id = kwargs.get("server_id")
         partner_id = kwargs.get("partner_id")
 
-        key_domain = [
-            ("reference", "=", reference),
-            ("server_id", "=", False),
-            ("partner_id", "=", False),
-        ]
-
-        if server_id:
-            key_domain = OR(
-                [
-                    key_domain,
-                    [("reference", "=", reference), ("server_id", "=", server_id)],
-                ]
-            )
-        if partner_id:
-            key_domain = OR(
-                [
-                    key_domain,
-                    [("reference", "=", reference), ("partner_id", "=", partner_id)],
-                ]
-            )
-
-        # Fetch keys
-        keys = self.sudo().search(key_domain)
-        if not keys:
+        # Fetch key
+        key = self.sudo().search([("reference", "=", reference)], limit=1)
+        if not key:
             return
 
-        # Try to get server specific key first
-        key = False
-        if server_id:
-            key = keys.filtered(lambda k: k.server_id.id == server_id)
+        # Check if key has custom values
+        key_values = key.value_ids
+        key_value = None
 
-        # Try to get partner specific key next
-        if not key and partner_id:
-            key = keys.filtered(lambda k: k.partner_id.id == partner_id)
+        # 1. Server and Partner specific key first
+        if key_values and server_id and partner_id:
+            filtered_key_values = key_values.filtered(
+                lambda k: k.server_id.id == server_id and k.partner_id.id == partner_id
+            )
+            if filtered_key_values:
+                key_value = filtered_key_values[0]
 
-        if not key:
-            # Fallback to a global key
-            key = keys
+        # 2. Server specific key first
+        if not key_value and key_values and server_id:
+            filtered_key_values = key_values.filtered(
+                lambda k: k.server_id.id == server_id and not k.partner_id
+            )
+            if filtered_key_values:
+                key_value = filtered_key_values[0]
 
-        # Read the first key secret value. Use context to show secret value
-        key_value = (
-            key.with_context(show_secret_value=True)
-            .read(["secret_value"])[0]
-            .get("secret_value")
-        )
-        return key_value
+        # 3. Partner specific key next
+        if not key_value and key_values and partner_id:
+            filtered_key_values = key_values.filtered(
+                lambda k: k.partner_id.id == partner_id and not k.server_id
+            )
+            if filtered_key_values:
+                key_value = filtered_key_values[0]
+
+        # 4. General key next
+        if not key_value and key_values:
+            filtered_key_values = key_values.filtered(
+                lambda k: not k.partner_id and not k.server_id
+            )
+            if filtered_key_values:
+                key_value = filtered_key_values[0]
+
+        if key_value:
+            return (
+                key_value.with_context(show_secret_value=True)
+                .read(["secret_value"])[0]
+                .get("secret_value")
+            )
 
     def _replace_with_spoiler(self, code, key_values):
         """Helper function that replaces clean text keys in code with spoiler.

--- a/cetmix_tower_server/models/cx_tower_key_value.py
+++ b/cetmix_tower_server/models/cx_tower_key_value.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class CxTowerKeyValue(models.Model):
+    """Key value storage"""
+
+    _name = "cx.tower.key.value"
+    _description = "Cetmix Tower key-value storage"
+
+    key_id = fields.Many2one(
+        comodel_name="cx.tower.key",
+        string="Key",
+        required=True,
+        ondelete="cascade",
+    )
+    server_id = fields.Many2one(
+        comodel_name="cx.tower.server",
+        ondelete="cascade",
+        help="Server to which the key belongs",
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        ondelete="cascade",
+        help="Partner to which the key belongs",
+    )
+    is_global = fields.Boolean(
+        string="Global",
+        compute="_compute_is_global",
+        help="This value is applicable to all servers and partners",
+    )
+    secret_value = fields.Text(string="Secret Value")
+
+    @api.constrains("key_id", "server_id", "partner_id")
+    def _check_key_id(self):
+        for rec in self:
+            if not rec.key_id:
+                continue
+            # Only keys of type 'secret' can have custom secret values
+            if rec.key_id.key_type != "s":
+                raise ValidationError(
+                    _(
+                        "Custom secret values can be defined"
+                        " only for key type 'secret'"
+                    )
+                )
+            # Only one global secret value can be defined for a key
+            global_values = rec.key_id.value_ids.filtered(
+                lambda x, rec=rec: not x.server_id and not x.partner_id
+            )
+            if len(global_values) > 1:
+                raise ValidationError(
+                    _("Only one global secret value can be defined for a key")
+                )
+            # Only one secret value can be defined for a server and partner
+            server_partner_values = rec.key_id.value_ids.filtered(
+                lambda x, rec=rec: x.server_id == rec.server_id
+                and x.partner_id == rec.partner_id
+            )
+            if len(server_partner_values) > 1:
+                raise ValidationError(
+                    _(
+                        "Only one secret value can be defined"
+                        " for a server and partner"
+                    )
+                )
+            # Only one secret value can be defined for a server
+            server_values = rec.key_id.value_ids.filtered(
+                lambda x, rec=rec: x.server_id == rec.server_id and not x.partner_id
+            )
+            if len(server_values) > 1:
+                raise ValidationError(
+                    _("Only one secret value can be defined for a server")
+                )
+            # Only one secret value can be defined for a partner
+            partner_values = rec.key_id.value_ids.filtered(
+                lambda x, rec=rec: x.partner_id == rec.partner_id and not x.server_id
+            )
+            if len(partner_values) > 1:
+                raise ValidationError(
+                    _("Only one secret value can be defined for a partner")
+                )
+
+    @api.depends("server_id", "partner_id")
+    def _compute_is_global(self):
+        for secret_value in self:
+            secret_value.is_global = (
+                not secret_value.server_id and not secret_value.partner_id
+            )
+
+    def _read(self, fields):
+        """Substitute fields based on api"""
+        super()._read(fields)
+        if not self.env.context.get("show_secret_value") and (
+            "secret_value" in fields or fields == []
+        ):
+            placeholder = self.env["cx.tower.key"].SECRET_VALUE_PLACEHOLDER
+            # Public user used for substitution
+            for record in self:
+                try:
+                    record._cache["secret_value"] = placeholder
+                except Exception:
+                    # skip SpecialValue
+                    # (e.g. for missing record or access right)
+                    pass

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -158,9 +158,8 @@ class CxTowerServer(models.Model):
     # ---- Keys
     secret_ids = fields.One2many(
         string="Secrets",
-        comodel_name="cx.tower.key",
+        comodel_name="cx.tower.key.value",
         inverse_name="server_id",
-        domain=[("key_type", "=", "s")],
         groups="cetmix_tower_server.group_manager",
     )
 

--- a/cetmix_tower_server/security/cx_tower_key_security.xml
+++ b/cetmix_tower_server/security/cx_tower_key_security.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <!-- Manager Read Rules -->
-    <record id="rule_tower_key_manager_read_any_type" model="ir.rule">
-        <field name="name">Tower Key: Manager Read Assigned Secrets</field>
+    <record id="rule_key_manager_read_users" model="ir.rule">
+        <field name="name">Key: Manager Read Access - Users/Managers</field>
         <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">['|',
-            ('user_ids', 'in', [user.id]),
-            ('manager_ids', 'in', [user.id])
-        ]</field>
+        <field
+            name="domain_force"
+        >['|', ('user_ids', 'in', [user.id]), ('manager_ids', 'in', [user.id])]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="perm_read" eval="1" />
         <field name="perm_write" eval="0" />
@@ -16,8 +14,19 @@
         <field name="perm_unlink" eval="0" />
     </record>
 
-    <record id="rule_tower_key_manager_read_ssh" model="ir.rule">
-        <field name="name">Tower Key: Manager Read SSH Keys</field>
+    <record id="rule_key_manager_read_secret" model="ir.rule">
+        <field name="name">Key: Manager Read Access - Secret Type</field>
+        <field name="model_id" ref="model_cx_tower_key" />
+        <field name="domain_force">[('key_type', '=', 's')]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_key_manager_read_ssh" model="ir.rule">
+        <field name="name">Key: Manager Read Access - SSH Key</field>
         <field name="model_id" ref="model_cx_tower_key" />
         <field name="domain_force">[('key_type', '=', 'k'), '|',
             ('server_ssh_ids.user_ids', 'in', [user.id]),
@@ -29,37 +38,22 @@
         <field name="perm_unlink" eval="0" />
     </record>
 
-    <record id="rule_tower_key_manager_read_secret" model="ir.rule">
-        <field name="name">Tower Key: Manager Read Secrets</field>
-        <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">[('key_type', '=', 's'), '|',
-            ('server_id.user_ids', 'in', [user.id]),
-            ('server_id.manager_ids', 'in', [user.id])]</field>
-        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_unlink" eval="0" />
-    </record>
-
-
     <!-- Manager Write/Create Rules -->
-    <record id="rule_tower_key_manager_write_any_type" model="ir.rule">
-        <field name="name">Tower Key: Manager Write/Create</field>
+    <record id="rule_key_manager_write_managers" model="ir.rule">
+        <field name="name">Key: Manager Write/Create Access - Managers</field>
         <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">[
-            ('manager_ids', 'in', [user.id])
-        ]</field>
+        <field name="domain_force">[('manager_ids', 'in', [user.id])]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_write" eval="1" />
         <field name="perm_create" eval="1" />
         <field name="perm_unlink" eval="0" />
+    </record>
 
-    </record><record id="rule_tower_key_manager_write_ssh" model="ir.rule">
-        <field name="name">Tower Key: Manager Write/Create SSH Keys</field>
+    <record id="rule_key_manager_write_ssh" model="ir.rule">
+        <field name="name">Key: Manager Write/Create Access - SSH Key</field>
         <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">[('key_type', '=', 'k'),
+        <field name="domain_force">['&amp;', ('key_type', '=', 'k'),
             ('server_ssh_ids.manager_ids', 'in', [user.id])]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="perm_read" eval="0" />
@@ -68,26 +62,26 @@
         <field name="perm_unlink" eval="0" />
     </record>
 
-    <record id="rule_tower_key_manager_write_secret" model="ir.rule">
-        <field name="name">Tower Key: Manager Write/Create Secrets</field>
+    <!-- Manager Delete Rules -->
+    <record id="rule_key_manager_unlink_managers" model="ir.rule">
+        <field name="name">Key: Manager Delete Access - Managers</field>
         <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">[('key_type', '=', 's'),
-            ('server_id.manager_ids', 'in', [user.id])]</field>
+        <field
+            name="domain_force"
+        >[('manager_ids', 'in', [user.id]), ('create_uid', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="perm_read" eval="0" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_unlink" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="1" />
     </record>
 
-    <!-- Manager Delete Rules -->
-    <record id="rule_tower_key_manager_unlink_any_type" model="ir.rule">
-        <field name="name">Tower Key: Manager Delete</field>
+    <record id="rule_key_manager_unlink_ssh" model="ir.rule">
+        <field name="name">Key: Manager Delete Access - SSH Key</field>
         <field name="model_id" ref="model_cx_tower_key" />
-        <field name="domain_force">[
-            ('manager_ids', 'in', [user.id]),
-            ('create_uid', '=', user.id)]
-        </field>
+        <field name="domain_force">[('key_type', '=', 'k'),
+            ('server_ssh_ids.manager_ids', 'in', [user.id]),
+            ('create_uid', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_write" eval="0" />
@@ -96,15 +90,10 @@
     </record>
 
     <!-- Root Access Rule -->
-    <record id="rule_tower_key_root" model="ir.rule">
-        <field name="name">Tower Key: Root Full Access</field>
+    <record id="rule_key_root" model="ir.rule">
+        <field name="name">Key: Root Full Access</field>
         <field name="model_id" ref="model_cx_tower_key" />
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_root'))]" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_unlink" eval="1" />
     </record>
-
 </odoo>

--- a/cetmix_tower_server/security/cx_tower_key_value_security.xml
+++ b/cetmix_tower_server/security/cx_tower_key_value_security.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Manager Read Rules -->
+    <record id="rule_key_value_manager_read_key" model="ir.rule">
+        <field name="name">Key Value: Manager Read Access - Key Users/Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field
+            name="domain_force"
+        >['|', ('key_id.user_ids', 'in', [user.id]), ('key_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_key_value_manager_read_server" model="ir.rule">
+        <field
+            name="name"
+        >Key Value: Manager Read Access - Server Users/Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field name="domain_force">[('key_id.key_type', '=', 's'),
+            '|', '|', ('server_id', '=', False),
+            ('server_id.user_ids', 'in', [user.id]),
+            ('server_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <!-- Manager Write/Create Rules -->
+    <record id="rule_key_value_manager_write_key" model="ir.rule">
+        <field name="name">Key Value: Manager Write/Create Access - Key Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field name="domain_force">[('key_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record id="rule_key_value_manager_write_server" model="ir.rule">
+        <field
+            name="name"
+        >Key Value: Manager Write/Create Access - Server Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field name="domain_force">[('server_id.manager_ids', 'in', [user.id])]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <!-- Manager Delete Rules -->
+    <record id="rule_key_value_manager_unlink_key" model="ir.rule">
+        <field name="name">Key Value: Manager Delete Access - Key Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field
+            name="domain_force"
+        >[('key_id.key_type', '=', 's'),('key_id.manager_ids', 'in', [user.id]), ('create_uid', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+    <record id="rule_key_value_manager_unlink_server" model="ir.rule">
+        <field name="name">Key Value: Manager Delete Access - Server Managers</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field
+            name="domain_force"
+        >[('key_id.key_type', '=', 's'),('server_id.manager_ids', 'in', [user.id]), ('create_uid', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+    <!-- Root Access Rule -->
+    <record id="rule_key_value_root" model="ir.rule">
+        <field name="name">Key Value: Root Full Access</field>
+        <field name="model_id" ref="model_cx_tower_key_value" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('cetmix_tower_server.group_root'))]" />
+    </record>
+</odoo>

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -22,6 +22,8 @@ access_execute_plan_user,Execute Plan->User,model_cx_tower_plan_execute_wizard,g
 access_key_user,Key->User,model_cx_tower_key,group_user,0,0,0,0
 access_key_manager,Key->Manager,model_cx_tower_key,group_manager,1,1,1,1
 access_key_root,Key->Root,model_cx_tower_key,group_root,1,1,1,1
+access_key_value_manager,Key Value->Manager,model_cx_tower_key_value,group_manager,1,1,1,1
+access_key_value_root,Key Value->Root,model_cx_tower_key_value,group_root,1,1,1,1
 access_command_log_user,Command Log->User,model_cx_tower_command_log,group_user,1,0,0,0
 access_command_log_root,Command Log->User,model_cx_tower_command_log,group_root,1,1,1,1
 access_plan_user,Plan->User,model_cx_tower_plan,group_user,1,0,0,0

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:7f8374e3bbc15a2487c09273b6fd8596dfa53b48576b343635915e84fc3cb326
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="http://cetmix.com/tower">Cetmix Tower</a> offers a streamlined solution
 for managing remote servers via SSH or API calls directly from
 <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for versatility across
@@ -469,7 +469,7 @@ Tower</a> features you need to provide access
 to in the the user settings. To configure it go to
 <tt class="docutils literal">Setting <span class="pre">-&gt;</span> Users &amp; Companies <span class="pre">-&gt;</span> Users</tt> and open a user whom you would
 like to provide access to the Cetmix Tower.</p>
-<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/user_profile.png" /></p>
+<p><img alt="User profile" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/user_profile.png" /></p>
 <p>In the <tt class="docutils literal">Cetmix Tower</tt> section select one of the following options in
 the <tt class="docutils literal">Access Level</tt> field:</p>
 <ul class="simple">
@@ -1032,7 +1032,7 @@ next to this one.</li>
 <p>Server Logs allow to fetch and view logs of a server fast and convenient
 way. To configure a Server Log open the server form, navigate to the
 <tt class="docutils literal">Server Logs</tt> tab and add a new record in the list.</p>
-<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
+<p><img alt="Server logs tab" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_tab.png" /></p>
 <p>Following fields are available:</p>
 <ul class="simple">
 <li><strong>Name</strong>: Readable name of the log</li>
@@ -1169,7 +1169,7 @@ arguments:</p>
 </pre>
 <p>Here is a short example of an Odoo automated action that creates a new
 server when a Sales Order is confirmed:</p>
-<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
+<p><img alt="Automatic action" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_from_template_auto_action.png" /></p>
 <pre class="code python literal-block">
 <span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">records</span><span class="p">:</span><span class="w">
 
@@ -1267,14 +1267,14 @@ before doing that.</p>
 up window. Or click on the <tt class="docutils literal">Open</tt> button <strong>(2)</strong> to open it in the
 full form view</li>
 </ul>
-<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
+<p><img alt="Open server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_1.png" /></p>
 <ul class="simple">
 <li>Click the <tt class="docutils literal">Refresh</tt> button to update the log. You can also click the
 <tt class="docutils literal">Refresh All</tt> button <strong>(3)</strong> located above the log list in order to
 refresh all logs at once. Log output will be displayed in the HTML
 field below.</li>
 </ul>
-<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0-dev/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
+<p><img alt="Update server log" src="https://raw.githubusercontent.com/cetmix/cetmix-tower/14.0/cetmix_tower_server/static/description/images/server_log_usage_2.png" /></p>
 </div>
 <div class="section" id="using-cetmix-tower-in-odoo-automation">
 <h2>Using Cetmix Tower in Odoo automation</h2>
@@ -1291,7 +1291,7 @@ those functions in the source code in the following file:
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0-dev%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/cetmix/cetmix-tower/issues/new?body=module:%20cetmix_tower_server%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -1304,7 +1304,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2>Maintainers</h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0-dev/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server">cetmix/cetmix-tower</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -109,6 +109,7 @@ class TestTowerCommon(TransactionCase):
 
         # Key
         self.Key = self.env["cx.tower.key"]
+        self.KeyValue = self.env["cx.tower.key.value"]
 
         self.key_1 = self.Key.create(
             {"name": "Test Key 1", "key_type": "k", "secret_value": "much key"}

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -43,7 +43,7 @@ class TestTowerCommand(TestTowerCommon):
             {
                 "name": "Test Python SSH Key",
                 "reference": "test_python_ssh_key",
-                "key_type": "k",
+                "key_type": "s",
                 "secret_value": """
                 Python
                 much
@@ -1284,6 +1284,7 @@ else:
         )
 
         # Execute the rendered Python code
+        # SSH keys are not parsed inline, so we should raise a validation error
         command_result = self.server_test_1._execute_python_code(
             rendered_command["rendered_code"]
         )
@@ -1358,8 +1359,14 @@ else:
             {
                 "name": "another secret",
                 "reference": secret_folder_key.reference,
+                "key_type": "s",
+            }
+        )
+        another_secret_value = self.KeyValue.create(
+            {
+                "key_id": another_secret.id,
                 "server_id": another_server.id,
-                "key_type": "k",
+                "secret_value": "another secret value",
             }
         )
         # Set original code again
@@ -1386,79 +1393,13 @@ else:
         yet_one_more_server = self.server_test_1.copy({"name": "yet one more server"})
 
         self.write_and_invalidate(
-            secret_folder_key, **{"server_id": yet_one_more_server.id}
+            another_secret_value, **{"server_id": yet_one_more_server.id}
         )
         self.write_and_invalidate(
             command_with_keys, **{"server_ids": self.server_test_1}
         )
         self.assertEqual(
             len(command_with_keys.secret_ids),
-            0,
-            msg="Must be no secrets",
-        )
-
-        # -- 5 --
-        # Add servers back to command and ensure secrets are linked
-        self.write_and_invalidate(
-            command_with_keys,
-            **{"server_ids": another_server | self.server_test_1 | yet_one_more_server},
-        )
-        self.assertEqual(
-            len(command_with_keys.secret_ids),
-            2,
-            msg="Must be two secrets",
-        )
-        self.assertIn(
-            secret_folder_key,
-            command_with_keys.secret_ids,
-            msg="The secret key is not linked with the command.",
-        )
-        self.assertIn(
-            another_secret,
-            command_with_keys.secret_ids,
-            msg="The another secret is not linked with the command.",
-        )
-
-        # -- 6 --
-        # Link another secret to a new partner and ensure
-        # it's not linked with the command
-        another_partner = self.env["res.partner"].create({"name": "another partner"})
-        self.write_and_invalidate(
-            another_secret, **{"partner_id": another_partner.id, "server_id": False}
-        )
-        self.assertEqual(
-            len(command_with_keys.secret_ids),
             1,
-            msg="Must one secret",
-        )
-        self.assertIn(
-            secret_folder_key,
-            command_with_keys.secret_ids,
-            msg="The secret key is not linked with the command.",
-        )
-        self.assertNotIn(
-            another_secret,
-            command_with_keys.secret_ids,
-            msg="The another secret is linked with the command.",
-        )
-
-        # -- 7 --
-        # Assign partner to a server and ensure secret is linked
-        self.write_and_invalidate(
-            self.server_test_1, **{"partner_id": another_partner.id}
-        )
-        self.assertEqual(
-            len(command_with_keys.secret_ids),
-            2,
-            msg="Must be two secrets",
-        )
-        self.assertIn(
-            secret_folder_key,
-            command_with_keys.secret_ids,
-            msg="The secret key is not linked with the command.",
-        )
-        self.assertIn(
-            another_secret,
-            command_with_keys.secret_ids,
-            msg="The another secret is not linked with the command.",
+            msg="Must be one secret",
         )

--- a/cetmix_tower_server/tests/test_key.py
+++ b/cetmix_tower_server/tests/test_key.py
@@ -1,4 +1,4 @@
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 
 from .common import TestTowerCommon
 
@@ -41,6 +41,9 @@ class TestTowerKey(TestTowerCommon):
                 "ssh_auth_mode": "p",
             }
         )
+        self.test_key = self.Key.create(
+            {"name": "Test Key", "key_type": "s", "secret_value": "test value"}
+        )
 
     def test_key_creation(self):
         """
@@ -61,53 +64,6 @@ class TestTowerKey(TestTowerCommon):
             "test key meme",
             "Trailing and leading whitespaces must be removed from name",
         )
-
-    def test_key_access_rights(self):
-        """Test private key security features"""
-
-        # Default message returned instead of key value
-        SECRET_VALUE_PLACEHOLDER = self.Key.SECRET_VALUE_PLACEHOLDER
-
-        # Store key value
-        self.write_and_invalidate(
-            self.key_1, **{"secret_value": "pepe", "key_type": "s"}
-        )
-
-        # Get key value as Bob
-        key_bob = self.key_1.with_user(self.user_bob)
-
-        with self.assertRaises(AccessError):
-            key_value = key_bob.secret_value
-
-        # Add user to group
-        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
-        # Add user to server
-        self.server_test_1.write({"user_ids": [(4, self.user_bob.id)]})
-        # Add server to key
-        self.write_and_invalidate(self.key_1, **{"server_id": self.server_test_1.id})
-
-        # Get value
-        key_value = key_bob.secret_value
-
-        # Ensure placeholder is used instead of the key value
-        self.assertEqual(
-            key_value,
-            SECRET_VALUE_PLACEHOLDER,
-            msg="Must return placeholder '{}'".format(SECRET_VALUE_PLACEHOLDER),
-        )
-
-        # Test write
-        with self.assertRaises(AccessError):
-            self.write_and_invalidate(key_bob, **{"secret_value": "frog"})
-
-        # Add Bob to Root group and test write again
-        self.add_to_group(self.user_bob, "cetmix_tower_server.group_root")
-        self.write_and_invalidate(key_bob, **{"secret_value": "frog"})
-
-        # Read with context and check if secret value is returned
-        key_with_context = self.key_1.with_context(show_secret_value=True)
-        key_value = key_with_context.secret_value
-        self.assertEqual(key_value, "frog", msg="Must return key value 'frog'")
 
     def test_extract_key_strings(self):
         """Check if key strings are extracted properly"""
@@ -139,7 +95,7 @@ class TestTowerKey(TestTowerCommon):
         """Check if key string is parsed correctly"""
 
         # Test global key
-        self.Key.create(
+        doge_key = self.Key.create(
             {
                 "name": "doge key",
                 "reference": "DOGE_KEY",
@@ -157,12 +113,10 @@ class TestTowerKey(TestTowerCommon):
         self.assertEqual(key_value, "Doge dog", "Key value doesn't match")
 
         # Test partner specific key
-        self.Key.create(
+        self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
+                "key_id": doge_key.id,
                 "secret_value": "Doge partner",
-                "key_type": "s",
                 "partner_id": self.user_bob.partner_id.id,
             }
         )
@@ -175,18 +129,28 @@ class TestTowerKey(TestTowerCommon):
         self.assertEqual(key_value, "Doge partner", "Key value doesn't match")
 
         # Test server specific key
-        self.Key.create(
+        self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
+                "key_id": doge_key.id,
                 "secret_value": "Doge server",
-                "key_type": "s",
-                "partner_id": self.user_bob.partner_id.id,
                 "server_id": self.server_test_1.id,
             }
         )
         key_value = self.Key._parse_key_string(key_string, **kwargs)
-        self.assertEqual(key_value, "Doge server", "Key value doesn't match")
+
+        # Test server and partner specific key
+        self.KeyValue.create(
+            {
+                "key_id": doge_key.id,
+                "secret_value": "Doge server and partner",
+                "server_id": self.server_test_1.id,
+                "partner_id": self.user_bob.partner_id.id,
+            }
+        )
+        key_value = self.Key._parse_key_string(key_string, **kwargs)
+        self.assertEqual(
+            key_value, "Doge server and partner", "Key value doesn't match"
+        )
 
         # Test missing key
         key_string = "#!cxtower.secret.ANOTHER_KEY!#"
@@ -224,54 +188,89 @@ class TestTowerKey(TestTowerCommon):
 
     def test_resolve_key_type_secret(self):
         """Check 'secret' type key resolver"""
-        self.Key.create(
+        doge_key = self.Key.create(
             {
                 "name": "doge key",
                 "reference": "DOGE_KEY",
-                "secret_value": "Doge dog",
                 "key_type": "s",
             }
         )
 
-        # Existing key
-        key_value = self.Key._resolve_key_type_secret("DOGE_KEY")
-        self.assertEqual(key_value, "Doge dog", "Key value doesn't match")
-
-        # Non existing key
-        key_value = self.Key._resolve_key_type_secret("PEPE_KEY")
-        self.assertIsNone(key_value, "Key value must be 'None'")
-
-        # Test partner specific key
-        self.Key.create(
+        # 1. Test server and partner specific key
+        server_partner_value = self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
-                "secret_value": "Doge partner",
-                "key_type": "s",
+                "key_id": doge_key.id,
+                "secret_value": "Doge server and partner",
+                "server_id": self.server_test_1.id,
                 "partner_id": self.user_bob.partner_id.id,
             }
         )
-        # compose kwargs
         kwargs = {
             "partner_id": self.user_bob.partner_id.id,
             "server_id": self.server_test_1.id,
         }
         key_value = self.Key._resolve_key_type_secret("DOGE_KEY", **kwargs)
+        self.assertEqual(
+            key_value, "Doge server and partner", "Key value doesn't match"
+        )
+
+        # 2. Global key
+        doge_key.write({"secret_value": "Doge dog"})
+        key_value = self.Key._resolve_key_type_secret("DOGE_KEY")
+        self.assertEqual(key_value, "Doge dog", "Key value doesn't match")
+
+        # 3. Non existing key
+        key_value = self.Key._resolve_key_type_secret("PEPE_KEY")
+        self.assertIsNone(key_value, "Key value must be 'None'")
+
+        # 4. Partner specific key
+        self.KeyValue.create(
+            {
+                "key_id": doge_key.id,
+                "secret_value": "Doge partner",
+                "partner_id": self.user_bob.partner_id.id,
+            }
+        )
+        kwargs = {
+            "partner_id": self.user_bob.partner_id.id,
+        }
+        key_value = self.Key._resolve_key_type_secret("DOGE_KEY", **kwargs)
         self.assertEqual(key_value, "Doge partner", "Key value doesn't match")
 
-        # Test server specific key
-        self.Key.create(
+        # 5. Test server specific key
+        self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
+                "key_id": doge_key.id,
                 "secret_value": "Doge server",
-                "key_type": "s",
-                "partner_id": self.user_bob.partner_id.id,
                 "server_id": self.server_test_1.id,
             }
         )
+        kwargs = {
+            "server_id": self.server_test_1.id,
+        }
         key_value = self.Key._resolve_key_type_secret("DOGE_KEY", **kwargs)
         self.assertEqual(key_value, "Doge server", "Key value doesn't match")
+
+        # 6. Test with non matching partner. Should return server specific value
+        kwargs = {
+            "partner_id": self.user.partner_id.id,
+            "server_id": self.server_test_1.id,
+        }
+        key_value = self.Key._resolve_key_type_secret("DOGE_KEY", **kwargs)
+        self.assertEqual(key_value, "Doge server", "Key value doesn't match")
+
+        # 7. Change partner in the server-partner specific value.
+        # Should return server specific value
+        server_partner_value.write({"partner_id": self.manager.partner_id.id})
+        kwargs = {
+            "server_id": self.server_test_1.id,
+        }
+        key_value = self.Key._resolve_key_type_secret("DOGE_KEY", **kwargs)
+        self.assertEqual(key_value, "Doge server", "Key value doesn't match")
+
+        # 8. Test with the global key again
+        key_value = self.Key._resolve_key_type_secret("DOGE_KEY")
+        self.assertEqual(key_value, "Doge dog", "Key value doesn't match")
 
     def test_parse_code(self):
         """Test code parsing"""
@@ -351,7 +350,7 @@ class TestTowerKey(TestTowerCommon):
 
         # 4 - Multi keys
         # Create new key
-        self.Key.create(
+        doge_key = self.Key.create(
             {
                 "name": "doge key",
                 "reference": "DOGE_KEY",
@@ -376,12 +375,10 @@ class TestTowerKey(TestTowerCommon):
 
         # 5 - Partner specific key
         # Create new key for partner Bob
-        self.Key.create(
+        self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
+                "key_id": doge_key.id,
                 "secret_value": "Doge wow",
-                "key_type": "s",
                 "partner_id": self.user_bob.partner_id.id,
             }
         )
@@ -398,13 +395,10 @@ class TestTowerKey(TestTowerCommon):
 
         # 6 - Server specific key
         # Create new key for server Test 1
-        self.Key.create(
+        self.KeyValue.create(
             {
-                "name": "doge key",
-                "reference": "DOGE_KEY",
+                "key_id": doge_key.id,
                 "secret_value": "Doge much",
-                "key_type": "s",
-                "partner_id": self.user_bob.partner_id.id,  # not needed but may keep it
                 "server_id": self.server_test_1.id,
             }
         )
@@ -452,251 +446,468 @@ class TestTowerKey(TestTowerCommon):
         self.assertEqual(result, code, "Result doesn't match expected code")
 
     def test_user_access(self):
-        """Test that regular users have no access"""
-        Key = self.env["cx.tower.key"].with_user(self.user)
+        """Test that regular users have no access to keys"""
+        user_key = self.Key.with_user(self.user)
 
-        # Try to read - should fail with access error
-        with self.assertRaises(AccessError):
-            Key.search([])
+        # Create test key
+        key = self.Key.create(
+            {"name": "Test Key", "secret_value": "test value", "key_type": "s"}
+        )
 
-        # Try to create - should fail
+        # Test CRUD operations
         with self.assertRaises(AccessError):
-            Key.create(
+            user_key.create(
+                {"name": "New Key", "secret_value": "secret", "key_type": "s"}
+            )
+        with self.assertRaises(AccessError):
+            user_key.browse(key.id).read(["name"])
+        with self.assertRaises(AccessError):
+            user_key.browse(key.id).write({"name": "Updated Name"})
+        with self.assertRaises(AccessError):
+            user_key.browse(key.id).unlink()
+
+    def test_manager_read_access(self):
+        """Test manager read access rules"""
+        manager_key = self.Key.with_user(self.manager)
+
+        # Create test keys
+        key_secret = self.Key.create(
+            {"name": "Secret Key", "secret_value": "secret value", "key_type": "s"}
+        )
+        key_ssh = self.Key.create(
+            {"name": "SSH Key", "secret_value": "ssh key", "key_type": "k"}
+        )
+
+        # Test read access for secret key - should read (all managers can read secrets)
+        self.assertTrue(manager_key.search([("id", "=", key_secret.id)]))
+
+        # Test read access for SSH key without server access - should not find
+        self.assertFalse(manager_key.search([("id", "=", key_ssh.id)]))
+
+        # Add manager to server users and set SSH key - should find SSH key
+        self.write_and_invalidate(
+            self.server_1,
+            **{"user_ids": [(4, self.manager.id)], "ssh_key_id": key_ssh.id},
+        )
+        self.assertTrue(manager_key.search([("id", "=", key_ssh.id)]))
+
+        # Remove key from server - should not find again
+        self.server_1.write({"ssh_key_id": False})
+        self.assertFalse(manager_key.search([("id", "=", key_ssh.id)]))
+
+        # Add as key user - should find both
+        key_secret.write({"user_ids": [(4, self.manager.id)]})
+        key_ssh.write({"user_ids": [(4, self.manager.id)]})
+        self.assertTrue(manager_key.search([("id", "=", key_secret.id)]))
+        self.assertTrue(manager_key.search([("id", "=", key_ssh.id)]))
+
+    def test_manager_write_access(self):
+        """Test manager write/create access rules"""
+        manager_key = self.Key.with_user(self.manager)
+
+        # Create test keys as root and ensure manager is not in manager_ids
+        key_secret = self.Key.create(
+            {
+                "name": "Secret Key",
+                "secret_value": "secret value",
+                "key_type": "s",
+                "manager_ids": [(5, 0)],  # Clear manager_ids
+            }
+        )
+        key_ssh = self.Key.create(
+            {
+                "name": "SSH Key",
+                "secret_value": "ssh key",
+                "key_type": "k",
+                "manager_ids": [(5, 0)],  # Clear manager_ids
+            }
+        )
+
+        # Try write without being manager - should fail
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_secret.id).write({"name": "Updated Secret"})
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_ssh.id).write({"name": "Updated SSH"})
+
+        # Add as key manager - should write to secret
+        key_secret.write({"manager_ids": [(4, self.manager.id)]})
+        manager_key.browse(key_secret.id).write({"name": "Updated Secret"})
+        self.assertEqual(key_secret.name, "Updated Secret")
+
+        # Add as server manager and set SSH key - should write to SSH key
+        self.server_1.write(
+            {"manager_ids": [(4, self.manager.id)], "ssh_key_id": key_ssh.id}
+        )
+        manager_key.browse(key_ssh.id).write({"name": "Updated SSH"})
+        self.assertEqual(key_ssh.name, "Updated SSH")
+
+    def test_manager_create_access(self):
+        """Test manager create access rules"""
+        manager_key = self.Key.with_user(self.manager)
+        manager_2_key = self.Key.with_user(self.manager_2)
+
+        # Try create secret key when not a manager - should fail
+        with self.assertRaises(AccessError):
+            manager_2_key.create(
                 {
-                    "name": "User Key",
-                    "key_type": "k",
-                    "secret_value": "user_key",
+                    "name": "New Secret",
+                    "secret_value": "secret",
+                    "key_type": "s",
+                    "manager_ids": [(5, 0)],  # Prevent automatic manager addition
                 }
             )
 
-        # Try to write - should fail
+        # Try create SSH key when not a server manager - should fail
         with self.assertRaises(AccessError):
-            self.key_1.with_user(self.user).write({"name": "New Name"})
+            manager_2_key.create(
+                {
+                    "name": "New SSH",
+                    "secret_value": "ssh key",
+                    "key_type": "k",
+                    "manager_ids": [(5, 0)],  # Prevent automatic manager addition
+                }
+            )
 
-        # Try to unlink - should fail
-        with self.assertRaises(AccessError):
-            self.key_1.with_user(self.user).unlink()
+        # Add as server manager - should create SSH key
+        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
+        new_ssh_key = manager_key.create(
+            {"name": "New SSH", "secret_value": "ssh key", "key_type": "k"}
+        )
+        # Link key to server
+        self.server_1.write({"ssh_key_id": new_ssh_key.id})
+        self.assertTrue(new_ssh_key.exists())
 
-    def test_manager_read_ssh_key(self):
-        """Test manager read access for SSH keys"""
-        Key = self.env["cx.tower.key"].with_user(self.manager)
+    def test_manager_unlink_access(self):
+        """Test manager unlink access rules"""
+        manager_key = self.Key.with_user(self.manager)
 
-        # Create SSH key with server reference
-        ssh_key = self.Key.create(
-            {
-                "name": "Test SSH Key",
-                "key_type": "k",
-                "secret_value": "test_key",
-            }
+        # Create keys as root
+        key_secret = self.Key.create(
+            {"name": "Secret Key", "secret_value": "secret value", "key_type": "s"}
+        )
+        key_ssh = self.Key.create(
+            {"name": "SSH Key", "secret_value": "ssh key", "key_type": "k"}
         )
         # Link SSH key to server
-        self.server_test_1.write({"ssh_key_id": ssh_key.id})
+        self.server_1.write({"ssh_key_id": key_ssh.id})
 
-        # No access initially
-        self.assertFalse(Key.search([("id", "=", ssh_key.id)]))
+        # Try delete without being manager and creator - should fail
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_secret.id).unlink()
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_ssh.id).unlink()
 
-        # Add as user - should read
-        self.server_test_1.write({"user_ids": [(4, self.manager.id)]})
-        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+        # Add as manager but not creator - should still fail
+        key_secret.write({"manager_ids": [(4, self.manager.id)]})
+        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_secret.id).unlink()
+        with self.assertRaises(AccessError):
+            manager_key.browse(key_ssh.id).unlink()
 
-        # Remove user, add as manager - should read
-        self.server_test_1.write(
+        # Create own keys - should delete
+        own_secret = manager_key.create(
             {
-                "user_ids": [(3, self.manager.id)],
+                "name": "Own Secret",
+                "secret_value": "secret",
+                "key_type": "s",
                 "manager_ids": [(4, self.manager.id)],
             }
         )
-        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
-
-        # Remove manager, add as user to key - should read
-        ssh_key.write({"user_ids": [(4, self.manager.id)]})
-        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
-
-        # Remove  user, add as manager to key - should read
-        ssh_key.write(
-            {"manager_ids": [(4, self.manager.id)], "user_ids": [(3, self.manager.id)]}
+        own_ssh = manager_key.create(
+            {"name": "Own SSH", "secret_value": "ssh key", "key_type": "k"}
         )
-        self.assertTrue(Key.search([("id", "=", ssh_key.id)]))
+        # Link own SSH key to server
+        self.server_1.write({"ssh_key_id": own_ssh.id})
 
-    def test_manager_read_secret(self):
-        """Test manager read access for secrets"""
-        Key = self.env["cx.tower.key"].with_user(self.manager)
+        own_secret.unlink()
+        own_ssh.unlink()
+        self.assertFalse(own_secret.exists())
+        self.assertFalse(own_ssh.exists())
 
-        # Create secret
-        secret = self.Key.create(
+    def test_root_access(self):
+        """Test root access rules"""
+        root_key = self.Key.with_user(self.root)
+
+        # Create
+        key = root_key.create(
+            {"name": "Root Key", "secret_value": "root secret", "key_type": "s"}
+        )
+        self.assertTrue(key.exists())
+
+        # Read
+        self.assertEqual(root_key.browse(key.id).name, "Root Key")
+
+        # Write
+        root_key.browse(key.id).write({"name": "Updated Root Key"})
+        self.assertEqual(key.name, "Updated Root Key")
+
+        # Delete
+        key.unlink()
+        self.assertFalse(key.exists())
+
+    def test_key_value_user_access(self):
+        """Test that regular users have no access to key values"""
+        user_key_value = self.KeyValue.with_user(self.user)
+
+        # Create test key and key value
+        key = self.Key.create({"name": "Test Key", "key_type": "s"})
+        key_value = self.KeyValue.create(
+            {"key_id": key.id, "secret_value": "test value"}
+        )
+
+        # Test CRUD operations
+        with self.assertRaises(AccessError):
+            user_key_value.create({"key_id": key.id, "secret_value": "new value"})
+        with self.assertRaises(AccessError):
+            user_key_value.browse(key_value.id).read(["secret_value"])
+        with self.assertRaises(AccessError):
+            user_key_value.browse(key_value.id).write({"secret_value": "updated value"})
+        with self.assertRaises(AccessError):
+            user_key_value.browse(key_value.id).unlink()
+
+    def test_key_value_manager_read_access(self):
+        """Test manager read access rules for key values"""
+        manager_key_value = self.KeyValue.with_user(self.manager)
+
+        # Create test key and key values
+        key = self.Key.create({"name": "Test Key", "key_type": "s"})
+        global_value = self.KeyValue.create(
+            {"key_id": key.id, "secret_value": "global value"}
+        )
+        server_value = self.KeyValue.create(
             {
-                "name": "Test Secret",
-                "key_type": "s",
-                "secret_value": "test_secret",
+                "key_id": key.id,
+                "secret_value": "server value",
                 "server_id": self.server_1.id,
             }
         )
 
-        # No access initially
-        self.assertFalse(Key.search([("id", "=", secret.id)]))
+        # Test read access - should not find without proper access
+        self.assertTrue(manager_key_value.search([("id", "=", global_value.id)]))
+        self.assertFalse(manager_key_value.search([("id", "=", server_value.id)]))
 
-        # Add as user - should read
+        # Add as key user - should find global value and server value for that key
+        key.write({"user_ids": [(4, self.manager.id)]})
+        self.assertTrue(manager_key_value.search([("id", "=", global_value.id)]))
+        self.assertTrue(manager_key_value.search([("id", "=", server_value.id)]))
+
+        # Remove from key users
+        key.write({"user_ids": [(3, self.manager.id)]})
+        self.assertTrue(manager_key_value.search([("id", "=", global_value.id)]))
+        self.assertFalse(manager_key_value.search([("id", "=", server_value.id)]))
+
+        # Add as server user - should find server value
         self.server_1.write({"user_ids": [(4, self.manager.id)]})
-        self.assertTrue(Key.search([("id", "=", secret.id)]))
+        self.assertTrue(manager_key_value.search([("id", "=", global_value.id)]))
+        self.assertTrue(manager_key_value.search([("id", "=", server_value.id)]))
 
-        # Remove user, add as manager - should read
-        self.server_1.write(
+    def test_key_value_manager_write_access(self):
+        """Test manager write/create access rules for key values"""
+        manager_key_value = self.KeyValue.with_user(self.manager)
+
+        # Create test key and key values
+        key = self.Key.create({"name": "Test Key", "key_type": "s"})
+        global_value = self.KeyValue.create(
+            {"key_id": key.id, "secret_value": "global value"}
+        )
+        server_value = self.KeyValue.create(
             {
-                "user_ids": [(3, self.manager.id)],
-                "manager_ids": [(4, self.manager.id)],
+                "key_id": key.id,
+                "secret_value": "server value",
+                "server_id": self.server_1.id,
             }
         )
-        self.assertTrue(Key.search([("id", "=", secret.id)]))
 
-    def test_manager_write_ssh_key(self):
-        """Test manager write/create access for SSH keys"""
-        Key = self.env["cx.tower.key"].with_user(self.manager)
-
-        # Try create without server access - should fail
+        # Try write without proper access - should fail
         with self.assertRaises(AccessError):
-            Key.create(
+            manager_key_value.browse(global_value.id).write(
+                {"secret_value": "new value"}
+            )
+        with self.assertRaises(AccessError):
+            manager_key_value.browse(server_value.id).write(
+                {"secret_value": "new value"}
+            )
+
+        # Add as key manager - should write to global value
+        key.write({"manager_ids": [(4, self.manager.id)]})
+        manager_key_value.browse(global_value.id).write(
+            {"secret_value": "updated global"}
+        )
+        self.assertEqual(global_value.secret_value, "updated global")
+
+        # Add as server manager - should write to server value
+        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
+        manager_key_value.browse(server_value.id).write(
+            {"secret_value": "updated server"}
+        )
+        self.assertEqual(server_value.secret_value, "updated server")
+
+        # Test create access
+        for_bob = manager_key_value.create(
+            {
+                "key_id": key.id,
+                "secret_value": "for bob",
+                "partner_id": self.user_bob.partner_id.id,
+            }
+        )
+        self.assertTrue(for_bob.exists())
+
+    def test_key_value_manager_unlink_access(self):
+        """Test manager unlink access rules for key values"""
+        manager_key_value = self.KeyValue.with_user(self.manager)
+
+        # Create test key and key values
+        key = self.Key.create({"name": "Test Key", "key_type": "s"})
+
+        # Create values as root
+        global_value = self.KeyValue.create(
+            {"key_id": key.id, "secret_value": "global value"}
+        )
+        server_value = self.KeyValue.create(
+            {
+                "key_id": key.id,
+                "secret_value": "server value",
+                "server_id": self.server_1.id,
+            }
+        )
+
+        # Try delete without proper access - should fail
+        with self.assertRaises(AccessError):
+            manager_key_value.browse(global_value.id).unlink()
+        with self.assertRaises(AccessError):
+            manager_key_value.browse(server_value.id).unlink()
+
+        # Add as manager but not creator - should still fail
+        key.write({"manager_ids": [(4, self.manager.id)]})
+        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
+        with self.assertRaises(AccessError):
+            manager_key_value.browse(global_value.id).unlink()
+        with self.assertRaises(AccessError):
+            manager_key_value.browse(server_value.id).unlink()
+
+        # Create own values - should delete
+        own_partner_value = manager_key_value.create(
+            {
+                "key_id": key.id,
+                "secret_value": "own partner",
+                "partner_id": self.user_bob.partner_id.id,
+            }
+        )
+
+        # Unlink server value first to avoid constraint error
+        server_value.unlink()
+
+        # Create server value
+        own_server_value = manager_key_value.create(
+            {
+                "key_id": key.id,
+                "secret_value": "own server",
+                "server_id": self.server_1.id,
+            }
+        )
+
+        own_partner_value.unlink()
+        own_server_value.unlink()
+        self.assertFalse(own_partner_value.exists())
+        self.assertFalse(own_server_value.exists())
+
+    def test_key_value_root_access(self):
+        """Test root access rules for key values"""
+        root_key_value = self.KeyValue.with_user(self.root)
+
+        # Create test key
+        key = self.Key.create({"name": "Test Key", "key_type": "s"})
+
+        # Create
+        value = root_key_value.create({"key_id": key.id, "secret_value": "root value"})
+        self.assertTrue(value.exists())
+
+        # Read
+        self.assertEqual(root_key_value.browse(value.id).secret_value, "root value")
+
+        # Write
+        root_key_value.browse(value.id).write({"secret_value": "updated value"})
+        self.assertEqual(value.secret_value, "updated value")
+
+        # Delete
+        value.unlink()
+        self.assertFalse(value.exists())
+
+    def test_key_value_global_unique(self):
+        """Test global value uniqueness"""
+
+        # Try to create a value for the same key
+        with self.assertRaises(ValidationError):
+            another_global_value = self.KeyValue.create(
+                {"key_id": self.test_key.id, "secret_value": "another test value"}
+            )
+            #
+            another_global_value.unlink()
+
+    def test_key_value_server_unique(self):
+        """Test server value uniqueness"""
+        # Create server tight value
+
+        self.KeyValue.create(
+            {
+                "key_id": self.test_key.id,
+                "secret_value": "server related",
+                "server_id": self.server_1.id,
+            }
+        )
+
+        # Try create another value for the same server
+        with self.assertRaises(ValidationError):
+            self.KeyValue.create(
                 {
-                    "name": "Manager SSH Key",
-                    "key_type": "k",
-                    "secret_value": "manager_key",
-                    "user_ids": [],
-                    "manager_ids": [],
+                    "key_id": self.test_key.id,
+                    "secret_value": "another server related",
+                    "server_id": self.server_1.id,
                 }
             )
 
-        # Add manager to server
-        self.server_test_1.write({"manager_ids": [(4, self.manager.id)]})
-
-        # Create SSH key and link to server - should succeed
-        ssh_key = Key.create(
+    def test_key_value_partner_unique(self):
+        """Test partner value uniqueness"""
+        # Create partner tight value
+        self.KeyValue.create(
             {
-                "name": "Manager SSH Key",
-                "key_type": "k",
-                "secret_value": "manager_key",
+                "key_id": self.test_key.id,
+                "secret_value": "partner related",
+                "partner_id": self.user_bob.partner_id.id,
             }
-        ).with_context(show_secret_value=True)
-        self.server_test_1.write({"ssh_key_id": ssh_key.id})
+        )
 
-        # Write - should succeed
-        self.write_and_invalidate(ssh_key, **{"secret_value": "updated_key"})
-        self.assertEqual(ssh_key.secret_value, "updated_key")
+        # Try create another value for the same partner
+        with self.assertRaises(ValidationError):
+            self.KeyValue.create(
+                {
+                    "key_id": self.test_key.id,
+                    "secret_value": "another partner related",
+                    "partner_id": self.user_bob.partner_id.id,
+                }
+            )
 
-        # Remove manager from server and add as manager to key
-        # Should succeed
-        self.server_test_1.write({"manager_ids": [(3, self.manager.id)]})
-        ssh_key.write({"manager_ids": [(4, self.manager.id)]})
-        self.write_and_invalidate(ssh_key, **{"secret_value": "updated_key_2"})
-        self.assertEqual(ssh_key.secret_value, "updated_key_2")
+    def test_key_value_server_partner_unique(self):
+        """Test server and partner value uniqueness"""
 
-    def test_manager_write_secret(self):
-        """Test manager write/create access for secrets"""
-        Key = self.env["cx.tower.key"].with_user(self.manager)
-
-        # Add manager to server
-        self.server_1.write({"manager_ids": [(4, self.manager.id)]})
-
-        # Create secret - should succeed
-        secret = Key.create(
+        # Create server and partner tight value
+        self.KeyValue.create(
             {
-                "name": "Manager Secret",
-                "key_type": "s",
-                "secret_value": "manager_secret",
+                "key_id": self.test_key.id,
+                "secret_value": "server related",
                 "server_id": self.server_1.id,
-            }
-        ).with_context(show_secret_value=True)
-        self.assertTrue(secret.exists())
-
-        # Write - should succeed
-        self.write_and_invalidate(secret, **{"secret_value": "updated_secret"})
-        self.assertEqual(secret.secret_value, "updated_secret")
-
-        # Try write to secret of another server - should fail
-        other_secret = self.Key.create(
-            {
-                "name": "Other Secret",
-                "key_type": "s",
-                "secret_value": "other_secret",
-                "server_id": self.server_2.id,
-            }
-        ).with_context(show_secret_value=True)
-        with self.assertRaises(AccessError):
-            other_secret.with_user(self.manager).write({"secret_value": "try_update"})
-
-    def test_manager_unlink(self):
-        """Test manager unlink access"""
-        # Add manager_2 to server first
-        self.server_test_1.write({"manager_ids": [(4, self.manager_2.id)]})
-
-        # Create keys as manager_2
-        Key = self.env["cx.tower.key"].with_user(self.manager_2)
-
-        # Create SSH key and link to server
-        ssh_key = Key.create(
-            {
-                "name": "Manager SSH Key",
-                "key_type": "k",
-                "secret_value": "manager_ssh_key",
-            }
-        )
-        self.server_test_1.write({"ssh_key_id": ssh_key.id})
-
-        # Create secret
-        secret = Key.create(
-            {
-                "name": "Manager Secret",
-                "key_type": "s",
-                "secret_value": "manager_secret",
-                "server_id": self.server_test_1.id,
+                "partner_id": self.user_bob.partner_id.id,
             }
         )
 
-        # Try delete as different manager - should fail
-        self.server_test_1.write({"manager_ids": [(4, self.manager.id)]})
-        with self.assertRaises(AccessError):
-            ssh_key.with_user(self.manager).unlink()
-        with self.assertRaises(AccessError):
-            secret.with_user(self.manager).unlink()
-
-        # Delete own keys - should succeed
-        ssh_key.with_user(self.manager_2).unlink()
-        secret.with_user(self.manager_2).unlink()
-        self.assertFalse(ssh_key.exists())
-        self.assertFalse(secret.exists())
-
-    def test_root_access(self):
-        """Test root access"""
-        Key = self.env["cx.tower.key"].with_user(self.root)
-
-        # Create
-        ssh_key = Key.create(
-            {
-                "name": "Root SSH Key",
-                "key_type": "k",
-                "secret_value": "root_ssh_key",
-            }
-        )
-        secret = Key.create(
-            {
-                "name": "Root Secret",
-                "key_type": "s",
-                "secret_value": "root_secret",
-                "server_id": self.server_1.id,
-            }
-        )
-        self.assertTrue(ssh_key.exists())
-        self.assertTrue(secret.exists())
-
-        # Read
-        self.assertTrue(Key.search([]))
-
-        # Write
-        ssh_key.write({"secret_value": "updated_ssh_key"})
-        secret.write({"secret_value": "updated_secret"})
-        self.assertEqual(ssh_key.secret_value, "updated_ssh_key")
-        self.assertEqual(secret.secret_value, "updated_secret")
-
-        # Delete
-        ssh_key.unlink()
-        secret.unlink()
-        self.assertFalse(ssh_key.exists())
-        self.assertFalse(secret.exists())
+        # Try create another value for the same server and partner
+        with self.assertRaises(ValidationError):
+            self.KeyValue.create(
+                {
+                    "key_id": self.test_key.id,
+                    "secret_value": "another server related",
+                    "server_id": self.server_1.id,
+                    "partner_id": self.user_bob.partner_id.id,
+                }
+            )

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -8,6 +8,20 @@ class TestTowerServer(TestTowerCommon):
         super().setUp(*args, **kwargs)
         self.os_ubuntu_20_04 = self.env["cx.tower.os"].create({"name": "Ubuntu 20.04"})
 
+        secret_1 = self.Key.create(
+            {
+                "name": "Secret 1",
+                "secret_value": "secret_value_1",
+                "key_type": "s",
+            },
+        )
+        secret_2 = self.Key.create(
+            {
+                "name": "Secret 2",
+                "secret_value": "secret_value_2",
+                "key_type": "s",
+            },
+        )
         self.server_test_2 = self.Server.create(
             {
                 "name": "Test Server #2",
@@ -24,18 +38,16 @@ class TestTowerServer(TestTowerCommon):
                         0,
                         0,
                         {
-                            "name": "Secret 1",
+                            "key_id": secret_1.id,
                             "secret_value": "secret_value_1",
-                            "key_type": "s",
                         },
                     ),
                     (
                         0,
                         0,
                         {
-                            "name": "Secret 2",
+                            "key_id": secret_2.id,
                             "secret_value": "secret_value_2",
-                            "key_type": "s",
                         },
                     ),
                 ],
@@ -298,7 +310,13 @@ COMMAND_RESULT = {
         """
         Test cascading deletion of server and its related records.
         """
-
+        secret_1 = self.Key.create(
+            {
+                "name": "Secret 1",
+                "secret_value": "secret_value_1",
+                "key_type": "s",
+            },
+        )
         # Create a test server
         server = self.Server.create(
             {
@@ -316,9 +334,8 @@ COMMAND_RESULT = {
                         0,
                         0,
                         {
-                            "name": "Secret 1",
+                            "key_id": secret_1.id,
                             "secret_value": "secret_value_1",
-                            "key_type": "s",
                         },
                     ),
                 ],

--- a/cetmix_tower_server/views/cx_tower_key_view.xml
+++ b/cetmix_tower_server/views/cx_tower_key_view.xml
@@ -20,23 +20,46 @@
                             <field name="key_type" />
                         </group>
                         <group>
-                            <field
-                                name="partner_id"
-                                attrs="{'invisible': [('key_type', '=', 'k')]}"
-                                placeholder="Leave blank to use with any partner"
-                            />
-                            <field
-                                name="server_id"
-                                invisible="context.get('from_server',False)"
-                                attrs="{'invisible': [('key_type', '=', 'k')]}"
-                                placeholder="Leave blank to use with any server"
-                            />
                             <field name="note" />
                         </group>
                     </group>
                     <notebook>
-                        <page name="value" string="Value">
+                        <page
+                            name="value"
+                            string="Key Value"
+                            attrs="{'invisible': [('key_type', '!=', 'k')]}"
+                        >
                             <field name="secret_value" />
+                        </page>
+                        <page
+                            name="secret_values"
+                            string="Secret Values"
+                            attrs="{'invisible': [('key_type', '!=', 's')]}"
+                        >
+                            <field name="value_ids">
+                                <tree
+                                    editable="bottom"
+                                    decoration-info="is_global == True"
+                                >
+                                    <field name="is_global" />
+                                    <field name="partner_id" />
+                                    <field name="server_id" />
+                                    <field name="secret_value" />
+                                </tree>
+                                <form>
+                                    <group>
+                                        <field name="is_global" />
+                                        <field
+                                            name="server_id"
+                                            attrs="{'invisible': [('is_global', '=', True)]}"
+                                        />
+                                        <field
+                                            name="partner_id"
+                                            attrs="{'invisible': [('is_global', '=', True)]}"
+                                        />
+                                    </group>
+                                </form>
+                            </field>
                         </page>
                         <page
                             name="servers"

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -392,9 +392,9 @@
                                 name="secret_ids"
                                 context="{'default_key_type': 's', 'from_server': True}"
                             >
-                                <tree>
-                                    <field name="name" />
-                                    <field name="reference" />
+                                <tree editable="bottom">
+                                    <field name="key_id" />
+                                    <field name="secret_value" />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Before this commit
-------------------

Current implementation of secrets presumes that a secret can be global, or linked either to a server or a partner.
This requires to make an exclusion from the unique constraint for the references to allow to have several secrets with the same reference. This breaks the general paradigm of references being unique, raises confusion and is error prone.

After this commit
-----------------

New dedicated model is added to store custom secret values for secrets. At the same time backward compatibility is kept by converting "Secret Value" field of a secret into a computed one.

Now there is no need in custom reference generation for secrets. Also it's much simpler to understand and maintain secrets logic and compute "Related Secrets" field in Commands, Files and File Templates.

Task: 4413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated all resource and image links in the documentation to reflect the latest stable version.

- **New Features**
  - Revamped the secret management interface with a dedicated section for custom key values.
  - Introduced a more flexible key-value storage approach for handling secrets.
  - Refined security access controls to improve secret key and key-value integrity.

- **Bug Fixes**
  - Removed outdated access control checks for private keys.
  - Streamlined the association of secrets with servers for improved clarity and efficiency.

- **Chores**
  - Updated version numbers and added new security configurations in the manifest.
  - Introduced a migration script to convert existing keys to the new secret value structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->