### PR TITLE
[14.0][IMP] cetmix_tower_server: New server wizard

### DIFF
--- a/cetmix_tower_server/tests/test_server_template.py
+++ b/cetmix_tower_server/tests/test_server_template.py
@@ -153,6 +153,10 @@ class TestTowerServerTemplate(TestTowerCommon):
             {
                 "name": "test",
                 "ip_v4_address": "0.0.0.0",
+                "use_sudo": "n",
+                "partner_id": self.user_bob.partner_id.id,
+                "os_id": self.os_debian_10.id,
+                "tag_ids": [(4, self.tag_test_production.id)],
             }
         )
         action = wizard.action_confirm()
@@ -161,6 +165,16 @@ class TestTowerServerTemplate(TestTowerCommon):
             [("server_template_id", "=", self.server_template_sample.id)]
         )
         self.assertEqual(action["res_id"], server.id, "Server ids must be the same")
+        self.assertEqual(
+            server.partner_id, self.user_bob.partner_id, "Partner must be the same"
+        )
+        self.assertEqual(server.os_id, self.os_debian_10, "OS must be the same")
+        self.assertEqual(
+            server.tag_ids, self.tag_test_production, "Tag must be the same"
+        )
+        self.assertEqual(server.use_sudo, "n", "Use sudo must be the same")
+        self.assertEqual(server.ip_v4_address, "0.0.0.0", "IP must be the same")
+        self.assertEqual(server.name, "test", "Name must be the same")
 
     def test_create_server_from_template_action(self):
         """

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard.py
@@ -20,7 +20,18 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
         string="Server Name",
         required=True,
     )
+    partner_id = fields.Many2one(
+        "res.partner",
+    )
     color = fields.Integer(help="For better visualization in views")
+    os_id = fields.Many2one(
+        string="Operating System",
+        comodel_name="cx.tower.os",
+    )
+    tag_ids = fields.Many2many(
+        comodel_name="cx.tower.tag",
+        string="Tags",
+    )
     ip_v4_address = fields.Char(string="IPv4 Address")
     ip_v6_address = fields.Char(string="IPv6 Address")
     ssh_port = fields.Integer(string="SSH port", default=22)
@@ -44,6 +55,11 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
         ],
         default="p",
         required=True,
+    )
+    use_sudo = fields.Selection(
+        string="Use sudo",
+        selection=[("n", "Without password"), ("p", "With password")],
+        help="Run commands using 'sudo'",
     )
     line_ids = fields.One2many(
         comodel_name="cx.tower.server.template.create.wizard.line",
@@ -103,6 +119,10 @@ class CxTowerServerTemplateCreateWizard(models.TransientModel):
             "ssh_password": self.ssh_password,
             "ssh_key_id": self.ssh_key_id.id,
             "ssh_auth_mode": self.ssh_auth_mode,
+            "use_sudo": self.use_sudo,
+            "partner_id": self.partner_id.id,
+            "os_id": self.os_id.id,
+            "tag_ids": [(4, tag_id) for tag_id in self.tag_ids.ids],
         }
         if self.line_ids:
             res.update(

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
@@ -12,20 +12,31 @@
                     </h1>
                     <field name="color" widget="color_picker" />
                 </div>
-                <group>
-                    <group name="main">
-                        <field name="ip_v4_address" />
-                        <field name="ip_v6_address" />
+                <group name="main">
+                    <group name="general">
+                        <field name="partner_id" />
+                        <field name="os_id" />
+                        <field name="tag_ids" widget="many2many_tags" />
                     </group>
                     <group name="ssh">
+                        <field name="ip_v4_address" />
+                        <field name="ip_v6_address" />
                         <field name="ssh_auth_mode" />
                         <field name="ssh_port" />
                         <field
                             name="ssh_username"
                             placeholder="this can be changed later"
                         />
-                        <field name="ssh_password" password="True" />
-                        <field name="ssh_key_id" />
+                        <field
+                            name="ssh_password"
+                            password="True"
+                            attrs="{'invisible': [('ssh_auth_mode', '=', 'k')]}"
+                        />
+                        <field
+                            name="ssh_key_id"
+                            attrs="{'invisible': [('ssh_auth_mode', '=', 'p')]}"
+                        />
+                        <field name="use_sudo" />
                     </group>
                     <field name="line_ids">
                         <tree editable="bottom">


### PR DESCRIPTION
Add the following fields to the new server wizard to improve the UX:

- Partner
- Operating System
- Tags
- Use sudo

Task: 4262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the server creation wizard with additional configuration options including partner association, operating system selection, tag management, and sudo mode.
	- Improved the form layout by categorizing fields and adding dynamic visibility for SSH authentication options, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->