### PR TITLE
[14.0][IMP] cetmix_tower_server: Variable form buttons

### DIFF
--- a/cetmix_tower_server/models/cx_tower_template_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_template_mixin.py
@@ -15,7 +15,9 @@ class CxTowerTemplateMixin(models.AbstractModel):
     _name = "cx.tower.template.mixin"
     _description = "Cetmix Tower template rendering mixin"
 
-    code = fields.Text(string="Code", help="This field will be rendered by default")
+    code = fields.Text(
+        string="Code", help="This field will be rendered using variables"
+    )
     variable_ids = fields.Many2many(
         string="Variables",
         comodel_name="cx.tower.variable",

--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -32,7 +32,84 @@ class TowerVariable(models.Model):
     )
     note = fields.Text()
 
+    # --- Link to records where the variable is used
+    command_ids = fields.Many2many(
+        comodel_name="cx.tower.command",
+        relation="cx_tower_command_variable_rel",
+        column1="variable_id",
+        column2="command_id",
+    )
+    command_ids_count = fields.Integer(
+        string="Command Count", compute="_compute_command_ids_count"
+    )
+    plan_line_ids = fields.Many2many(
+        comodel_name="cx.tower.plan.line",
+        relation="cx_tower_plan_line_variable_rel",
+        column1="variable_id",
+        column2="plan_line_id",
+    )
+    plan_line_ids_count = fields.Integer(
+        string="Plan Line Count", compute="_compute_plan_line_ids_count"
+    )
+    file_ids = fields.Many2many(
+        comodel_name="cx.tower.file",
+        relation="cx_tower_file_variable_rel",
+        column1="variable_id",
+        column2="file_id",
+    )
+    file_ids_count = fields.Integer(
+        string="File Count", compute="_compute_file_ids_count"
+    )
+    file_template_ids = fields.Many2many(
+        comodel_name="cx.tower.file.template",
+        relation="cx_tower_file_template_variable_rel",
+        column1="variable_id",
+        column2="file_template_id",
+    )
+    file_template_ids_count = fields.Integer(
+        string="File Template Count", compute="_compute_file_template_ids_count"
+    )
+    variable_value_ids = fields.Many2many(
+        comodel_name="cx.tower.variable.value",
+        relation="cx_tower_variable_value_variable_rel",
+        column1="variable_id",
+        column2="variable_value_id",
+    )
+    variable_value_ids_count = fields.Integer(
+        string="Variable Value Count", compute="_compute_variable_value_ids_count"
+    )
+
     _sql_constraints = [("name_uniq", "unique (name)", "Variable names must be unique")]
+
+    @api.depends("command_ids")
+    def _compute_command_ids_count(self):
+        """Count number of commands for the variable"""
+        for rec in self:
+            rec.command_ids_count = len(rec.command_ids)
+
+    @api.depends("plan_line_ids")
+    def _compute_plan_line_ids_count(self):
+        """Count number of plan lines for the variable"""
+        for rec in self:
+            rec.plan_line_ids_count = len(rec.plan_line_ids)
+
+    @api.depends("file_ids")
+    def _compute_file_ids_count(self):
+        """Count number of files for the variable"""
+        for rec in self:
+            rec.file_ids_count = len(rec.file_ids)
+
+    @api.depends("file_template_ids")
+    def _compute_file_template_ids_count(self):
+        """Count number of file templates for the variable"""
+        for rec in self:
+            rec.file_template_ids_count = len(rec.file_template_ids)
+
+    @api.depends("variable_value_ids")
+    def _compute_variable_value_ids_count(self):
+        """Count number of variable values for the variable"""
+        for rec in self:
+            rec.variable_value_ids_count = len(rec.variable_value_ids)
 
     @api.depends("value_ids", "value_ids.variable_id")
     def _compute_value_ids_count(self):
@@ -41,6 +118,7 @@ class TowerVariable(models.Model):
             rec.value_ids_count = len(rec.value_ids)
 
     def action_open_values(self):
+        self.ensure_one()
         context = self.env.context.copy()
         context.update(
             {
@@ -56,4 +134,74 @@ class TowerVariable(models.Model):
             "target": "current",
             "context": context,
             "domain": [("variable_id", "=", self.id)],
+        }
+
+    def action_open_commands(self):
+        """Open the commands where the variable is used"""
+
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_server.action_cx_tower_command"
+        )
+        action.update(
+            {
+                "domain": [("variable_ids", "in", self.ids)],
+            }
+        )
+        return action
+
+    def action_open_plan_lines(self):
+        """Open the plan lines where the variable is used"""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Plan Lines"),
+            "res_model": "cx.tower.plan.line",
+            "views": [
+                [False, "tree"],
+                [
+                    self.env.ref("cetmix_tower_server.cx_tower_plan_line_view_form").id,
+                    "form",
+                ],
+            ],
+            "target": "current",
+            "domain": [("variable_ids", "in", self.ids)],
+        }
+
+    def action_open_files(self):
+        """Open the files where the variable is used"""
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_server.cx_tower_file_action"
+        )
+        action.update(
+            {
+                "domain": [("variable_ids", "in", self.ids)],
+            }
+        )
+        return action
+
+    def action_open_file_templates(self):
+        """Open the file templates where the variable is used"""
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_server.cx_tower_file_template_action"
+        )
+        action.update(
+            {
+                "domain": [("variable_ids", "in", self.ids)],
+            }
+        )
+        return action
+
+    def action_open_variable_values(self):
+        """Open the variable values where the variable is used"""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Variable Values"),
+            "res_model": "cx.tower.variable.value",
+            "views": [[False, "tree"]],
+            "target": "current",
+            "domain": [("variable_ids", "in", self.ids)],
         }

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -13,11 +13,77 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-pencil-square-o"
+                            attrs="{'invisible': [('value_ids_count', '=', 0)]}"
                         >
                             <field
                                 name="value_ids_count"
                                 widget="statinfo"
                                 string="Values"
+                            />
+                        </button>
+                        <button
+                            name="action_open_commands"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-code"
+                            attrs="{'invisible': [('command_ids_count', '=', 0)]}"
+                        >
+                            <field
+                                name="command_ids_count"
+                                widget="statinfo"
+                                string="Commands"
+                            />
+                        </button>
+                        <button
+                            name="action_open_plan_lines"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-plane"
+                            attrs="{'invisible': [('plan_line_ids_count', '=', 0)]}"
+                        >
+                            <field
+                                name="plan_line_ids_count"
+                                widget="statinfo"
+                                string="Plan Lines"
+                            />
+                        </button>
+                        <button
+                            name="action_open_files"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                            attrs="{'invisible': [('file_ids_count', '=', 0)]}"
+                        >
+                            <field
+                                name="file_ids_count"
+                                widget="statinfo"
+                                string="Files"
+                            />
+                        </button>
+                        <button
+                            name="action_open_file_templates"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-list-alt"
+                            attrs="{'invisible': [('file_template_ids_count', '=', 0)]}"
+                        >
+                            <field
+                                name="file_template_ids_count"
+                                widget="statinfo"
+                                string="File Templates"
+                            />
+                        </button>
+                        <button
+                            name="action_open_variable_values"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-pencil-square-o"
+                            attrs="{'invisible': [('variable_value_ids_count', '=', 0)]}"
+                        >
+                            <field
+                                name="variable_value_ids_count"
+                                widget="statinfo"
+                                string="Used in Values"
                             />
                         </button>
                     </div>


### PR DESCRIPTION
Show related records in variables so users can navigate to them easily directly from the variable form.

Task: 4445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated descriptive text for template settings to clarify that variable substitution is applied during rendering.

- **New Features**
  - Enhanced variable management with additional linked records and count displays.
  - Introduced new interface buttons for quick access to related records, which only appear when associated data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->