### PR TITLE
[14.0][IMP] cetmix_tower_server: variable value modifier

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -1,6 +1,25 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
+from odoo.tools.safe_eval import wrap_module
+
+re = wrap_module(
+    __import__("re"),
+    [
+        "match",
+        "fullmatch",
+        "search",
+        "sub",
+        "subn",
+        "split",
+        "findall",
+        "finditer",
+        "compile",
+        "template",
+        "escape",
+        "error",
+    ],
+)
 
 
 class TowerVariable(models.Model):
@@ -29,6 +48,14 @@ class TowerVariable(models.Model):
         default="s",
         required=True,
         string="Type",
+    )
+    applied_expression = fields.Text(
+        help="Python expression to apply to the variable value. \n"
+        "You can use general python sting functions and 're' module "
+        "for regex operations. "
+        "Use 'value' variable to refer to the variable value, use 'result'"
+        " to assign the final result that will be used as a variable value.\n"
+        "Eg 'result = value.lower().replace(' ', '_')'",
     )
     note = fields.Text()
 
@@ -204,4 +231,21 @@ class TowerVariable(models.Model):
             "views": [[False, "tree"]],
             "target": "current",
             "domain": [("variable_ids", "in", self.ids)],
+        }
+
+    @api.model
+    def _get_eval_context(self, value_char=None):
+        """
+        Evaluation context to pass to safe_eval to evaluate
+        the Python expression used in the `applied_expression` field
+
+        Args:
+            value_char (Char): variable value
+
+        Returns:
+            dict: evaluation context
+        """
+        return {
+            "re": re,
+            "value": value_char,
         }

--- a/cetmix_tower_server/models/cx_tower_variable_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_variable_mixin.py
@@ -1,9 +1,13 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 import re
 import uuid
 
 from odoo import fields, models
+from odoo.tools.safe_eval import safe_eval
+
+_logger = logging.getLogger(__name__)
 
 
 class TowerVariableMixin(models.AbstractModel):
@@ -55,7 +59,13 @@ class TowerVariableMixin(models.AbstractModel):
                             == variable_reference
                         )
                         if value:
-                            res_vars.update({variable_reference: value.value_char})
+                            res_vars.update(
+                                {
+                                    variable_reference: self._apply_applied_expression(
+                                        value
+                                    )
+                                }
+                            )
 
                 res.update({rec.id: res_vars})
 
@@ -93,7 +103,13 @@ class TowerVariableMixin(models.AbstractModel):
                         variable_reference=variable_reference: v.variable_reference
                         == variable_reference
                     )
-                    res_vars.update({variable_reference: value.value_char or None})
+                    res_vars.update(
+                        {
+                            variable_reference: self._apply_applied_expression(value)
+                            if value
+                            else None
+                        }
+                    )
                 res.update({rec.id: res_vars})
         return res
 
@@ -224,3 +240,34 @@ class TowerVariableMixin(models.AbstractModel):
                 variables[key] = TemplateMixin.render_code_custom(
                     var_value, **res[self.id]
                 )
+
+    def _apply_applied_expression(self, value):
+        """Apply pre-defined Python expression to the variable value.
+
+        Args:
+            value (str): variable value
+
+        Returns:
+            str: evaluated value
+        """
+        if value.variable_id.applied_expression:
+            eval_context = self.env["cx.tower.variable"]._get_eval_context(
+                value.value_char
+            )
+            try:
+                safe_eval(
+                    value.variable_id.applied_expression,
+                    eval_context,
+                    mode="exec",
+                    nocopy=True,
+                )
+                return eval_context.get("result")
+            except Exception as e:
+                _logger.error(
+                    "Error evaluating applied expression for "
+                    "variable %s value %s: %s",
+                    value.variable_id.name,
+                    value.value_char,
+                    str(e),
+                )
+        return value.value_char

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -8,6 +8,10 @@ from odoo.osv.expression import OR
 
 
 class TowerVariableValue(models.Model):
+    """
+    This model is used to store variable values.
+    """
+
     _name = "cx.tower.variable.value"
     _description = "Cetmix Tower Variable Values"
     _inherit = [

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -2,11 +2,21 @@ from unittest.mock import patch
 
 from odoo.exceptions import AccessError
 from odoo.tests.common import Form
+from odoo.tools import mute_logger
 
 from .common import TestTowerCommon
 
 
 class TestTowerCommand(TestTowerCommon):
+    """
+    Test the command model.
+
+    Important!
+    As this model inherits from the `cx.tower.template.mixin`
+    we will tests template rendering methods in this class too.
+
+    """
+
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
 
@@ -654,6 +664,67 @@ COMMAND_RESULT = {
         )
         self.assertFalse(
             rendered_command["rendered_path"], "Rendered path doesn't match"
+        )
+
+    def test_server_render_command_variable_with_value_modifier(self):
+        """Test rendering command using `_render_command` method
+        of cx.tower.server.
+        Use variable with value modifier for testing.
+        """
+
+        # -- 1 --
+        # Set modifiers for variables
+        modifier_for_path = """
+if 'opt' in value:
+    result = value.replace('opt', 'home')
+else:
+    result = value
+"""
+        self.variable_path.applied_expression = modifier_for_path
+
+        modifier_for_dir = """
+pattern = r'(?i)odoo'
+replacement = 'sap'
+result = re.sub(pattern, replacement, value)
+"""
+        self.variable_dir.applied_expression = modifier_for_dir
+
+        # -- 1 --
+        # Test with default path
+        rendered_command = self.server_test_1._render_command(self.command_create_dir)
+        rendered_code_expected = "cd /home/tower && mkdir test-sap-1"
+        rendered_path_expected = f"/home/{self.server_test_1.ssh_username}"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+        self.assertEqual(
+            rendered_command["rendered_path"],
+            rendered_path_expected,
+            "Rendered path doesn't match",
+        )
+
+        # -- 2 --
+        # Set invalid expression modifier
+        self.variable_path.applied_expression = "invalid"
+        with mute_logger("odoo.addons.cetmix_tower_server"):
+            rendered_command = self.server_test_1._render_command(
+                self.command_create_dir
+            )
+        rendered_code_expected = "cd /opt/tower && mkdir test-sap-1"
+        rendered_path_expected = f"/home/{self.server_test_1.ssh_username}"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+        self.assertEqual(
+            rendered_command["rendered_path"],
+            rendered_path_expected,
+            "Rendered path doesn't match",
         )
 
     def test_render_code_generic(self):

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -153,6 +153,34 @@
                                 </form>
                             </field>
                         </page>
+                        <page name="value_modifier" string="Value Modifier">
+                            <div class="alert alert-info" role="alert">
+                            <p>
+                                Python code that is used to modify the variable values.
+                                <br />
+                                Available variables and functions:
+                                <ul>
+                                    <li>value: variable value</li>
+                                    <li
+                                        >result: final result that will be used as a variable value</li>
+                                    <li
+                                        >general python functions (eg. lower(), replace(), etc.)</li>
+                                    <li
+                                        >re: regex operations (eg. re.sub, re.match, etc.)</li>
+                                </ul>
+                                Example:
+                                <br />
+                                <code>
+                                    result = value.lower().replace(' ', '_') if value.startswith('http') else 'https://' + re.sub(r'\s+', '', value)
+                                </code>
+                            </p>
+                            </div>
+                            <field
+                                name="applied_expression"
+                                widget="ace"
+                                options="{'mode': 'python'}"
+                            />
+                        </page>
                     </notebook>
                 </sheet>
             </form>


### PR DESCRIPTION
Allow to modify variable values using Python code.

Why?
----

In case we need to post-process the variable value, for example to remove special characters or modify it based on some logic. Eg. we have a variable which values are used for URLs, so we want to remove all special characters from the value.

Task: 4474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic way to modify variable values using secure Python expressions.
  - Added a new "Value Modifier" page featuring an interactive code editor (with Python mode) that lets users apply custom transformations—including regex and string functions—to variable values.

- **Bug Fixes**
  - Improved error handling for invalid expression modifiers in command rendering.

- **Documentation**
  - Added a docstring to the `TowerVariableValue` class to clarify its purpose.

- **Tests**
  - Enhanced testing coverage for command rendering with variable modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->