### PR TITLE
[14.0][IMP] cetmix_tower_yaml: multi record support

### DIFF
--- a/cetmix_tower_yaml/models/cx_tower_variable_value.py
+++ b/cetmix_tower_yaml/models/cx_tower_variable_value.py
@@ -15,5 +15,6 @@ class CxTowerVariableValue(models.Model):
             "variable_id",
             "value_char",
             "variable_ids",
+            "required",
         ]
         return res

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -194,7 +194,6 @@ class CxTowerYamlMixin(models.AbstractModel):
         if not self._context.get("no_yaml_service_fields"):
             model_name = self._name.replace("cx.tower.", "").replace(".", "_")
             model_values = {
-                "cetmix_tower_yaml_version": self.CETMIX_TOWER_YAML_VERSION,
                 "cetmix_tower_model": model_name,
             }
         else:
@@ -245,22 +244,6 @@ class CxTowerYamlMixin(models.AbstractModel):
         Returns:
             dict(): Post-processed values
         """
-
-        # Check Cetmix Tower YAML version
-        yaml_version = values.pop("cetmix_tower_yaml_version", None)
-        if (
-            yaml_version
-            and isinstance(yaml_version, int)
-            and yaml_version > self.CETMIX_TOWER_YAML_VERSION
-        ):
-            raise ValidationError(
-                _(
-                    "YAML version is higher than version"
-                    " supported by your Cetmix Tower instance. %(code_version)s > %(tower_version)s",  # noqa
-                    code_version=yaml_version,
-                    tower_version=self.CETMIX_TOWER_YAML_VERSION,
-                )
-            )
 
         # Remove model data because it is not a field
         if "cetmix_tower_model" in values:

--- a/cetmix_tower_yaml/tests/test_command.py
+++ b/cetmix_tower_yaml/tests/test_command.py
@@ -11,8 +11,7 @@ class TestTowerCommand(TransactionCase):
         self.Command = self.env["cx.tower.command"]
 
         # Expected YAML content of the test command
-        self.command_test_yaml = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: command
+        self.command_test_yaml = """cetmix_tower_model: command
 access_level: manager
 reference: test_yaml_in_tests
 name: Test YAML
@@ -85,11 +84,6 @@ Ensure all fields are rendered properly.""",
             "YAML value doesn't match Cetmix Tower one",
         )
         self.assertEqual(
-            self.Command.CETMIX_TOWER_YAML_VERSION,
-            self.command_test_yaml_dict["cetmix_tower_yaml_version"],
-            "YAML value doesn't match Cetmix Tower one",
-        )
-        self.assertEqual(
             command_test.code,
             self.command_test_yaml_dict["code"],
             "YAML value doesn't match Cetmix Tower one",
@@ -142,11 +136,6 @@ Ensure all fields are rendered properly.""",
                 "YAML value doesn't match Cetmix Tower one",
             )
             self.assertEqual(
-                self.Command.CETMIX_TOWER_YAML_VERSION,
-                self.command_test_yaml_dict["cetmix_tower_yaml_version"],
-                "YAML value doesn't match Cetmix Tower one",
-            )
-            self.assertEqual(
                 command.code,
                 self.command_test_yaml_dict["code"],
                 "YAML value doesn't match Cetmix Tower one",
@@ -191,7 +180,6 @@ doge: wow
 memes: much nice!
 allow_parallel_run: false
 cetmix_tower_model: command
-cetmix_tower_yaml_version: 1
 code: |-
   cd /home/{{ tower.server.ssh_username }} \\
   && ls -lha
@@ -216,7 +204,6 @@ doge: wow
 memes: much nice!
 allow_parallel_run: false
 cetmix_tower_model: command
-cetmix_tower_yaml_version: 1
 code: |-
   cd /home/{{ tower.server.ssh_username }} \\
   && ls -lha
@@ -241,8 +228,7 @@ tag_ids: false
 
     def test_command_with_action_file_template(self):
         """Test command with 'File from template' action"""
-        yaml_with_reference = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: command
+        yaml_with_reference = """cetmix_tower_model: command
 access_level: manager
 reference: such_much_test_command
 name: Such Much Command
@@ -292,8 +278,7 @@ secret_ids: false
 
         # -- 2 --
         # Explode related record and check the YAML
-        yaml_with_reference_exploded = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: command
+        yaml_with_reference_exploded = """cetmix_tower_model: command
 access_level: manager
 reference: such_much_test_command
 name: Such Much Command

--- a/cetmix_tower_yaml/tests/test_file_template.py
+++ b/cetmix_tower_yaml/tests/test_file_template.py
@@ -10,8 +10,7 @@ class TestTowerFileTemplate(TransactionCase):
         self.FileTemplate = self.env["cx.tower.file.template"]
 
         # Expected YAML content of the test file template
-        self.file_template_test_yaml = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: file_template
+        self.file_template_test_yaml = """cetmix_tower_model: file_template
 reference: dockerfile_unit_test
 name: Dockerfile Test
 source: tower
@@ -35,8 +34,7 @@ secret_ids: false
 
         # Expected YAML content of the test file template
         # without empty x2mvalues
-        self.file_template_test_yaml_no_empty_values = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: file_template
+        self.file_template_test_yaml_no_empty_values = """cetmix_tower_model: file_template
 reference: dockerfile_unit_test
 name: Dockerfile Test
 source: tower
@@ -107,11 +105,6 @@ Depends on Odoo core image.""",
         self.assertEqual(
             file_template_test.file_name,
             self.file_template_test_yaml_dict["file_name"],
-            "YAML value doesn't match Cetmix Tower one",
-        )
-        self.assertEqual(
-            self.FileTemplate.CETMIX_TOWER_YAML_VERSION,
-            self.file_template_test_yaml_dict["cetmix_tower_yaml_version"],
             "YAML value doesn't match Cetmix Tower one",
         )
         self.assertEqual(
@@ -201,13 +194,6 @@ Depends on Odoo core image.""",
             "YAML value doesn't match Cetmix Tower one",
         )
         self.assertEqual(
-            self.FileTemplate.CETMIX_TOWER_YAML_VERSION,
-            self.file_template_test_yaml_dict_no_empty_values[
-                "cetmix_tower_yaml_version"
-            ],
-            "YAML value doesn't match Cetmix Tower one",
-        )
-        self.assertEqual(
             file_template_test.code,
             self.file_template_test_yaml_dict_no_empty_values["code"],
             "YAML value doesn't match Cetmix Tower one",
@@ -263,11 +249,6 @@ Depends on Odoo core image.""",
                 "YAML value doesn't match Cetmix Tower one",
             )
             self.assertEqual(
-                self.FileTemplate.CETMIX_TOWER_YAML_VERSION,
-                self.file_template_test_yaml_dict["cetmix_tower_yaml_version"],
-                "YAML value doesn't match Cetmix Tower one",
-            )
-            self.assertEqual(
                 file_template.code,
                 self.file_template_test_yaml_dict["code"],
                 "YAML value doesn't match Cetmix Tower one",
@@ -315,7 +296,6 @@ Depends on Odoo core image.""",
         # -- 2 --
         #  Insert some non supported keys and ensure nothing bad happens
         yaml_with_non_supported_keys = """cetmix_tower_model: file_template
-cetmix_tower_yaml_version: 1
 code: |-
   FROM odoo:{{ odoo_test_version }}
   # Install git-aggregator and tools for requirements generation

--- a/cetmix_tower_yaml/tests/test_plan.py
+++ b/cetmix_tower_yaml/tests/test_plan.py
@@ -10,8 +10,7 @@ class TestTowerPlan(TransactionCase):
     def test_plan_create_from_yaml(self):
         """Test plan creation from YAML."""
 
-        plan_yaml = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: plan
+        plan_yaml = """cetmix_tower_model: plan
 access_level: manager
 reference: test_plan_from_yaml
 name: 'Test Plan From Yaml'
@@ -37,8 +36,7 @@ line_ids:
     note: false
     code: Such much code
     variable_ids:
-    - cetmix_tower_yaml_version: 1
-      cetmix_tower_model: variable
+    - cetmix_tower_model: variable
       reference: test_plan_dir
       name: Test Plan Directory
   action_ids:
@@ -48,24 +46,21 @@ line_ids:
     action: n
     custom_exit_code: 0
     variable_value_ids:
-    - cetmix_tower_yaml_version: 1
-      cetmix_tower_model: variable_value
+    - cetmix_tower_model: variable_value
       variable_id:
         cetmix_tower_yaml_version: 1
         cetmix_tower_model: variable
         reference: test_plan_branch
         name: Test Plan Branch
       value_char: production
-    - cetmix_tower_yaml_version: 1
-      cetmix_tower_model: variable_value
+    - cetmix_tower_model: variable_value
       variable_id:
         cetmix_tower_yaml_version: 1
         cetmix_tower_model: variable
         reference: test_plan_some_unique_variable
         name: Test Plan Some Unique Variable
       value_char: 'Final Value'
-  - cetmix_tower_yaml_version: 1
-    cetmix_tower_model: plan_line_action
+  - cetmix_tower_model: plan_line_action
     access_level: manager
     sequence: 2
     condition: '>'

--- a/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
@@ -100,11 +100,6 @@ class TestTowerYamlMixin(TransactionCase):
             "Access level is not parsed correctly",
         )
         self.assertEqual(
-            result_values["cetmix_tower_yaml_version"],
-            self.YamlMixin.CETMIX_TOWER_YAML_VERSION,
-            "Cetmix Tower YAML version is not added",
-        )
-        self.assertEqual(
             result_values["name"],
             source_values["name"],
             "Other values should remain unchanged",
@@ -134,7 +129,6 @@ class TestTowerYamlMixin(TransactionCase):
         # Test regular flow
         source_values = {
             "access_level": "user",
-            "cetmix_tower_yaml_version": self.YamlMixin.CETMIX_TOWER_YAML_VERSION,
             "name": "Doge Much Like",
             "reference": "such_much_doge",
             "some_doge_field": "some_meme",
@@ -145,11 +139,6 @@ class TestTowerYamlMixin(TransactionCase):
         )
         self.assertNotIn(
             "some_doge_field", result_values, "Non listed fields must be removed"
-        )
-        self.assertNotIn(
-            "cetmix_tower_yaml_version",
-            result_values,
-            "Cetmix Tower YAML version must be removed",
         )
         self.assertEqual(
             result_values["access_level"],
@@ -167,37 +156,11 @@ class TestTowerYamlMixin(TransactionCase):
             "Other values should remain unchanged",
         )
 
-        # -- 2 --
-        # Test flow with exception due to yaml version incompatibility
-        source_values = {
-            "access_level": "user",
-            "cetmix_tower_yaml_version": self.YamlMixin.CETMIX_TOWER_YAML_VERSION + 1,
-            "name": "Doge Much Like",
-            "reference": "such_much_doge",
-            "some_doge_field": "some_meme",
-        }
-
-        with self.assertRaises(ValidationError) as e:
-            result_values = self.YamlMixin._post_process_yaml_dict_values(
-                source_values.copy()
-            )
-            self.assertEqual(
-                str(e),
-                _(
-                    "YAML version is higher than version"
-                    " supported by your Cetmix Tower instance. %(code_version)s > %(tower_version)s",  # noqa
-                    code_version=self.YamlMixin.CETMIX_TOWER_YAML_VERSION + 1,
-                    tower_version=self.YamlMixin.CETMIX_TOWER_YAML_VERSION,
-                ),
-                "Exception message doesn't match",
-            )
-
-        # -- Test 3 --
+        # -- Test 2 --
         # Submit wrong value for access level
         source_values.update(
             {
                 "access_level": "doge",
-                "cetmix_tower_yaml_version": self.YamlMixin.CETMIX_TOWER_YAML_VERSION,
             }
         )
         with self.assertRaises(ValidationError) as e:

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -23,6 +23,13 @@ class TestYamlExportWizard(TransactionCase):
                 "code": "echo 'Test Command From Yaml'",
             }
         )
+        self.command_test_wizard_2 = self.TowerCommand.create(
+            {
+                "reference": "test_command_from_yaml_2",
+                "name": "Test Command From Yaml 2",
+                "code": "echo 'Test Command From Yaml 2'",
+            }
+        )
 
         # Create a flight plan
         self.FlightPlan = self.env["cx.tower.plan"]
@@ -91,18 +98,54 @@ class TestYamlExportWizard(TransactionCase):
             "Comment should be properly prepended to YAML code",
         )
 
+    def test_yaml_export_wizard_yaml_generation(self):
+        """Test code generation of YAML export wizard."""
+
+        wizard_yaml = """
+# This file is generated with Cetmix Tower.
+# Details and documentation: https://cetmix.com/tower
+# Test Comment
+cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: command
+  access_level: manager
+  reference: test_command_from_yaml
+  name: Test Command From Yaml
+  action: ssh_command
+  allow_parallel_run: false
+  note: false
+  path: false
+  code: echo 'Test Command From Yaml'
+  server_status: false
+- cetmix_tower_model: command
+  access_level: manager
+  reference: test_command_from_yaml_2
+  name: Test Command From Yaml 2
+  action: ssh_command
+  allow_parallel_run: false
+  note: false
+  path: false
+  code: echo 'Test Command From Yaml 2'
+  server_status: false
+"""
+
+        # -- 1 --
+        # Test with two commands
+        context = {
+            "default_explode_child_records": True,
+            "default_comment": "Test Comment",
+            "default_remove_empty_values": True,
+            "active_model": "cx.tower.command",
+            "active_ids": [self.command_test_wizard.id, self.command_test_wizard_2.id],
+        }
+        wizard = self.YamlExportWizard.with_context(context).create({})
+        wizard.onchange_explode_child_records()
+        self.assertEqual(wizard.yaml_code, wizard_yaml)
+
     def test_yaml_export_wizard(self):
         """Test the YAML export wizard."""
 
         # -- 1 --
-        # Test wizard creation
-        self.assertEqual(
-            self.test_wizard.yaml_code,
-            f"{self.file_header}\n{self.server_template_test_wizard.yaml_code}",
-            "YAML code should be the same",
-        )
-
-        # -- 2 --
         # Test wizard action
         result = self.test_wizard.action_generate_yaml_file()
         self.assertEqual(
@@ -115,7 +158,7 @@ class TestYamlExportWizard(TransactionCase):
         )
         self.assertTrue(result["res_id"], "Wizard should have been created")
 
-        # -- 3 --
+        # -- 2 --
         # Ensure download wizard file name is generated
         # based on the record reference
         download_wizard = self.env["cx.tower.yaml.export.wiz.download"].browse(
@@ -127,24 +170,24 @@ class TestYamlExportWizard(TransactionCase):
             "YAML file name should be generated based on record reference",
         )
 
-        # -- 4 --
+        # -- 3 --
         # Decode YAML file and check if it's valid
         yaml_file_content = base64.decodebytes(download_wizard.yaml_file).decode(
             "utf-8"
         )
         self.assertEqual(
             yaml_file_content,
-            f"{self.file_header}\n{self.server_template_test_wizard.yaml_code}",
+            self.test_wizard.yaml_code,
             "YAML file content should be the same as the original YAML code",
         )
 
-        # -- 5 --
+        # -- 4 --
         # Test if empty YAML code is handled correctly
         self.test_wizard.yaml_code = ""
         with self.assertRaises(ValidationError):
             self.test_wizard.action_generate_yaml_file()
 
-        # -- 6 --
+        # -- 5 --
         # Test non utf-8 characters encoding
         self.test_wizard.yaml_code = "Non-ascii characters: \udc80"
         with self.assertRaises(ValidationError):

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -99,10 +99,17 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             }
         )
 
-        # YAML code
-        self.yaml_code = self.server_template_yaml_test.with_context(
-            explode_related_record=True
-        ).yaml_code
+        # Create an export wizard and generate YAML code
+        context = {
+            "active_model": "cx.tower.server.template",
+            "active_ids": [self.server_template_yaml_test.id],
+        }
+        self.export_wizard = (
+            self.env["cx.tower.yaml.export.wiz"].with_context(context).create({})
+        )
+        self.export_wizard.onchange_explode_child_records()
+        self.export_wizard.action_generate_yaml_file()
+        self.yaml_code = self.export_wizard.yaml_code
         self.yaml_file = base64.b64encode(self.yaml_code.encode("utf-8"))
 
         # YAML import upload wizard
@@ -116,6 +123,7 @@ class TestTowerYamlImportWizUpload(TransactionCase):
         self.import_wizard = self.env[self.import_wizard_action["res_model"]].browse(
             self.import_wizard_action["res_id"]
         )
+        self.import_wizard.if_record_exists = "update"
 
     def test_extract_yaml_data(self):
         """Test extract YAML data from file"""
@@ -124,19 +132,9 @@ class TestTowerYamlImportWizUpload(TransactionCase):
         # Test if YAML file is valid
         extracted_yaml_data = self.yaml_upload_wizard._extract_yaml_data()
         self.assertEqual(
-            extracted_yaml_data[0],
+            extracted_yaml_data,
             self.yaml_code,
             "YAML code is not extracted correctly",
-        )
-        self.assertEqual(
-            extracted_yaml_data[1],
-            "cx.tower.server.template",
-            "Model name is not extracted correctly",
-        )
-        self.assertEqual(
-            extracted_yaml_data[2],
-            self.server_template_yaml_test.id,
-            "Record ID is not extracted correctly",
         )
 
         # -- 2 --
@@ -153,7 +151,7 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             self.yaml_upload_wizard._extract_yaml_data()
         self.assertEqual(
             e.exception.name,
-            _("Invalid model specified in the YAML file"),
+            _("'invalid_model' is not a valid model"),
             "Exception message does not match",
         )
 
@@ -171,7 +169,7 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             self.yaml_upload_wizard._extract_yaml_data()
         self.assertEqual(
             e.exception.name,
-            _("Model does not support YAML import"),
+            _("Model 'server' does not support YAML import"),
             "Exception message does not match",
         )
 
@@ -226,10 +224,64 @@ class TestTowerYamlImportWizUpload(TransactionCase):
         self.assertEqual(
             e.exception.name,
             _(
-                "YAML file version is not supported."
-                " You may need to update the Cetmix Tower Yaml module."
+                "YAML version is higher than version"
+                " supported by your Cetmix Tower instance."
+                " %(code_version)s > %(tower_version)s",
+                code_version=self.FlightPlan.CETMIX_TOWER_YAML_VERSION + 1,
+                tower_version=self.FlightPlan.CETMIX_TOWER_YAML_VERSION,
             ),
             "Exception message does not match",
+        )
+
+        # -- 8 --
+        # Test YAML file with no records
+        self.import_wizard.yaml_code = "cetmix_tower_yaml_version: 1"
+        with self.assertRaises(ValidationError) as e:
+            self.import_wizard.action_import_yaml()
+        self.assertEqual(
+            e.exception.name,
+            _("YAML file doesn't contain any records"),
+            "Exception message does not match",
+        )
+
+    def test_action_import_yaml_skip_if_exists(self):
+        """Test YAML import wizard action when skipping an existing record"""
+
+        self.import_wizard.if_record_exists = "skip"
+
+        # Run import wizard action
+        import_wizard_result_action = self.import_wizard.action_import_yaml()
+
+        # Test if action is composed properly
+        self.assertEqual(
+            import_wizard_result_action["type"],
+            "ir.actions.client",
+            "Import wizard action type is not correct",
+        )
+        self.assertEqual(
+            import_wizard_result_action["tag"],
+            "display_notification",
+            "Import wizard action tag is not correct",
+        )
+        self.assertEqual(
+            import_wizard_result_action["params"]["title"],
+            _("Record Import"),
+            "Import wizard action title is not correct",
+        )
+        self.assertEqual(
+            import_wizard_result_action["params"]["message"],
+            _("No records were created or updated"),
+            "Import wizard action message is not correct",
+        )
+        self.assertEqual(
+            import_wizard_result_action["params"]["sticky"],
+            True,
+            "Import wizard action sticky is not correct",
+        )
+        self.assertEqual(
+            import_wizard_result_action["params"]["type"],
+            "warning",
+            "Import wizard action type is not correct",
         )
 
     def test_action_import_yaml_update_existing_record(self):
@@ -246,12 +298,6 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             self.import_wizard_action["view_mode"],
             "form",
             "Import wizard action view mode is not correct",
-        )
-
-        self.assertEqual(
-            self.import_wizard.model_name,
-            "cx.tower.server.template",
-            "Import wizard model name is not correct",
         )
 
         # -- 2 --
@@ -280,8 +326,8 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             "Import wizard action model is not correct",
         )
         self.assertEqual(
-            import_wizard_result_action["res_id"],
-            self.server_template_yaml_test.id,
+            import_wizard_result_action["domain"],
+            [("id", "in", self.server_template_yaml_test.ids)],
             "ID must match existing record ID",
         )
         self.assertEqual(
@@ -321,15 +367,15 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             "Import wizard action model is not correct",
         )
         self.assertNotEqual(
-            import_wizard_result_action["res_id"],
-            self.server_template_yaml_test.id,
+            import_wizard_result_action["domain"],
+            f"[('id', '=', {self.server_template_yaml_test.ids})]",
             "ID must not match existing record ID",
         )
 
         # -- 2 --
         # Ensure that existing flight plan is used instead of creating a new one
-        new_server_template = self.env[import_wizard_result_action["res_model"]].browse(
-            import_wizard_result_action["res_id"]
+        new_server_template = self.env[import_wizard_result_action["res_model"]].search(
+            import_wizard_result_action["domain"]
         )
         self.assertEqual(
             new_server_template.flight_plan_id,
@@ -369,22 +415,28 @@ class TestTowerYamlImportWizUpload(TransactionCase):
 
         # NB: this is not a real model, it's just for testing
         yaml_code = """cetmix_tower_yaml_version: 1
-cetmix_tower_model: test_model
-access_level: manager
-reference: such_much_test_record
-name: Such Much Command
-action: file_using_template
-allow_parallel_run: false
-note: Just a note
-os_ids: false
-tag_ids: false
-path: false
-ssh_key_id:
-  reference: test_ssh_key
-  name: Test SSH Key
-  key_type: k
-  note: false
-record_with_the_same_ssh_key:
+records:
+- cetmix_tower_model: test_model
+  access_level: manager
+  reference: such_much_test_record
+  name: Such Much Command
+  action: file_using_template
+  allow_parallel_run: false
+  note: Just a note
+  os_ids: false
+  tag_ids: false
+  path: false
+  file_template_id: false
+  flight_plan_id: false
+  code: false
+  variable_ids: false
+  secret_ids: false
+  ssh_key_id:
+    reference: test_ssh_key
+    name: Test SSH Key
+    key_type: k
+    note: false
+- cetmix_tower_model: another_test_model
   reference: such_much_test_record_2
   name: Such Much Test Record 2
   note: Just a note 2
@@ -402,7 +454,7 @@ record_with_the_same_ssh_key:
       name: Secret 3
       key_type: s
       note: false
-record_with_another_ssh_key:
+- cetmix_tower_model: another_test_model
   reference: such_much_test_record_3
   name: Such Much Test Record 3
   note: Just a note 3
@@ -422,31 +474,31 @@ record_with_another_ssh_key:
       name: Secret 4
       key_type: s
       note: false
-file_template_id:
-  reference: my_custom_test_template
-  name: Such much demo
-  source: tower
-  file_type: text
-  server_dir: /var/log/my/files
-  file_name: much_logs.txt
-  keep_when_deleted: false
-  tag_ids: false
-  note: Hey!
+  file_template_id:
+    reference: my_custom_test_template
+    name: Such much demo
+    source: tower
+    file_type: text
+    server_dir: /var/log/my/files
+    file_name: much_logs.txt
+    keep_when_deleted: false
+    tag_ids: false
+    note: Hey!
+    code: false
+    variable_ids: false
+    secret_ids: false
+  flight_plan_id: false
   code: false
   variable_ids: false
-  secret_ids: false
-flight_plan_id: false
-code: false
-variable_ids: false
-secret_ids:
-- reference: secret_1
-  name: Secret 1
-  key_type: s
-  note: false
-- reference: secret_2
-  name: Secret 2
-  key_type: s
-  note: false
+  secret_ids:
+  - reference: secret_1
+    name: Secret 1
+    key_type: s
+    note: false
+  - reference: secret_2
+    name: Secret 2
+    key_type: s
+    note: false
 """
         secret_list = self.env["cx.tower.yaml.import.wiz"]._extract_secret_names(
             yaml.safe_load(yaml_code)
@@ -461,3 +513,88 @@ secret_ids:
         self.assertIn("Secret 4", secret_list, "Key is not in the list")
         self.assertIn("Secret 1", secret_list, "Key is not in the list")
         self.assertIn("Secret 2", secret_list, "Key is not in the list")
+
+    def test_create_records_different_models(self):
+        """Test create records with different models"""
+
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: command
+  access_level: manager
+  reference: much_much_command
+  name: Much Much Command
+  action: file_using_template
+  allow_parallel_run: false
+  note: Just a note
+  os_ids: false
+  tag_ids: false
+  path: false
+  file_template_id: false
+  flight_plan_id: false
+  code: false
+  variable_ids: false
+  secret_ids: false
+  ssh_key_id:
+    reference: test_ssh_key
+    name: Test SSH Key
+    key_type: k
+    note: false
+- cetmix_tower_model: server_template
+  reference: wow_much_server_template
+  name: Wow Much Server Template
+  note: Just a note 2
+- cetmix_tower_model: tag
+  reference: such_much_tag
+  name: Such Much Tag
+"""
+        # Create a new command record
+        self.import_wizard.if_record_exists = "update"
+        self.import_wizard.yaml_code = yaml_code
+
+        action = self.import_wizard.action_import_yaml()
+
+        # Check if action is composed properly
+        self.assertEqual(
+            action["type"],
+            "ir.actions.client",
+            "Import wizard action type is not correct",
+        )
+        self.assertEqual(
+            action["tag"],
+            "display_notification",
+            "Import wizard action tag is not correct",
+        )
+        self.assertEqual(
+            action["params"]["title"],
+            _("Record Import"),
+            "Import wizard action title is not correct",
+        )
+        self.assertEqual(
+            action["params"]["type"],
+            "success",
+            "Import wizard action type is not correct",
+        )
+        self.assertEqual(
+            action["params"]["sticky"],
+            True,
+            "Import wizard action sticky is not correct",
+        )
+
+        # Check command
+        self.assertTrue(
+            self.Command.get_by_reference("much_much_command"),
+            "Command must be created",
+        )
+
+        # Check server template
+        self.assertTrue(
+            self.env["cx.tower.server.template"].get_by_reference(
+                "wow_much_server_template"
+            ),
+            "Server template must be created",
+        )
+
+        # Check tag
+        self.assertTrue(
+            self.Tag.get_by_reference("such_much_tag"), "Tag must be created"
+        )

--- a/cetmix_tower_yaml/views/cx_tower_command_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_command_view.xml
@@ -23,4 +23,13 @@
             </xpath>
         </field>
     </record>
+    <record id="action_cx_tower_command_export_yaml" model="ir.actions.act_window">
+        <field name="name">Export YAML</field>
+        <field name="res_model">cx.tower.yaml.export.wiz</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_cx_tower_command" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('cetmix_tower_yaml.group_export'))]" />
+    </record>
 </odoo>

--- a/cetmix_tower_yaml/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_file_template_view.xml
@@ -26,5 +26,16 @@
             </xpath>
         </field>
     </record>
-
+    <record
+        id="action_cx_tower_file_template_export_yaml"
+        model="ir.actions.act_window"
+    >
+        <field name="name">Export YAML</field>
+        <field name="res_model">cx.tower.yaml.export.wiz</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_cx_tower_file_template" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('cetmix_tower_yaml.group_export'))]" />
+    </record>
 </odoo>

--- a/cetmix_tower_yaml/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_plan_view.xml
@@ -23,5 +23,13 @@
             </xpath>
         </field>
     </record>
-
+    <record id="action_cx_tower_plan_export_yaml" model="ir.actions.act_window">
+        <field name="name">Export YAML</field>
+        <field name="res_model">cx.tower.yaml.export.wiz</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_cx_tower_plan" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('cetmix_tower_yaml.group_export'))]" />
+    </record>
 </odoo>

--- a/cetmix_tower_yaml/views/cx_tower_server_template_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_server_template_view.xml
@@ -26,5 +26,16 @@
             </xpath>
         </field>
     </record>
-
+    <record
+        id="action_cx_tower_server_template_export_yaml"
+        model="ir.actions.act_window"
+    >
+        <field name="name">Export YAML</field>
+        <field name="res_model">cx.tower.yaml.export.wiz</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_cx_tower_server_template" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('cetmix_tower_yaml.group_export'))]" />
+    </record>
 </odoo>

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -42,25 +42,38 @@ class CxTowerYamlExportWiz(models.TransientModel):
 
         # Get model records
         records = self._get_model_record()
+        if not records:
+            raise ValidationError(_("No valid records selected"))
+
         explode_related_record = self.explode_child_records
         remove_empty_values = self.remove_empty_values
-        # Collact YAML code into a list
-        yaml_codes = (
-            [FILE_HEADER + self._text_to_yaml_comment(self.comment)]
+
+        # Prepare YAML header
+        yaml_header = (
+            FILE_HEADER + self._text_to_yaml_comment(self.comment)
             if self.comment
-            else [FILE_HEADER]
+            else FILE_HEADER
         )
 
-        # Concatenate all YAML codes from selected records
+        # Compose list of dictionaries ready for YAML conversion
+        record_list = []
         for record in records:
-            record_yaml_code = record.with_context(
+            record_yaml_dict = record.with_context(
                 explode_related_record=explode_related_record,
                 remove_empty_values=remove_empty_values,
-            ).yaml_code
-            if record_yaml_code:
-                yaml_codes.append(record_yaml_code)
+            )._prepare_record_for_yaml()
+            if record_yaml_dict:
+                record_list.append(record_yaml_dict)
 
-        self.yaml_code = "\n".join(yaml_codes) if yaml_codes else ""
+        if record_list:
+            yaml_version = self.env["cx.tower.yaml.mixin"].CETMIX_TOWER_YAML_VERSION
+            yaml_code = records._convert_dict_to_yaml(
+                {"cetmix_tower_yaml_version": yaml_version, "records": record_list}
+            )
+        else:
+            yaml_code = ""
+
+        self.yaml_code = f"{yaml_header}\n{yaml_code}"
 
     def action_generate_yaml_file(self):
         """Save YAML file"""

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -1,6 +1,11 @@
+import logging
+
 import yaml
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class CxTowerYamlImportWiz(models.TransientModel):
@@ -11,17 +16,14 @@ class CxTowerYamlImportWiz(models.TransientModel):
     """
 
     yaml_code = fields.Text(readonly=True)
-    model_name = fields.Char(readonly=True, help="Model to create records in")
-    model_description = fields.Char(
-        string="Model", readonly=True, compute="_compute_model_description"
-    )
-    record_id = fields.Integer(readonly=True, help="Record ID to update")
+    model_names = fields.Char(readonly=True, help="Models to create records in")
     if_record_exists = fields.Selection(
         selection=[
+            ("skip", "Skip record"),
             ("update", "Update existing record"),
             ("create", "Create a new record"),
         ],
-        default="update",
+        default="skip",
         required=True,
         help="What to do if record with the same reference already exists",
     )
@@ -31,12 +33,6 @@ class CxTowerYamlImportWiz(models.TransientModel):
         compute="_compute_secret_list",
     )
     preview_code = fields.Boolean()
-
-    @api.depends("model_name")
-    def _compute_model_description(self):
-        """Compute model description"""
-        for record in self:
-            record.model_description = self.env[record.model_name]._description
 
     @api.depends("yaml_code")
     def _compute_secret_list(self):
@@ -59,48 +55,138 @@ class CxTowerYamlImportWiz(models.TransientModel):
 
         # Parse YAML code
         yaml_data = yaml.safe_load(self.yaml_code)
+        records = yaml_data.get("records")
+        if not records:
+            raise ValidationError(_("YAML file doesn't contain any records"))
 
-        # Update existing record
-        if (
-            self.record_id
-            and yaml_data.get("reference")
-            and self.if_record_exists == "update"
-        ):
-            record = self.env[self.model_name].browse(self.record_id)
-            record.update({"yaml_code": self.yaml_code})
-        else:
-            model = self.env[self.model_name]
+        # Cache models
+        models = {}
+        odoo_record_ids = []
+
+        # Process each record
+        for record in records:
+            record_reference = record.get("reference")
+            if not record_reference:
+                raise ValidationError(_("Record reference is missing"))
+            model_name = record.get("cetmix_tower_model")
+            if not model_name:
+                raise ValidationError(
+                    _("Record model is missing for record %s", record_reference)
+                )
+
+            # Get model from cache or create new one
+            model = models.get(model_name)
+            if not model:
+                model = self.env[f"cx.tower.{model_name.replace('_', '.')}"]
+                models[model_name] = model
+
+            # Get existing record by reference
+            # NOTE: we don't validate models here because they are
+            # already validated in the file upload wizard.
+            odoo_record = model.get_by_reference(record_reference)
+
+            # Skip
+            if self.if_record_exists == "skip" and odoo_record:
+                _logger.info(
+                    f"Skipping record '{record_reference}' in model '{model_name}'"
+                    " because it already exists"
+                )
+                continue
+
+            # Update existing record
+            if self.if_record_exists == "update" and odoo_record:
+                try:
+                    record_values = model.with_context(
+                        force_create_related_record=False
+                    )._post_process_yaml_dict_values(record)
+                    odoo_record.write(record_values)
+                    odoo_record_ids.append(odoo_record.id)
+                except Exception as e:
+                    raise ValidationError(
+                        _(
+                            "Error updating record %(reference)s: %(error)s",
+                            reference=record_reference,
+                            error=e,
+                        )
+                    ) from e
+                _logger.info(
+                    f"Updated record '{record_reference}' in model '{model_name}'"
+                )
+                continue
+
+            # Or create a new record
             record_values = model.with_context(
                 force_create_related_record=(self.if_record_exists == "create")
-            )._post_process_yaml_dict_values(yaml_data)
-            record = model.create(record_values)
+            )._post_process_yaml_dict_values(record)
+            try:
+                odoo_record = model.create(record_values)
+                odoo_record_ids.append(odoo_record.id)
+            except Exception as e:
+                raise ValidationError(
+                    _(
+                        "Error creating record '%(reference)s' in model"
+                        " '%(model)s': %(error)s",
+                        reference=record_reference,
+                        model=model_name,
+                        error=e,
+                    )
+                ) from e
+            _logger.info(f"Created record '{record_reference}' in model '{model_name}'")
 
-        # Open created record
-        return {
-            "name": record.display_name,
-            "type": "ir.actions.act_window",
-            "res_model": self.model_name,
-            "res_id": record.id,
-            "view_mode": "form",
-            "view_type": "form",
-            "target": "current",
-        }
-
-    def action_open_existing_record(self):
-        """Open existing record"""
-
-        if self.model_name and self.record_id:
-            record = self.env[self.model_name].browse(self.record_id)
-
-            return {
-                "name": record.display_name,
-                "type": "ir.actions.act_window",
-                "res_model": self.model_name,
-                "res_id": record.id,
-                "view_mode": "form",
-                "view_type": "form",
-                "target": "current",
+        # No records were created or updated
+        if not odoo_record_ids:
+            action = {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": _("Record Import"),
+                    "message": _("No records were created or updated"),
+                    "sticky": True,
+                    "type": "warning",
+                    "next": {"type": "ir.actions.act_window_close"},
+                },
             }
+
+        # All records from the same model
+        elif len(models) == 1:
+            model = list(models.values())[0]
+            action = {
+                "name": _("Import result: %(model)s", model=model._description),
+                "type": "ir.actions.act_window",
+                "res_model": model._name,
+                "target": "current",
+                "domain": [("id", "in", odoo_record_ids)],
+            }
+            if len(odoo_record_ids) == 1:
+                # Open single record in form view
+                action["res_id"] = odoo_record_ids[0]
+                action["view_mode"] = "form"
+            else:
+                # Open list view of all records
+                action["view_mode"] = "list"
+
+        # Records from different models
+        else:
+            model_names = ", ".join(
+                f"'{model._description}'" for model in models.values()
+            )
+            action = {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": _("Record Import"),
+                    "message": _(
+                        "Records of the following models were created "
+                        "or updated: %(models)s",
+                        models=model_names,
+                    ),
+                    "sticky": True,
+                    "type": "success",
+                    "next": {"type": "ir.actions.act_window_close"},
+                },
+            }
+
+        return action
 
     def _extract_secret_names(self, data: dict) -> list:
         """Extract names of secrets from YAML data.

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
@@ -7,18 +7,12 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="model_name" invisible="1" />
-                    <field name="record_id" invisible="1" />
-                    <field
-                        name="model_description"
-                        attrs="{'invisible': [('model_name', '=', False)]}"
-                    />
                     <field name="if_record_exists" />
                 </group>
                 <div
                     class="alert alert-warning"
                     role="alert"
-                    attrs="{'invisible': [('if_record_exists', '=', 'update')]}"
+                    attrs="{'invisible': [('if_record_exists', '!=', 'create')]}"
                     style="margin-bottom:0px;"
                 >
                 <p>
@@ -26,6 +20,7 @@
                         >Important:</strong> To maintain data consistency, the following model records will always be updated if they exist in Odoo:
                     <ul>
                         <li>Variables</li>
+                        <li>Variable Options</li>
                         <li>Key/Secrets</li>
                         <li>Tags</li>
                         <li>OSs</li>
@@ -37,7 +32,7 @@
                 <div
                     class="alert alert-warning"
                     role="alert"
-                    attrs="{'invisible': [('if_record_exists', '=', 'create')]}"
+                    attrs="{'invisible': [('if_record_exists', '!=', 'update')]}"
                     style="margin-bottom:0px;"
                 >
                     <p>
@@ -67,27 +62,19 @@
                 />
                 <footer>
                     <button
-                        string="Update Existing Record"
+                        string="Import"
                         type="object"
                         name="action_import_yaml"
                         class="oe_highlight"
-                        confirm="This will overwrite the existing record. Proceed?"
-                        attrs="{'invisible': [('record_id', '!=', False), ('if_record_exists', '=', 'create')]}"
+                        attrs="{'invisible': [('if_record_exists', '!=', 'update')]}"
+                        confirm="This may overwrite existing records. Proceed?"
                     />
                     <button
-                        string="Open Existing Record"
-                        type="object"
-                        name="action_open_existing_record"
-                        class="oe_highlight"
-                        attrs="{'invisible': ['|', ('record_id', '=', False), ('record_id', '=', 0)]}"
-                    />
-                    <button
-                        string="Create New Record"
+                        string="Import"
                         type="object"
                         name="action_import_yaml"
                         class="oe_highlight"
-                        confirm="This will create a new record. Proceed?"
-                        attrs="{'invisible': ['|', ('record_id', '=', False), ('if_record_exists', '=', 'update')]}"
+                        attrs="{'invisible': [('if_record_exists', '=', 'update')]}"
                     />
                     <button string="Close" special="cancel" />
                 </footer>

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
@@ -21,23 +21,15 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
     def action_import_yaml(self):
         """Parse YAML data to the import wizard
 
-        Args:
-            decoded_file (Text): YAML code
-            model_name (Char): Name of the Odoo model, if parsed from YAML
-            record_id (_type_): ID of the record, if passed from YAML
-
         Returns:
             Action Window: Action to open the import wizard
         """
 
-        decoded_file, model_name, record_id = self._extract_yaml_data()
+        decoded_file = self._extract_yaml_data()
 
         import_wizard = self.env["cx.tower.yaml.import.wiz"].create(
             {
                 "yaml_code": decoded_file,
-                "model_name": model_name,
-                "record_id": record_id,
-                "if_record_exists": "update" if record_id else "create",
             }
         )
 
@@ -53,11 +45,10 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
         """Extract data form YAML file and validate them
 
         Returns:
-            decoded_file, model_name, record_id
-            - decoded_file (Text): YAML code
-            - model_name (Char): Name of the Odoo model, if resolved
-            - record_id (_type_): ID of the record, if resolved
-
+            decoded_file (Text): YAML code
+            Raises:
+                ValidationError: If the YAML file is invalid
+                or contains unsupported data
         """
 
         self.ensure_one()
@@ -81,45 +72,60 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
         if not yaml_data or not isinstance(yaml_data, dict):
             raise ValidationError(_("Yaml file doesn't contain valid data"))
 
-        # Get Odoo model name from YAML
-        yaml_model = yaml_data.get("cetmix_tower_model")
-        if not yaml_model:
-            raise ValidationError(
-                _("No model for import is specified in the YAML file")
-            )
-
-        model_name = f"cx.tower.{yaml_model.replace('_', '.')}"
-
-        # Check if model exists
-        try:
-            model = self.env[model_name]
-        except KeyError as e:
-            raise ValidationError(_("Invalid model specified in the YAML file")) from e
-
-        # Check if model supports YAML import
-        if not hasattr(model, "yaml_code"):
-            raise ValidationError(_("Model does not support YAML import"))
-
-        # Check if YAML version is supported
-        yaml_version = yaml_data.get("cetmix_tower_yaml_version")
+        # Check Cetmix Tower YAML version
+        yaml_version = yaml_data.pop("cetmix_tower_yaml_version", None)
+        supported_version = self.env["cx.tower.yaml.mixin"].CETMIX_TOWER_YAML_VERSION
         if (
             yaml_version
             and isinstance(yaml_version, int)
-            and yaml_version > model.CETMIX_TOWER_YAML_VERSION
+            and yaml_version > supported_version
         ):
             raise ValidationError(
                 _(
-                    "YAML file version is not supported."
-                    " You may need to update the Cetmix Tower Yaml module."
+                    "YAML version is higher than version"
+                    " supported by your Cetmix Tower instance."
+                    " %(code_version)s > %(tower_version)s",
+                    code_version=yaml_version,
+                    tower_version=supported_version,
                 )
             )
 
-        # Get record id from YAML
-        record_reference = yaml_data.get("reference")
-        if record_reference:
-            record = model.get_by_reference(record_reference)
-            record_id = record and record.id or False
-        else:
-            record_id = False
+        # Get records from YAML
+        records = yaml_data.get("records")
+        if not records:
+            raise ValidationError(_("YAML file doesn't contain any records"))
 
-        return decoded_file, model_name, record_id
+        # Collect and validate all record models
+        ir_model_obj = self.env["ir.model"]
+        unique_models = {}
+
+        # First pass: check all records have models and collect unique models
+        for record in records:
+            record_model = record.get("cetmix_tower_model")
+            if not record_model:
+                raise ValidationError(
+                    _(
+                        "Record model is missing for record %s",
+                        record.get("reference", ""),
+                    )
+                )
+            if record_model not in unique_models:
+                odoo_model = f"cx.tower.{record_model}".replace("_", ".")
+                unique_models[record_model] = odoo_model
+
+        # Second pass: validate all unique models in a single query
+        odoo_models = list(unique_models.values())
+        valid_models = {
+            model.model: model
+            for model in ir_model_obj.search([("model", "in", odoo_models)])
+        }
+
+        # Third pass: check models exist and support YAML import
+        for record_model, odoo_model in unique_models.items():
+            if odoo_model not in valid_models:
+                raise ValidationError(_("'%s' is not a valid model", record_model))
+            if not hasattr(self.env[odoo_model], "yaml_code"):
+                raise ValidationError(
+                    _("Model '%s' does not support YAML import", record_model)
+                )
+        return decoded_file


### PR DESCRIPTION
Before
------

Records were exported and imported one by one.
This was not so handy, especially when importing a lot of records or handling complex configurations.

After
-----

Multiple records can be exported and imported at once.
Moreover, records from different models can be mixed in the same file and imported all together.
This adds flexibility and improves the UX.

Task: 4446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated actions for exporting YAML data across different sections.

- **Enhancements**
  - Improved the YAML export process with more robust error handling.
  - Upgraded the YAML import wizard to support multiple models and provide clearer error messaging.

- **Refactor**
  - Simplified YAML processing by removing redundant version validations for cleaner record handling.
  - Streamlined test cases by eliminating checks related to YAML versioning.
  - Added a new field "required" to the YAML output structure in variable value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->