### PR TITLE
[14.0][FIX] cetmix_tower_server: Variable modifier

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_variable_mixin.py
@@ -25,11 +25,12 @@ class TowerVariableMixin(models.AbstractModel):
         help="Variable values for selected record",
     )
 
-    def get_variable_values(self, variable_references):
+    def get_variable_values(self, variable_references, apply_modifiers=True):
         """Get variable values for selected records
 
         Args:
             variable_references (list of Char): variable names
+            apply_modifiers (bool): apply Python modifiers to the values
 
         Returns:
             dict {record_id: {variable_reference: value}}
@@ -59,20 +60,18 @@ class TowerVariableMixin(models.AbstractModel):
                             == variable_reference
                         )
                         if value:
-                            res_vars.update(
-                                {
-                                    variable_reference: self._apply_applied_expression(
-                                        value
-                                    )
-                                }
-                            )
+                            res_vars.update({variable_reference: value.value_char})
 
                 res.update({rec.id: res_vars})
 
+            # Final render
             # Render templates in values
-            for variables in res.values():
-                self._render_variable_values(variables)
+            for variable_values in res.values():
+                self._render_variable_values(variable_values)
 
+        # Apply modifiers
+        if apply_modifiers:
+            self._apply_modifiers(res)
         return res
 
     def get_global_variable_values(self, variable_references):
@@ -104,11 +103,7 @@ class TowerVariableMixin(models.AbstractModel):
                         == variable_reference
                     )
                     res_vars.update(
-                        {
-                            variable_reference: self._apply_applied_expression(value)
-                            if value
-                            else None
-                        }
+                        {variable_reference: value.value_char if value else None}
                     )
                 res.update({rec.id: res_vars})
         return res
@@ -212,7 +207,7 @@ class TowerVariableMixin(models.AbstractModel):
         ]
         return domain
 
-    def _render_variable_values(self, variables):
+    def _render_variable_values(self, variable_values):
         """Renders variable values using other variable values.
         For example we have the following values:
             "server_root": "/opt/server"
@@ -222,52 +217,67 @@ class TowerVariableMixin(models.AbstractModel):
             "server_assets": "/opt/server/assets"
 
         Args:
-            variables (dict): values to complete
+            variable_values (dict): values to complete
         """
         self.ensure_one()
         TemplateMixin = self.env["cx.tower.template.mixin"]
-        for key in variables:
-            var_value = variables[key]
+        for key, var_value in variable_values.items():
             # Render only if template is found
             if var_value and "{{ " in var_value:
                 # Get variables used in value
                 value_vars = TemplateMixin.get_variables_from_code(var_value)
 
                 # Render variables used in value
-                res = self.get_variable_values(value_vars)
+                res = self.get_variable_values(value_vars, apply_modifiers=True)
 
                 # Render value using variables
-                variables[key] = TemplateMixin.render_code_custom(
+                variable_values[key] = TemplateMixin.render_code_custom(
                     var_value, **res[self.id]
                 )
 
-    def _apply_applied_expression(self, value):
-        """Apply pre-defined Python expression to the variable value.
+    def _apply_modifiers(self, variable_values):
+        """Apply pre-defined Python expression to the dictionary
+            of variable values.
 
         Args:
-            value (str): variable value
-
-        Returns:
-            str: evaluated value
+            variable_values (dict): variable values
+            {record_id: {variable_reference: value}}
         """
-        if value.variable_id.applied_expression:
-            eval_context = self.env["cx.tower.variable"]._get_eval_context(
-                value.value_char
-            )
-            try:
-                safe_eval(
-                    value.variable_id.applied_expression,
-                    eval_context,
-                    mode="exec",
-                    nocopy=True,
-                )
-                return eval_context.get("result")
-            except Exception as e:
-                _logger.error(
-                    "Error evaluating applied expression for "
-                    "variable %s value %s: %s",
-                    value.variable_id.name,
-                    value.value_char,
-                    str(e),
-                )
-        return value.value_char
+        variable_obj = self.env["cx.tower.variable"]
+
+        for record_id, values in variable_values.items():
+            for variable_reference, value in values.items():
+                if not value:
+                    continue
+
+                # ORM should cache resolved variables
+                variable = variable_obj.get_by_reference(variable_reference)
+
+                # Should never happen.. anyway
+                if not variable:
+                    continue
+
+                # Skip if no expression to apply
+                if not variable.applied_expression:
+                    continue
+
+                # Evaluate expression
+                eval_context = variable_obj._get_eval_context(value)
+                try:
+                    safe_eval(
+                        variable.applied_expression,
+                        eval_context,
+                        mode="exec",
+                        nocopy=True,
+                    )
+                    variable_values[record_id][variable_reference] = eval_context.get(
+                        "result"
+                    )
+                except Exception as e:
+                    _logger.error(
+                        "Error evaluating applied expression for "
+                        "variable %s value %s: %s",
+                        variable.name,
+                        value,
+                        str(e),
+                    )

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -727,6 +727,52 @@ result = re.sub(pattern, replacement, value)
             "Rendered path doesn't match",
         )
 
+        # -- 3 --
+        # Test with variable in variable value
+        complex_variable = self.Variable.create(
+            {
+                "name": "Complex Variable",
+                "applied_expression": "result = value.replace('opt', 'meme')",
+            }
+        )
+        # Create a complex variable value
+        self.VariableValue.create(
+            {
+                "variable_id": complex_variable.id,
+                "value_char": "{{ test_path_ }}/{{ test_dir }}",
+            }
+        )
+        command_with_complex_variable = self.Command.create(
+            {
+                "name": "Command with complex variable",
+                "code": "cd {{ complex_variable }}",
+                "action": "ssh_command",
+            }
+        )
+        rendered_command = self.server_test_1._render_command(
+            command_with_complex_variable
+        )
+        rendered_code_expected = "cd /meme/tower/test-sap-1"
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+
+        # -- 4 --
+        # Remove modifier from variable "Path" and check again
+        self.variable_dir.applied_expression = None
+        rendered_command = self.server_test_1._render_command(
+            command_with_complex_variable
+        )
+        rendered_code_expected = "cd /meme/tower/test-odoo-1"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+
     def test_render_code_generic(self):
         """Test generic (aka ssh) code template direct rendering"""
 

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -171,7 +171,7 @@
                                 Example:
                                 <br />
                                 <code>
-                                    result = value.lower().replace(' ', '_') if value.startswith('http') else 'https://' + re.sub(r'\s+', '', value)
+                                result = value.lower().strip().replace('_', '-').replace(" ","") if value.startswith('http') else 'https://' + re.sub(r'\s+', '', value)
                                 </code>
                             </p>
                             </div>


### PR DESCRIPTION
Fix issue when variable modifiers were not applied to variables used in another variable values.
Eg if for a variable `sentence` with value `{{ word_1 }} + {{ word_2}}` modifiers were applied only to `sentence` but not to `word_1` and `word_2`.

Task: 4490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of variable values with optional modifiers, resulting in more consistent command outputs and clearer text formatting.
- **Tests**
  - Added test cases to ensure reliable rendering of commands with transformed variable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->