### PR TITLE
[14.0][IMP] cetmix_tower_yaml: Add fields

### DIFF
--- a/cetmix_tower/readme/newsfragments/4602.feature
+++ b/cetmix_tower/readme/newsfragments/4602.feature
@@ -1,0 +1,2 @@
+Export additional fields for shortcuts, variables and options.
+Add action menu to export keys/secrets.

--- a/cetmix_tower_yaml/__manifest__.py
+++ b/cetmix_tower_yaml/__manifest__.py
@@ -24,6 +24,7 @@
         "views/cx_tower_os_view.xml",
         "views/cx_tower_tag_view.xml",
         "views/cx_tower_shortcut_view.xml",
+        "views/cx_tower_key_view.xml",
         "wizards/cx_tower_yaml_export_wiz.xml",
         "wizards/cx_tower_yaml_export_wiz_download.xml",
         "wizards/cx_tower_yaml_import_wiz_upload.xml",

--- a/cetmix_tower_yaml/models/cx_tower_shortcut.py
+++ b/cetmix_tower_yaml/models/cx_tower_shortcut.py
@@ -9,5 +9,14 @@ class CxTowerShortcut(models.Model):
 
     def _get_fields_for_yaml(self):
         res = super()._get_fields_for_yaml()
-        res += ["name", "action", "command_id", "plan_id", "note"]
+        res += [
+            "name",
+            "sequence",
+            "access_level",
+            "action",
+            "command_id",
+            "use_sudo",
+            "plan_id",
+            "note",
+        ]
         return res

--- a/cetmix_tower_yaml/models/cx_tower_variable_option.py
+++ b/cetmix_tower_yaml/models/cx_tower_variable_option.py
@@ -11,6 +11,7 @@ class CxTowerVariableOption(models.Model):
         res = super()._get_fields_for_yaml()
         res += [
             "sequence",
+            "access_level",
             "name",
             "value_char",
         ]

--- a/cetmix_tower_yaml/readme/newsfragments/4602.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/4602.feature
@@ -1,0 +1,2 @@
+Export additional fields for shortcuts, variables and options.
+Add action menu to export keys/secrets.

--- a/cetmix_tower_yaml/views/cx_tower_key_view.xml
+++ b/cetmix_tower_yaml/views/cx_tower_key_view.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="action_cx_tower_key_export_yaml" model="ir.actions.act_window">
+        <field name="name">Export YAML</field>
+        <field name="res_model">cx.tower.yaml.export.wiz</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_cx_tower_key" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('cetmix_tower_yaml.group_export'))]" />
+    </record>
+</odoo>


### PR DESCRIPTION
Shortcuts: export access_level, sequence and use_sudo Variable Options: access_level
Add menu to export keys/secrets.

Task: 4602



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Export YAML" action for specific users, allowing export functionality directly from the list view.
- **Enhancements**
  - Expanded the set of fields included in YAML exports for shortcuts and variable options, providing more detailed data in exported files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->