### PR TITLE
[17.0][FIX] cetmix_tower_server: Fix kanban action

### DIFF
--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -22,16 +22,16 @@
                                     <div role="menuitem">
                                         <a
                                             role="menuitem"
-                                            type="action"
-                                            name="%(cetmix_tower_server.cx_tower_command_run_wizard_action)d"
+                                            type="object"
+                                            name="action_run_command"
                                         >Run Command
                                         </a>
                                         </div>
                                         <div role="menuitem">
                                             <a
                                             role="menuitem"
-                                            type="action"
-                                            name="%(cetmix_tower_server.cx_tower_plan_run_wizard_action)d"
+                                            type="object"
+                                            name="action_run_flight_plan"
                                         >Run Flight Plan
                                             </a>
                                         </div>


### PR DESCRIPTION
Error when trying to run command or flight plan from kanban.

Task: 4634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated menu actions in the kanban view to directly invoke methods instead of referencing server actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->