### PR TITLE
[14.0][FIX] cetmix_tower_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Banner](https://github.com/cetmix/cetmix-tower/blob/5ff7c0aafe22db6686d0919cc560f7f8a0fe7cd7/cetmix_tower_server/static/description/banner.png)
 
-[Cetmix Tower](http://cetmix.com/tower) offers a streamlined solution for managing remote servers via SSH or API calls directly from [Odoo](https:/odoo.com).
+[Cetmix Tower](http://cetmix.com/tower) offers a streamlined solution for managing remote servers via SSH or API calls directly from [Odoo](https://odoo.com).
 It is designed for versatility across different operating systems and software environments, providing a practical option for those looking to manage servers without getting tied down by vendor or technology constraints.
 
 # Why Cetmix Tower?

--- a/cetmix_tower/README.rst
+++ b/cetmix_tower/README.rst
@@ -13,7 +13,7 @@ Cetmix Tower
 .. |badge1| image:: https://img.shields.io/badge/maturity-Production%2FStable-green.png
     :target: https://odoo-community.org/page/development-status
     :alt: Production/Stable
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github

--- a/cetmix_tower/readme/newsfragments/4547.feature
+++ b/cetmix_tower/readme/newsfragments/4547.feature
@@ -1,0 +1,1 @@
+Cetmix Tower Odoo Automation model: pass custom variable values to the `server_run_command` method.

--- a/cetmix_tower/readme/newsfragments/4612.bugfix
+++ b/cetmix_tower/readme/newsfragments/4612.bugfix
@@ -1,0 +1,1 @@
+Random id generation, sudo command parsing, record rule names, spelling errors in descriptions.

--- a/cetmix_tower_server/README.rst
+++ b/cetmix_tower_server/README.rst
@@ -13,7 +13,7 @@ Cetmix Tower Server
 .. |badge1| image:: https://img.shields.io/badge/maturity-Production%2FStable-green.png
     :target: https://odoo-community.org/page/development-status
     :alt: Production/Stable
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github
@@ -24,7 +24,7 @@ Cetmix Tower Server
 
 `Cetmix Tower <https://cetmix.com/tower>`__ offers a streamlined
 solution for managing remote servers and applications via SSH or API
-calls directly from `Odoo <https:/odoo.com>`__. It is designed for
+calls directly from `Odoo <https://odoo.com>`__. It is designed for
 versatility across different operating systems and software
 environments, providing a practical option for those looking to manage
 servers without getting tied down by vendor or technology constraints.

--- a/cetmix_tower_server/models/cetmix_tower.py
+++ b/cetmix_tower_server/models/cetmix_tower.py
@@ -34,7 +34,7 @@ class CetmixTower(models.AbstractModel):
 
     @api.model
     def server_run_command(
-        self, server_reference, command_reference, get_result=True, **kwargs
+        self, server_reference, command_reference, get_result=True, **variable_values
     ):
         """Run command on selected server.
 
@@ -44,6 +44,11 @@ class CetmixTower(models.AbstractModel):
             get_result (bool, optional): Get the result of the command.
                 If False, the result will be saved to the log.
                 Defaults to True.
+
+        **variable_values:
+            Dict: with variable values.
+            The keys are the variable references and the values are the variable values.
+            eg `{'odoo_version': '16.0'}`
 
         Returns:
             Dict: with who keys if `get_result` is True:
@@ -61,7 +66,7 @@ class CetmixTower(models.AbstractModel):
         # Will return command result if get_result is True
         # Otherwise will save to log and return None
         command_result = server.with_context(no_command_log=get_result).run_command(
-            command, **kwargs
+            command, **{"variable_values": variable_values} if variable_values else {}
         )
 
         # Return command result if get_result is True
@@ -74,7 +79,7 @@ class CetmixTower(models.AbstractModel):
                 "message": response or error,
             }
 
-    def server_run_flight_plan(self, server_reference, flight_plan_reference, **kwargs):
+    def server_run_flight_plan(self, server_reference, flight_plan_reference):
         """Run flight plan on selected server.
 
         Args:
@@ -94,7 +99,7 @@ class CetmixTower(models.AbstractModel):
             # This is not the best way to handle this, but it's the only way to
             # avoid complex response handling
             return False
-        return server.run_flight_plan(flight_plan, **kwargs)
+        return server.run_flight_plan(flight_plan)
 
     @api.model
     def server_set_variable_value(self, server_reference, variable_reference, value):

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1532,7 +1532,7 @@ class CxTowerServer(models.Model):
         """Prepare ssh command
         IMPORTANT:
         Commands run with sudo will be run separately one after another
-        even if there is a single command separated with '&&' or ';'
+        even if there is a single command separated with '&&'
         Example:
         "pwd && ls -l" will be run as:
             sudo pwd
@@ -1561,17 +1561,10 @@ class CxTowerServer(models.Model):
             sudo_prefix = "sudo -S -p ''"
 
             # Detect command separator
-            if "&&" in command_code or ";" in command_code:
-                # If command consists of several commands:
-                # Replace alternative separator to avoid possible issues.
-                # We need to stop always if some command issues error.
-                command_code.replace(";", "&&")
-                separator = "&&"
-                command_code.replace("\\", "").replace("\n", "").split(separator)
+            separator = "&&"
+            if separator in command_code:
                 result = (
                     command_code.replace("\\", "").replace("\n", "").split(separator)
-                    if separator
-                    else [command_code]
                 )
 
                 # Sudo with password expects a list of commands

--- a/cetmix_tower_server/models/tools.py
+++ b/cetmix_tower_server/models/tools.py
@@ -29,8 +29,7 @@ def generate_random_id(sections=1, population=4, separator="-"):
 
     # Multiple sections
     result = []
-    for i in range(1, sections):
-        result.append("".join(choices(CHARS, k=population)))
-        i += 1
+    for _ in range(sections):
+        result.append(get_section())
 
     return separator.join(result)

--- a/cetmix_tower_server/readme/DESCRIPTION.md
+++ b/cetmix_tower_server/readme/DESCRIPTION.md
@@ -1,4 +1,4 @@
-[Cetmix Tower](https://cetmix.com/tower) offers a streamlined solution for managing remote servers and applications via SSH or API calls directly from [Odoo](https:/odoo.com).
+[Cetmix Tower](https://cetmix.com/tower) offers a streamlined solution for managing remote servers and applications via SSH or API calls directly from [Odoo](https://odoo.com).
 It is designed for versatility across different operating systems and software environments, providing a practical option for those looking to manage servers without getting tied down by vendor or technology constraints.
 
 Please refer to the [official documentation](https://cetmix.com/tower) for detailed information.

--- a/cetmix_tower_server/readme/newsfragments/4547.feature
+++ b/cetmix_tower_server/readme/newsfragments/4547.feature
@@ -1,0 +1,1 @@
+Cetmix Tower Odoo Automation model: pass custom variable values to the `server_run_command` method.

--- a/cetmix_tower_server/readme/newsfragments/4612.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4612.bugfix
@@ -1,0 +1,1 @@
+Random id generation, sudo command parsing, record rule names, spelling errors in descriptions.

--- a/cetmix_tower_server/security/cx_tower_variable_option_security.xml
+++ b/cetmix_tower_server/security/cx_tower_variable_option_security.xml
@@ -26,7 +26,7 @@
 
     <!-- Manager Write/Create Rules -->
     <record id="rule_cx_tower_variable_option_manager_write" model="ir.rule">
-        <field name="name">Variable Option: Manager Write Access</field>
+        <field name="name">Variable Option: Manager Write/Create/Unlink Access</field>
         <field name="model_id" ref="model_cx_tower_variable_option" />
         <field
             name="domain_force"

--- a/cetmix_tower_server/security/cx_tower_variable_security.xml
+++ b/cetmix_tower_server/security/cx_tower_variable_security.xml
@@ -26,7 +26,7 @@
 
     <!-- Manager Write/Create Rule -->
     <record id="rule_cx_tower_variable_manager_write" model="ir.rule">
-        <field name="name">Variable: Manager Write Access</field>
+        <field name="name">Variable: Manager Write/Create/Unlink Access</field>
         <field name="model_id" ref="model_cx_tower_variable" />
         <field
             name="domain_force"

--- a/cetmix_tower_server/security/cx_tower_variable_value_security.xml
+++ b/cetmix_tower_server/security/cx_tower_variable_value_security.xml
@@ -125,7 +125,7 @@
 
     <!-- Manager Write/Create Rules -->
     <record id="rule_cx_tower_variable_value_manager_write_server" model="ir.rule">
-        <field name="name">Variable Value: Manager Write Server Access</field>
+        <field name="name">Variable Value: Manager Write/Create Server Access</field>
         <field name="model_id" ref="model_cx_tower_variable_value" />
         <field
             name="domain_force"
@@ -141,7 +141,9 @@
         id="rule_cx_tower_variable_value_manager_write_server_template"
         model="ir.rule"
     >
-        <field name="name">Variable Value: Manager Write Server Template Access</field>
+        <field
+            name="name"
+        >Variable Value: Manager Write/Create Server Template Access</field>
         <field name="model_id" ref="model_cx_tower_variable_value" />
         <field
             name="domain_force"
@@ -154,7 +156,7 @@
     </record>
 
     <record id="rule_cx_tower_variable_value_manager_write_plan" model="ir.rule">
-        <field name="name">Variable Value: Manager Write Plan Access</field>
+        <field name="name">Variable Value: Manager Write/Create Plan Access</field>
         <field name="model_id" ref="model_cx_tower_variable_value" />
         <field
             name="domain_force"
@@ -167,7 +169,9 @@
     </record>
 
     <record id="rule_cx_tower_variable_value_manager_write_plan_action" model="ir.rule">
-        <field name="name">Variable Value: Manager Write Plan Server Access</field>
+        <field
+            name="name"
+        >Variable Value: Manager Write/Create Plan Server Access</field>
         <field name="model_id" ref="model_cx_tower_variable_value" />
         <field
             name="domain_force"

--- a/cetmix_tower_server/static/description/index.html
+++ b/cetmix_tower_server/static/description/index.html
@@ -369,10 +369,10 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:f987a2612cc1dad67ed09e06dc0486d6d47aebd34938cb05ae7f4912244506ba
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/14.0/cetmix_tower_server"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p><a class="reference external" href="https://cetmix.com/tower">Cetmix Tower</a> offers a streamlined
 solution for managing remote servers and applications via SSH or API
-calls directly from <a class="reference external" href="https:/odoo.com">Odoo</a>. It is designed for
+calls directly from <a class="reference external" href="https://odoo.com">Odoo</a>. It is designed for
 versatility across different operating systems and software
 environments, providing a practical option for those looking to manage
 servers without getting tied down by vendor or technology constraints.</p>

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -19,3 +19,4 @@ from . import test_key
 from . import test_cetmix_tower
 from . import test_tag
 from . import test_shortcut
+from . import test_tools

--- a/cetmix_tower_server/tests/test_cetmix_tower.py
+++ b/cetmix_tower_server/tests/test_cetmix_tower.py
@@ -203,3 +203,40 @@ class TestCetmixTower(TestTowerCommon):
             # Verify result
             self.assertEqual(result, plan_log, "Should return plan log record")
             mock_run.assert_called_once_with(flight_plan)
+
+    def test_server_run_command_with_variable_values(self):
+        """Test running command with variable values"""
+        # Create test command
+        command = self.Command.create(
+            {
+                "name": "Test Command",
+                "reference": "test_command",
+                "code": "result = {'exit_code': 0, 'message': {{ test_version }}}",
+                "action": "python_code",
+            }
+        )
+        # Set variable value for the server
+        self.CetmixTower.server_set_variable_value(
+            server_reference=self.server_test_1.reference,
+            variable_reference=self.variable_version.reference,
+            value="prod",
+        )
+
+        # -- 1 --
+        # Run command without modifying variable values
+        result = self.CetmixTower.server_run_command(
+            server_reference=self.server_test_1.reference,
+            command_reference=command.reference,
+        )
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["message"], "prod")
+
+        # -- 2 --
+        # Run command with modified variable values
+        result = self.CetmixTower.server_run_command(
+            server_reference=self.server_test_1.reference,
+            command_reference=command.reference,
+            **{"test_version": "dev"},
+        )
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["message"], "dev")

--- a/cetmix_tower_server/tests/test_tools.py
+++ b/cetmix_tower_server/tests/test_tools.py
@@ -1,0 +1,38 @@
+from odoo.tests import common
+
+from ..models.tools import CHARS, generate_random_id
+
+
+class TestTools(common.TransactionCase):
+    """Test class for tools module."""
+
+    def test_generate_random_id(self):
+        """Test random id generation"""
+        # Test single section
+        result = generate_random_id()
+        self.assertEqual(len(result), 4)  # Default length is 4
+        self.assertTrue(all(c in CHARS for c in result))  # All chars from CHARS
+
+        # Test multiple sections
+        result = generate_random_id(sections=2)
+        sections = result.split("-")
+        self.assertEqual(len(sections), 2)
+        self.assertTrue(all(len(s) == 4 for s in sections))
+        self.assertTrue(all(c in CHARS for s in sections for c in s))
+
+        # Test custom population
+        result = generate_random_id(population=6)
+        self.assertEqual(len(result), 6)
+
+        # Test custom separator
+        result = generate_random_id(sections=2, separator="_")
+        self.assertIn("_", result)
+        self.assertEqual(len(result.split("_")), 2)
+
+        # Test invalid inputs
+        self.assertIsNone(generate_random_id(sections=0))
+        self.assertIsNone(generate_random_id(population=-1))
+
+        # Test empty separator
+        result = generate_random_id(sections=3, separator="")
+        self.assertEqual(len(result), 12)  # 3 sections of 4 chars with no separator

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -84,6 +84,7 @@ class CxTowerCommandRunWizard(models.TransientModel):
         "cx.tower.variable",
         related="command_id.variable_ids",
         readonly=True,
+        string="Command Variables",
     )
     custom_variable_values = fields.One2many(
         "cx.tower.command.run.wizard.variable.value",


### PR DESCRIPTION
- Random id generator: incorrect number of sections and population.
- SSH command preparation: use '&&' only as a command separator because replacing ';' to '&&'
can cause issues with command execution.
- Improve record rule names, fix spelling errors in descriptions.

Task: 4612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected malformed and incomplete URLs in documentation and descriptions to ensure all links are valid and clickable.
  - Fixed spelling errors in documentation and badge labels.
  - Improved random ID generation to match expected section counts.
  - Simplified sudo command parsing for SSH execution.
  - Updated rule names in security settings to accurately reflect granted permissions.

- **Documentation**
  - Updated documentation to reflect corrected URLs, spelling, and badge labels.
  - Added news fragments summarizing recent bug fixes and improvements.
  - Documented support for passing custom variable values in server run commands.

- **Tests**
  - Introduced new tests to validate random ID generation functionality.
  - Included the new test module in the test suite initialization.
  - Added tests verifying command execution with variable substitution.

- **New Features**
  - Added descriptive label to command variables field in command run wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->