### PR TITLE
[FIX] cetmix_tower_server: Server status widget

### DIFF
--- a/cetmix_tower_server/static/src/components/server_status/server_status_field.esm.js
+++ b/cetmix_tower_server/static/src/components/server_status/server_status_field.esm.js
@@ -18,6 +18,13 @@ export class ServerStatusField extends StateSelectionField {
     /**
      * @override
      */
+    get options() {
+        return [[false, "Undefined"], ...super.options];
+    }
+
+    /**
+     * @override
+     */
     get showLabel() {
         return !this.props.hideLabel;
     }

--- a/cetmix_tower_server/static/src/utils/server_utils.esm.js
+++ b/cetmix_tower_server/static/src/utils/server_utils.esm.js
@@ -4,7 +4,7 @@
  * List of colors according to the selection value
  */
 export const STATUS_COLORS = {
-    undefined: "info",
+    false: "info",
     stopped: "danger",
     starting: "warning",
     running: "success",


### PR DESCRIPTION
- Fix "undefined" server status widget

Task: 4545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Undefined" option to the server status selection field.

- **Bug Fixes**
  - Improved handling and display of status colors for uninitialized or undefined server statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->