### PR TITLE
[14.0][IMP] cetmix_tower_yaml: Rearrange groups

### DIFF
--- a/cetmix_tower_yaml/security/cetmix_tower_yaml_groups.xml
+++ b/cetmix_tower_yaml/security/cetmix_tower_yaml_groups.xml
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-<record id="ir_module_category_tower_yaml" model="ir.module.category">
+<record id="ir_module_category_tower_yaml_export" model="ir.module.category">
     <field name="parent_id" ref="cetmix_tower_server.ir_module_category_tower" />
-    <field name="name">Cetmix Tower YAML</field>
+    <field name="name">YAML Export</field>
+</record>
+
+<record id="ir_module_category_tower_yaml_import" model="ir.module.category">
+    <field name="parent_id" ref="cetmix_tower_server.ir_module_category_tower" />
+    <field name="name">YAML Import</field>
 </record>
 
 <record id="group_export" model="res.groups">
-    <field name="name">Export</field>
-    <field name="category_id" ref="ir_module_category_tower_yaml" />
+    <field name="name">Allow</field>
+    <field name="category_id" ref="ir_module_category_tower_yaml_export" />
     <field name="comment">
         Export data to YAML.
     </field>
 </record>
 
 <record id="group_import" model="res.groups">
-    <field name="name">Import</field>
-    <field name="category_id" ref="ir_module_category_tower_yaml" />
+    <field name="name">Allow</field>
+    <field name="category_id" ref="ir_module_category_tower_yaml_import" />
     <field name="comment">
         Import data from YAML.
     </field>


### PR DESCRIPTION
Move groups to separate categories and rename them to "Allow" in order to make them visible without enabling the developer mode.

Task: 4638

![image](https://github.com/user-attachments/assets/d40e915f-e4f5-410f-9556-e009d9dbf8b5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated security group categories to distinguish between YAML export and import, providing clearer separation for permissions.
	- Renamed group names for export and import permissions to a unified name for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->