### PR TITLE
[14.0][IMP] cetmix_tower_server_queue: Cancel stuck jobs

### DIFF
--- a/cetmix_tower/readme/newsfragments/4550.feature
+++ b/cetmix_tower/readme/newsfragments/4550.feature
@@ -1,0 +1,1 @@
+Cancel the related queue job when a command is forcefully stopped.

--- a/cetmix_tower_server_queue/__manifest__.py
+++ b/cetmix_tower_server_queue/__manifest__.py
@@ -12,4 +12,7 @@
     "installable": True,
     "auto_install": True,
     "depends": ["cetmix_tower_server", "queue_job"],
+    "data": [
+        "views/cx_tower_command_log_view.xml",
+    ],
 }

--- a/cetmix_tower_server_queue/models/__init__.py
+++ b/cetmix_tower_server_queue/models/__init__.py
@@ -1,1 +1,2 @@
+from . import cx_tower_command_log
 from . import cx_tower_server

--- a/cetmix_tower_server_queue/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_queue/models/cx_tower_command_log.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+from odoo.addons.cetmix_tower_server.models.constants import COMMAND_TIMED_OUT
+from odoo.addons.queue_job.job import CANCELLED
+
+
+class CxTowerCommandLog(models.Model):
+    _inherit = "cx.tower.command.log"
+
+    queue_job_id = fields.Many2one(
+        "queue.job",
+        readonly=True,
+        groups="queue_job.group_queue_job_manager",
+    )
+
+    def finish(
+        self, finish_date=None, status=None, response=None, error=None, **kwargs
+    ):
+        res = super().finish(finish_date, status, response, error, **kwargs)
+        if status == COMMAND_TIMED_OUT:
+            self.queue_job_id.sudo()._change_job_state(CANCELLED, result=error)
+        return res

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -21,7 +21,7 @@ class CxTowerServer(models.Model):
         # preserve the order of execution of commands with action “Run flight plan”.
         # Use runner only if command log record is provided.
         if log_record and not log_record.plan_log_id.parent_flight_plan_log_id:
-            self.with_delay()._command_runner(
+            job = self.with_delay()._command_runner(
                 command,
                 log_record,
                 rendered_command_code,
@@ -29,6 +29,7 @@ class CxTowerServer(models.Model):
                 ssh_connection,
                 **kwargs,
             )
+            log_record.sudo().queue_job_id = job.db_record().id
 
         # Otherwise fallback to `super` to return the command output
         else:

--- a/cetmix_tower_server_queue/readme/newsfragments/4550.feature
+++ b/cetmix_tower_server_queue/readme/newsfragments/4550.feature
@@ -1,0 +1,1 @@
+Cancel the related queue job when a command is forcefully stopped.

--- a/cetmix_tower_server_queue/tests/__init__.py
+++ b/cetmix_tower_server_queue/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_command

--- a/cetmix_tower_server_queue/tests/test_command.py
+++ b/cetmix_tower_server_queue/tests/test_command.py
@@ -1,0 +1,142 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo.fields import Datetime
+
+from odoo.addons.cetmix_tower_server.tests.common import TestTowerCommon
+
+
+class TestTowerCommand(TestTowerCommon):
+    """Test suite for verifying zombie command detection and related
+    queue job cancellation.
+
+    Tests in this class verify that commands which have been running
+    longer than the timeout are properly detected as zombies, and their
+    associated queue jobs are cancelled.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Set command timeout to 10 seconds
+        self.env["ir.config_parameter"].sudo().set_param(
+            "cetmix_tower_server.command_timeout", "10"
+        )
+        # Set old time to 20 seconds ago (older than timeout)
+        # to simulate running command in past
+        now = Datetime.now()
+        self.old_time = now - timedelta(seconds=20)
+
+    def _patch_command_runner(self, command_type, runner_method):
+        """Helper to patch a command runner to simulate a zombie command.
+
+        Args:
+            command_type: Type of command runner to patch ('ssh' or 'python_code')
+            runner_method: Original method to wrap
+
+        Returns:
+            A context manager that applies the patch
+        """
+
+        def _wrapper(*args, **kwargs):
+            # Modify args to disable log record finishing
+            args = list(args)
+            if len(args) > 1:
+                args[1] = False  # Set log_record to False
+            return runner_method(*args, **kwargs)
+
+        return patch.object(
+            self.registry["cx.tower.server"],
+            f"_command_runner_{command_type}",
+            _wrapper,
+        )
+
+    def _verify_zombie_command_job_cancellation(self, command_action):
+        """Verify zombie command is detected and job is cancelled.
+
+        Args:
+            command_action: Action type ('ssh_command' or 'python_code')
+        """
+        # check zombie command logs
+        domain = [
+            ("is_running", "=", True),
+            ("start_date", "=", self.old_time),
+            ("command_action", "=", command_action),
+        ]
+        zombie_command_logs = self.env["cx.tower.command.log"].search(domain)
+
+        self.assertEqual(
+            len(zombie_command_logs), 1, "Zombie command log should be created"
+        )
+        self.assertTrue(
+            zombie_command_logs.queue_job_id,
+            "Zombie command log should have queue job",
+        )
+
+        job = self.env["queue.job"].search(
+            [("id", "=", zombie_command_logs.queue_job_id.id)]
+        )
+        self.assertEqual(job.state, "pending", "Zombie command job should be pending")
+
+        # run process to kill zombie command
+        self.server_test_1._check_zombie_commands()
+
+        # check that command log is cancelled
+        self.assertEqual(
+            job.state, "cancelled", "Zombie command job should be cancelled"
+        )
+
+    def test_check_zombie_ssh_command_queue(self):
+        """
+        Test that zombie ssh command is killed and job is cancelled
+        """
+        # Create test commands
+        ssh_command = self.Command.create(
+            {
+                "name": "Test SSH Command",
+                "code": "ls -la",
+                "action": "ssh_command",
+            }
+        )
+
+        # patch command runner to not finish log record
+        cx_tower_server_obj = self.registry["cx.tower.server"]
+        _command_runner_ssh_super = cx_tower_server_obj._command_runner_ssh
+
+        with self._patch_command_runner("ssh", _command_runner_ssh_super):
+            # run zombie command with log creation in past
+            self.server_test_1.run_command(
+                ssh_command, log={"start_date": self.old_time}
+            )
+
+        # check zombie command logs
+        self._verify_zombie_command_job_cancellation("ssh_command")
+
+    def test_check_zombie_python_command_queue(self):
+        """
+        Test that zombie python command is killed and job is cancelled
+        """
+        # Create test commands
+        python_command = self.Command.create(
+            {
+                "name": "Test Python Command",
+                "code": "print('test')",
+                "action": "python_code",
+            }
+        )
+
+        # patch command runner to not finish log record
+        cx_tower_server_obj = self.registry["cx.tower.server"]
+        _command_runner_python_code_super = (
+            cx_tower_server_obj._command_runner_python_code
+        )
+
+        with self._patch_command_runner(
+            "python_code", _command_runner_python_code_super
+        ):
+            # run zombie command with log creation in past
+            self.server_test_1.run_command(
+                python_command, log={"start_date": self.old_time}
+            )
+
+        # check zombie command logs
+        self._verify_zombie_command_job_cancellation("python_code")

--- a/cetmix_tower_server_queue/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server_queue/views/cx_tower_command_log_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="cx_tower_command_log_view_form" model="ir.ui.view">
+        <field name="name">cx.tower.command.log.view.form</field>
+        <field name="model">cx.tower.command.log</field>
+        <field
+            name="inherit_id"
+            ref="cetmix_tower_server.cx_tower_command_log_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='command_id']" position="after">
+                <field
+                    name="queue_job_id"
+                    attrs="{'invisible': [('queue_job_id', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Cancel related stuck jobs after finished zombie commands

Task: 4550


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tracking of queue job IDs in command logs for improved traceability.
  - Added automatic cancellation of related queue jobs when commands time out or are forcefully stopped.
  - Added a new view displaying queue job information within command logs.

- **Bug Fixes**
  - Enhanced detection and cleanup of zombie (stuck) commands, ensuring pending jobs are cancelled.

- **Tests**
  - Added tests verifying zombie command detection and queue job cancellation for SSH and Python commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->