### PR TITLE
[14.0][IMP] cetmix_tower_server: Provide custom variable values directly in command  

### DIFF
--- a/cetmix_tower/README.rst
+++ b/cetmix_tower/README.rst
@@ -34,6 +34,14 @@ Tower <https://cetmix.com/tower>`__ modules at once.
 .. contents::
    :local:
 
+Changelog
+=========
+
+14.0.1.0.0
+----------
+
+Release for Odoo 14.0
+
 Bug Tracker
 ===========
 

--- a/cetmix_tower/readme/HISTORY.md
+++ b/cetmix_tower/readme/HISTORY.md
@@ -1,0 +1,3 @@
+## 14.0.1.0.0
+
+Release for Odoo 14.0

--- a/cetmix_tower/readme/newsfragments/4524.feature
+++ b/cetmix_tower/readme/newsfragments/4524.feature
@@ -1,0 +1,1 @@
+Allow to pass custom variable values to commands

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -795,8 +795,12 @@ class CxTowerServer(models.Model):
                 the ssh command running.
             kwargs (dict):  extra arguments. Use to pass external values.
                 Following keys are supported by default:
-                    - "log": {values passed to logger}
-                    - "key": {values passed to key parser}
+                    - "log", dict(): values passed to logger
+                    - "key", dict(): values passed to key parser
+                    - "variable_values", dict(): custom variable values
+                        in the format of `{variable_reference: variable_value}`
+                        eg `{'odoo_version': '16.0'}`
+                        Will be applied only if user has write access to the server.
         Context:
             no_command_log (Bool): set this context key to `True`
                 to disable the command log creation.
@@ -864,8 +868,8 @@ class CxTowerServer(models.Model):
                     )
                     return
 
-        # Render command
-        rendered_command = self._render_command(command, path)
+        custom_variable_values = kwargs.get("variable_values", {})
+        rendered_command = self._render_command(command, path, custom_variable_values)
         rendered_command_code = rendered_command["rendered_code"]
         rendered_command_path = rendered_command["rendered_path"]
 
@@ -895,7 +899,7 @@ class CxTowerServer(models.Model):
             **kwargs,
         )
 
-    def _render_command(self, command, path=None):
+    def _render_command(self, command, path=None, custom_variable_values=None):
         """Renders command code for selected command for current server
 
         Args:
@@ -938,10 +942,15 @@ class CxTowerServer(models.Model):
 
         # Extract variable values for current server
         variable_values = (
-            variable_values_dict.get(self.id) if variable_values_dict else False
+            variable_values_dict.get(self.id) if variable_values_dict else {}
         )  # pylint: disable=no-member
 
-        # Render command code using variables
+        # Apply custom variable values only if user has write access to the server
+        has_write_access = self._have_access_to_server("write")
+        if custom_variable_values and has_write_access:
+            variable_values.update(custom_variable_values)
+
+        # Render command code and path using variables
         if variable_values:
             if command.action == "python_code":
                 variable_values["pythonic_mode"] = True
@@ -960,6 +969,28 @@ class CxTowerServer(models.Model):
             rendered_path = path
 
         return {"rendered_code": rendered_code, "rendered_path": rendered_path}
+
+    def _have_access_to_server(self, operation):
+        """Check access to the server.
+        This is a wrapper function over the Odoo built-in ones.
+        It's used in order we need to implement custom access checks.
+
+        Args:
+            operation (Char): Operation to check access
+                same format as `check_access_rights`
+        Returns:
+            Bool: True if access is granted, False otherwise
+        """
+        # Check access rights first
+        has_write_access = self.check_access_rights(operation, raise_exception=False)
+
+        # Check access rule to parti
+        if has_write_access:
+            try:
+                self.check_access_rule(operation)
+            except UserError:
+                has_write_access = False
+        return has_write_access
 
     def run_flight_plan(self, flight_plan, **kwargs):
         """

--- a/cetmix_tower_server/readme/newsfragments/4524.feature
+++ b/cetmix_tower_server/readme/newsfragments/4524.feature
@@ -1,0 +1,1 @@
+Allow to pass custom variable values to commands

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -17,6 +17,7 @@ access_command_user,Command->User,model_cx_tower_command,group_user,1,0,0,0
 access_command_manager,Command->Manager,model_cx_tower_command,group_manager,1,1,1,1
 access_command_root,Command->Root,model_cx_tower_command,group_root,1,1,1,1
 access_run_command_user,Run Command->User,model_cx_tower_command_run_wizard,group_user,1,1,1,1
+access_run_command_variable_value_user,Run Command Variable Value->User,model_cx_tower_command_run_wizard_variable_value,group_user,1,1,1,1
 access_execute_plan_user,Run Plan->User,model_cx_tower_plan_run_wizard,group_user,1,1,1,1
 access_key_user,Key->User,model_cx_tower_key,group_user,0,0,0,0
 access_key_manager,Key->Manager,model_cx_tower_key,group_manager,1,1,1,1

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -674,6 +674,64 @@ result = {
             rendered_command["rendered_path"], "Rendered path doesn't match"
         )
 
+    def test_server_render_command_with_custom_variable_values(self):
+        """Test rendering command using `_render_command` method
+        of cx.tower.server with custom variable values
+        """
+        self.write_and_invalidate(
+            self.server_test_1,
+            **{"user_ids": [(4, self.user.id)], "manager_ids": [(4, self.manager.id)]},
+        )
+        # -- 1 --
+        # Set custom variable values
+        custom_variable_values = {
+            "test_path_": "/pepe/memes",
+            "other_path": "/etc/chad",
+        }
+
+        # Modify command path
+        self.write_and_invalidate(
+            self.command_create_dir,
+            **{"path": "{{ other_path }}/{{ tower.server.username }}"},
+        )
+
+        # Render command
+        rendered_command = self.server_test_1.with_user(self.manager)._render_command(
+            self.command_create_dir, custom_variable_values=custom_variable_values
+        )
+        rendered_code_expected = "cd /pepe/memes && mkdir test-odoo-1"
+        rendered_path_expected = f"/etc/chad/{self.server_test_1.ssh_username}"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+        self.assertEqual(
+            rendered_command["rendered_path"],
+            rendered_path_expected,
+            "Rendered path doesn't match",
+        )
+
+        # -- 2 --
+        # Test with user who doesn't have access to the server
+        rendered_command = self.server_test_1.with_user(self.user)._render_command(
+            self.command_create_dir, custom_variable_values=custom_variable_values
+        )
+        rendered_code_expected = "cd /opt/tower && mkdir test-odoo-1"
+        rendered_path_expected = f"None/{self.server_test_1.ssh_username}"
+
+        self.assertEqual(
+            rendered_command["rendered_code"],
+            rendered_code_expected,
+            "Rendered code doesn't match",
+        )
+        self.assertEqual(
+            rendered_command["rendered_path"],
+            rendered_path_expected,
+            "Rendered path doesn't match",
+        )
+
     def test_server_render_command_variable_with_value_modifier(self):
         """Test rendering command using `_render_command` method
         of cx.tower.server.

--- a/cetmix_tower_server/tests/test_command_wizard.py
+++ b/cetmix_tower_server/tests/test_command_wizard.py
@@ -4,6 +4,8 @@ from .common import TestTowerCommon
 
 
 class TestTowerCommandWizard(TestTowerCommon):
+    """Test Tower Command Run Wizard"""
+
     def test_user_access_rules(self):
         """Test user access rules"""
 
@@ -248,3 +250,184 @@ class TestTowerCommandWizard(TestTowerCommon):
             test_wizard.result,
             msg="Command execution should succeed with a single server selected",
         )
+
+    def test_custom_variable_values_creation(self):
+        """
+        Test that custom variable values are created properly
+        when command has variables
+        """
+        # Add manager as server user
+        self.server_test_1.write({"user_ids": [(4, self.manager.id)]})
+
+        # Create variables that will be used in command
+        variable = self.Variable.create(
+            {
+                "name": "Test Variable",
+                "reference": "test_var",
+                "variable_type": "s",  # string type
+            }
+        )
+        option_variable = self.Variable.create(
+            {
+                "name": "Option Variable",
+                "reference": "opt_var",
+                "variable_type": "o",  # option type
+            }
+        )
+        option = self.VariableOption.create(
+            {
+                "name": "Test Option",
+                "value_char": "option_value",
+                "variable_id": option_variable.id,
+            }
+        )
+
+        # Add variable values to server
+        self.VariableValue.create(
+            [
+                {
+                    "variable_id": variable.id,
+                    "server_id": self.server_test_1.id,
+                    "value_char": "server value",
+                },
+                {
+                    "variable_id": option_variable.id,
+                    "server_id": self.server_test_1.id,
+                    "value_char": "option_value",
+                },
+            ]
+        )
+
+        # Create command that uses these variables in its code
+        command = self.Command.create(
+            {
+                "name": "Test Command with Variables",
+                "action": "ssh_command",
+                "code": "echo {{ test_var }} && echo {{ opt_var }}",
+            }
+        )
+
+        # Create wizard
+        wizard = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.manager)
+            .create(
+                {
+                    "server_ids": [self.server_test_1.id],
+                    "command_id": command.id,
+                    "action": "ssh_command",
+                }
+            )
+        )
+
+        # Trigger onchange to generate custom_variable_values
+        wizard._onchange_command_variable_ids()
+
+        # Check that custom variable values were created
+        self.assertEqual(len(wizard.custom_variable_values), 2)
+
+        # Check char variable value
+        char_value = wizard.custom_variable_values.filtered(
+            lambda v: v.variable_id == variable
+        )
+        self.assertTrue(char_value)
+        self.assertEqual(char_value.value_char, "server value")
+
+        # Check option variable value
+        option_value = wizard.custom_variable_values.filtered(
+            lambda v: v.variable_id == option_variable
+        )
+        self.assertTrue(option_value)
+        self.assertEqual(option_value.value_char, "option_value")
+        self.assertEqual(option_value.option_id, option)
+
+        # Try to change variable value when user doesn't have write access
+        char_value.value_char = "custom value"
+
+        # Run command
+        wizard.run_command_on_server()
+
+        # Get latest command log
+        command_log = self.env["cx.tower.command.log"].search(
+            [
+                ("server_id", "=", self.server_test_1.id),
+                ("command_id", "=", command.id),
+            ],
+            order="create_date desc",
+            limit=1,
+        )
+
+        # Verify that original server values were used
+        self.assertEqual(command_log.code, "echo server value && echo option_value")
+
+    def test_custom_variable_values_with_manager_access(self):
+        """
+        Test that custom variable values are applied
+        when manager has write access
+        """
+        # Add manager as server manager
+        self.server_test_1.write({"manager_ids": [(4, self.manager.id)]})
+
+        # Create variables that will be used in command
+        variable = self.Variable.create(
+            {
+                "name": "Test Variable",
+                "reference": "test_var",
+                "variable_type": "s",  # string type
+            }
+        )
+
+        # Add variable value to server
+        self.VariableValue.create(
+            {
+                "variable_id": variable.id,
+                "server_id": self.server_test_1.id,
+                "value_char": "server value",
+            }
+        )
+
+        # Create command that uses the variable
+        command = self.Command.create(
+            {
+                "name": "Test Command with Variables",
+                "action": "ssh_command",
+                "code": "echo {{ test_var }}",
+            }
+        )
+
+        # Create wizard
+        wizard = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.manager)
+            .create(
+                {
+                    "server_ids": [self.server_test_1.id],
+                    "command_id": command.id,
+                    "action": "ssh_command",
+                }
+            )
+        )
+
+        # Trigger onchange to generate custom_variable_values
+        wizard._onchange_command_variable_ids()
+
+        # Modify variable value
+        wizard.custom_variable_values.filtered(
+            lambda v: v.variable_id == variable
+        ).value_char = "manager value"
+
+        # Run command
+        wizard.run_command_on_server()
+
+        # Get latest command log
+        command_log = self.env["cx.tower.command.log"].search(
+            [
+                ("server_id", "=", self.server_test_1.id),
+                ("command_id", "=", command.id),
+            ],
+            order="create_date desc",
+            limit=1,
+        )
+
+        # Verify that custom value was used
+        self.assertEqual(command_log.code, "echo manager value")

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -80,6 +80,18 @@ class CxTowerCommandRunWizard(models.TransientModel):
         compute_sudo=True,
         help="Warning about OS compatibility of the command",
     )
+    command_variable_ids = fields.Many2many(
+        "cx.tower.variable",
+        related="command_id.variable_ids",
+        readonly=True,
+    )
+    custom_variable_values = fields.One2many(
+        "cx.tower.command.run.wizard.variable.value",
+        "wizard_id",
+    )
+    have_access_to_server = fields.Boolean(
+        compute="_compute_have_access_to_server",
+    )
 
     @api.depends("server_ids")
     def _compute_show_servers(self):
@@ -103,6 +115,7 @@ class CxTowerCommandRunWizard(models.TransientModel):
         """
         for record in self:
             if record.command_id and record.server_ids:
+                # Render code preview for the first server only.
                 record.update(
                     {
                         "code": record.command_id.code,
@@ -114,7 +127,7 @@ class CxTowerCommandRunWizard(models.TransientModel):
             else:
                 record.update({"code": False, "path": False})
 
-    @api.depends("code", "server_ids", "action")
+    @api.depends("code", "server_ids", "action", "custom_variable_values.value_char")
     def _compute_rendered_code(self):
         for record in self:
             if record.server_ids and len(record.server_ids) == 1:
@@ -128,6 +141,13 @@ class CxTowerCommandRunWizard(models.TransientModel):
                 variable_values = server_id.get_variable_values(
                     variables.get(str(record.id))
                 )
+                if variable_values and record.custom_variable_values:
+                    custom_vals = {
+                        custom_value.variable_id.reference: custom_value.value_char
+                        for custom_value in record.custom_variable_values
+                        if custom_value.variable_id
+                    }
+                    variable_values[server_id.id].update(custom_vals)
 
                 # Render template
                 if variable_values:
@@ -182,12 +202,75 @@ class CxTowerCommandRunWizard(models.TransientModel):
                 "\n".join(warning_list) if warning_list else False
             )
 
+    @api.depends("server_ids")
+    def _compute_have_access_to_server(self):
+        """
+        Compute have_access_to_server field
+        """
+        for record in self:
+            if not record.server_ids:
+                record.have_access_to_server = False
+                continue
+            record.have_access_to_server = all(
+                server._have_access_to_server("write") for server in record.server_ids
+            )
+
     @api.onchange("action", "applicability")
     def _onchange_action(self):
         """
         Reset command after change action
         """
         self.command_id = False
+
+    @api.onchange("command_variable_ids", "server_ids")
+    def _onchange_command_variable_ids(self):
+        """
+        Reset custom variable values after change code
+        """
+        # Remove existing custom variable values
+        self.custom_variable_values = False
+
+        if (
+            not self.command_variable_ids
+            or not self.server_ids
+            or len(self.server_ids) > 1
+        ):
+            return
+
+        # Add new custom variable values
+        # Render values for the first server only.
+        server_id = self.server_ids
+
+        # Get variable list
+        variables = self.get_variables()
+
+        # Get variable values
+        variable_values = server_id.get_variable_values(variables.get(str(self.id)))[
+            server_id.id
+        ]
+
+        # Filter variables current user has access to
+        command_variables = self.command_variable_ids.search(
+            [("id", "in", self.command_variable_ids.ids)]
+        )
+
+        self.custom_variable_values = [
+            (
+                0,
+                0,
+                {
+                    "variable_id": variable.id,
+                    "value_char": variable_values.get(variable.reference),
+                    "option_id": variable.option_ids.filtered(
+                        lambda o, v=variable: o.value_char
+                        == variable_values.get(v.reference)
+                    ).id
+                    if variable.variable_type == "o"
+                    else None,
+                },
+            )
+            for variable in command_variables
+        ]
 
     def action_run_command(self):
         """
@@ -209,7 +292,7 @@ class CxTowerCommandRunWizard(models.TransientModel):
         }
 
     def run_command_on_server(self):
-        """Render selected command rendered using server method"""
+        """Run command on selected servers"""
         # Check if command is selected
         if not self.command_id:
             raise ValidationError(_("Please select a command to execute"))
@@ -219,13 +302,19 @@ class CxTowerCommandRunWizard(models.TransientModel):
             self.env.user.has_group("cetmix_tower_server.group_manager") and self.path
         )
         # Add custom values for log
-        custom_values = {"log": {"label": log_label}}
+        kwargs = {
+            "log": {"label": log_label},
+            "variable_values": {
+                value.variable_id.reference: value.value_char
+                for value in self.custom_variable_values
+            },
+        }
         for server in self.server_ids:
             server.run_command(
                 self.command_id,
                 sudo=self.use_sudo,
                 path=path_value,
-                **custom_values,
+                **kwargs,
             )
         return {
             "type": "ir.actions.act_window",
@@ -294,7 +383,9 @@ class CxTowerCommandRunWizard(models.TransientModel):
                 "partner_id": server.partner_id.id if server.partner_id else None,
             }
 
-            kwargs = {"key": key_vals}
+            kwargs = {
+                "key": key_vals,
+            }
             if self.action == "python_code":
                 command_result = server._run_python_code(
                     code=self.rendered_code, **kwargs
@@ -326,3 +417,46 @@ class CxTowerCommandRunWizard(models.TransientModel):
                 "view_mode": "form",
                 "target": "new",
             }
+
+
+class CxTowerCommandRunWizardVariableValue(models.TransientModel):
+    """
+    Custom variable values for command run wizard
+    """
+
+    _name = "cx.tower.command.run.wizard.variable.value"
+    _description = "Custom variable values for command run wizard"
+
+    wizard_id = fields.Many2one(
+        "cx.tower.command.run.wizard",
+        string="Wizard",
+    )
+    variable_id = fields.Many2one(
+        "cx.tower.variable",
+        readonly=True,
+    )
+    variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
+    value_char = fields.Char(
+        string="Value",
+        compute="_compute_value_char",
+        readonly=False,
+        store=True,
+    )
+    option_id = fields.Many2one(
+        "cx.tower.variable.option", domain="[('variable_id', '=', variable_id)]"
+    )
+
+    @api.depends("option_id", "variable_id", "variable_type")
+    def _compute_value_char(self):
+        for rec in self:
+            if rec.variable_id and rec.variable_type == "o" and rec.option_id:
+                rec.value_char = rec.option_id.value_char
+            else:
+                rec.value_char = ""
+
+    @api.onchange("variable_id")
+    def _onchange_variable_id(self):
+        """
+        Reset option_id when variable changes.
+        """
+        self.update({"option_id": None})

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard_view.xml
@@ -105,6 +105,50 @@
                         />
                     </page>
                     <page
+                        name="configuration_values"
+                        string="Configuration Values"
+                        attrs="{'invisible': [('custom_variable_values', '=', [])]}"
+                    >
+                        <field name="command_variable_ids" invisible="1" />
+                        <field name="have_access_to_server" invisible="1" />
+                        <div
+                            class="alert alert-warning"
+                            role="alert"
+                            attrs="{'invisible': [('have_access_to_server', '=', True)]}"
+                            style="margin-bottom:5px;"
+                        >
+                            You need 'Manager' access to the server to override the default configuration values.
+                            Without this access, the server's configured values will be used.
+                        </div>
+                        <div
+                            class="alert alert-warning"
+                            role="alert"
+                            style="margin-bottom:5px;"
+                        >
+                            Only values that the current user has access to are shown.
+                        </div>
+                        <field
+                            name="custom_variable_values"
+                            force_save="1"
+                            options="{'no_create': True, 'no_open': True}"
+                            attrs="{'readonly': [('have_access_to_server', '!=', True)]}"
+                        >
+                            <tree create="0" delete="0" editable="bottom">
+                                <field name="variable_id" force_save="1" />
+                                <field name="variable_type" invisible="1" />
+                                <field
+                                    name="value_char"
+                                    attrs="{'readonly': [('variable_type', '!=', 's')]}"
+                                />
+                                <field
+                                    name="option_id"
+                                    attrs="{'readonly': [('variable_type', '!=', 'o')]}"
+                                    options="{'no_create': True}"
+                                />
+                            </tree>
+                        </field>
+                    </page>
+                    <page
                         name="preview"
                         string="Preview"
                         attrs="{'invisible': [('show_servers', '=', True)]}"


### PR DESCRIPTION
UX
--

Add ability to pass custom variable values to commands. This is needed to override values that are rendered from the server.

**Important**: user must have `write` access to the server in order to be able to submit custom configuration values.
Otherwise, only values rendered from the server will be used.

UI
--

Add a new "Configuration Values" page to the command run wizard. This page allows to edit variable values passed to the command. Only users with `write` access to the server can edit values in the page.

Possible use cases
------------------

A command that updates modules:

- Before: list of modules is defined in the server configuration values.
- After: list of modules can be provided dynamically to the command.

A command that creates a backup of a database:

- Before: database name is defined in the server configuration values.
- After: database name can be provided dynamically to the command.

Task: 4524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for passing custom variable values to commands, enhancing configurability for users with write access.
  - Introduced a configuration page in the command run wizard for viewing and editing variable values per command execution.
  - The wizard now shows a warning if the user lacks sufficient access to edit configuration values.

- **Bug Fixes**
  - Improved initialization and merging of variable values based on user permissions.

- **Tests**
  - Added tests verifying command rendering with custom variable values for authorized and unauthorized users.

- **Documentation**
  - Enhanced docstrings to clarify new features and behaviors in the command run wizard and command execution methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->