### PR TITLE
[14.0][IMP]  cetmix_tower-add_search_and_access_level_and_default_ssh

### DIFF
--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -162,6 +162,7 @@
                 <field name="name" />
                 <field name="reference" optional="hide" />
                 <field name="action" />
+                <field name="access_level" optional="hide" />
                 <field
                     name="server_ids"
                     widget="many2many_tags"
@@ -263,6 +264,12 @@
                         name="group_action"
                         domain="[]"
                         context="{'group_by': 'action'}"
+                    />
+                    <filter
+                        string="Access Level"
+                        name="group_access_level"
+                        domain="[]"
+                        context="{'group_by': 'access_level'}"
                     />
                 </group>
             </search>

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -129,6 +129,7 @@
             <tree>
                 <field name="name" />
                 <field name="reference" optional="hide" />
+                <field name="access_level" optional="hide" />
                 <field
                     name="server_ids"
                     widget="many2many_tags"
@@ -176,6 +177,14 @@
                     name="archived"
                     domain="[('active', '=', False)]"
                 />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Access Level"
+                        name="group_access_level"
+                        domain="[]"
+                        context="{'group_by': 'access_level'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -459,9 +459,13 @@
             <search string="Search Servers">
                 <field name="name" />
                 <field name="reference" />
-                <field name="status" />
-                <field name="os_id" />
+                <field name="url" />
+                <field name="partner_id" />
                 <field name="tag_ids" />
+                <field name="ip_v4_address" />
+                <field name="ip_v6_address" />
+                <field name="os_id" />
+                <field name="status" />
                 <filter
                     string="Archived"
                     name="archived"

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
@@ -43,6 +43,7 @@
                         <field
                             name="ssh_key_id"
                             attrs="{'invisible': [('ssh_auth_mode', '=', 'p')]}"
+                            context="{'default_key_type': 'k'}"
                         />
                         <field name="use_sudo" placeholder="No/Undefined" />
                     </group>


### PR DESCRIPTION
Enable more powerful filtering and streamline server creation:

 -  Allow searching servers by partner, IPv4, IPv6 and URL for finer filtering.

  -  Add an access_level column and “Group By → Access Level” filter to commands and flight plans, so users can surface and organize records by their access levels.

 -  Preselect SSH key type as “Key” in the server-creation wizard to streamline new server setup.

Task: 4632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to display and group commands and plans by access level in list and search views.
  - Enhanced server search functionality by allowing filtering by partner, IPv4 address, IPv6 address, and URL.

- **Improvements**
  - Default key type is now set when selecting an SSH key in the server template creation wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->