### PR TITLE
[17.0][IMP] cetmix_tower_server/yaml UI/UX improvements

### DIFF
--- a/cetmix_tower/README.rst
+++ b/cetmix_tower/README.rst
@@ -13,7 +13,7 @@ Cetmix Tower
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github

--- a/cetmix_tower/readme/newsfragments/4647.feature
+++ b/cetmix_tower/readme/newsfragments/4647.feature
@@ -1,0 +1,1 @@
+UI/UX improvements.

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -63,6 +63,7 @@
         "views/cx_tower_server_log_view.xml",
         "views/cx_tower_server_template_view.xml",
         "views/cx_tower_shortcut_view.xml",
+        "views/res_partner_view.xml",
         "views/res_config_settings.xml",
         "views/menuitems.xml",
     ],

--- a/cetmix_tower_server/data/ir_actions_server.xml
+++ b/cetmix_tower_server/data/ir_actions_server.xml
@@ -23,4 +23,11 @@
         <field name="groups_id" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
     </record>
 
+    <record id="action_cx_cetmix_tower_partner" model="ir.actions.act_window">
+      <field name="name">Partners</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">res.partner</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
 </odoo>

--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -402,6 +402,11 @@
             name="tag_ids"
             eval="[(6, 0, [ref('cetmix_tower_server.tag_staging')])]"
         />
+        <field name="access_level">1</field>
+        <field
+            name="server_ids"
+            eval="[(6, 0, [ref('cetmix_tower_server.server_demo_1'), ref('cetmix_tower_server.server_demo_2')])]"
+        />
     </record>
 
     <!-- Flight Plan #2 -->
@@ -448,6 +453,10 @@
     <record id="command_update_upgrade" model="cx.tower.command">
         <field name="name">Update packages</field>
         <field name="action">ssh_command</field>
+        <field
+            name="server_ids"
+            eval="[(6, 0, [ref('cetmix_tower_server.server_demo_1'), ref('cetmix_tower_server.server_demo_2')])]"
+        />
         <field name="code">apt-get update &amp;&amp; apt-get upgrade -y</field>
         <field
             name="tag_ids"
@@ -458,12 +467,17 @@
             eval="[(6, 0, [ref('cetmix_tower_server.os_debian_11'), ref('cetmix_tower_server.os_ubuntu_22_04'),ref('cetmix_tower_server.os_ubuntu_24_04')])]"
         />
         <field name="note">Update and upgrade packages on the host system</field>
+        <field name="access_level">1</field>
     </record>
 
     <!-- Command #2 -->
     <record id="command_create_dir" model="cx.tower.command">
         <field name="name">Create directory</field>
         <field name="action">ssh_command</field>
+        <field
+            name="server_ids"
+            eval="[(6, 0, [ref('cetmix_tower_server.server_demo_1')])]"
+        />
         <field name="path">/home/{{ tower.server.username }}</field>
         <field name="code">mkdir -p {{ demo_dir }}</field>
         <field
@@ -471,6 +485,7 @@
             eval="[(6, 0, [ref('cetmix_tower_server.tag_production')])]"
         />
         <field name="note">Create a directory on the host system</field>
+        <field name="access_level">1</field>
     </record>
 
     <!-- Command #3 -->

--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -28,3 +28,4 @@ from . import cetmix_tower
 from . import cx_tower_variable_option
 from . import ir_actions_server
 from . import res_config_settings
+from . import res_partner

--- a/cetmix_tower_server/models/cx_tower_key_value.py
+++ b/cetmix_tower_server/models/cx_tower_key_value.py
@@ -17,6 +17,7 @@ class CxTowerKeyValue(models.Model):
         string="Key",
         required=True,
         ondelete="cascade",
+        domain="[('key_type', '=', 's')]",
     )
     server_id = fields.Many2one(
         comodel_name="cx.tower.server",

--- a/cetmix_tower_server/models/res_partner.py
+++ b/cetmix_tower_server/models/res_partner.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    server_ids = fields.One2many(
+        "cx.tower.server",
+        "partner_id",
+        string="Servers",
+        groups="cetmix_tower_server.group_user",
+    )
+
+    server_count = fields.Integer(
+        compute="_compute_server_count",
+        recursive=True,
+    )
+
+    secret_ids = fields.One2many(
+        "cx.tower.key.value",
+        "partner_id",
+        string="Secrets",
+        domain=[("key_id.key_type", "=", "s")],
+        groups="cetmix_tower_server.group_user",
+    )
+
+    @api.depends("server_ids", "child_ids.server_count")
+    def _compute_server_count(self):
+        for partner in self:
+            own_server_count = len(partner.server_ids)
+            child_server_count = sum(partner.child_ids.mapped("server_count"))
+            partner.server_count = own_server_count + child_server_count
+
+    def action_view_partner_servers(self):
+        """Open server list filtered by partner and all its descendants."""
+        self.ensure_one()
+        return {
+            "name": "Servers",
+            "type": "ir.actions.act_window",
+            "res_model": "cx.tower.server",
+            "view_mode": "kanban,tree,form",
+            "domain": [("partner_id", "child_of", self.id)],
+            "context": {"default_partner_id": self.id},
+        }

--- a/cetmix_tower_server/readme/newsfragments/4647.feature
+++ b/cetmix_tower_server/readme/newsfragments/4647.feature
@@ -1,0 +1,1 @@
+UI/UX improvements.

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -20,3 +20,4 @@ from . import test_cetmix_tower
 from . import test_tag
 from . import test_shortcut
 from . import test_tools
+from . import test_partner_server_btn

--- a/cetmix_tower_server/tests/test_command_wizard.py
+++ b/cetmix_tower_server/tests/test_command_wizard.py
@@ -431,3 +431,72 @@ class TestTowerCommandWizard(TestTowerCommon):
 
         # Verify that custom value was used
         self.assertEqual(command_log.code, "echo manager value")
+
+    def test_default_applicability_for_regular_and_manager(self):
+        """sets applicability='this' for regular users, keeps default for managers."""
+        # Regular user (no special groups)
+        default_usr = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.user_bob)
+            .default_get(["applicability"])
+        )
+        self.assertEqual(default_usr.get("applicability"), "this")
+
+        # Manager user should receive the original default ("shared")
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        default_mgr = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.user_bob)
+            .default_get(["applicability"])
+        )
+        self.assertEqual(default_mgr.get("applicability"), "shared")
+
+    def test_compute_show_servers_behavior(self):
+        """Should enforce 'this' for regular users but preserve manager choice."""
+        # Grant Bob the basic 'user' group so he can read servers and create the wizard
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_user")
+
+        # Ensure Bob has read access to the first server
+        self.server_test_1.write({"user_ids": [(4, self.user_bob.id)]})
+        # Create a second server and grant Bob read access to it
+        srv2 = self.Server.create(
+            {
+                "name": "Server 2",
+                "ip_v4_address": "127.0.0.2",
+                "ssh_username": "root",
+                "ssh_password": "pwd",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+            }
+        )
+        srv2.write({"user_ids": [(4, self.user_bob.id)]})
+
+        # --- Regular user scenario ---
+        wiz_usr = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.user_bob)
+            .create({"server_ids": [self.server_test_1.id, srv2.id]})
+        )
+        # Compute show_servers under Bob; he should see both servers
+        wiz_usr._compute_show_servers()
+        self.assertTrue(wiz_usr.show_servers)
+        # Enforcement should set applicability to 'this'
+        self.assertEqual(wiz_usr.applicability, "this")
+
+        # --- Manager user scenario ---
+        self.add_to_group(self.user_bob, "cetmix_tower_server.group_manager")
+        # Grant Bob manager access to both servers
+        self.server_test_1.write({"manager_ids": [(4, self.user_bob.id)]})
+        srv2.write({"manager_ids": [(4, self.user_bob.id)]})
+
+        wiz_mgr = (
+            self.env["cx.tower.command.run.wizard"]
+            .with_user(self.user_bob)
+            .create({"server_ids": [self.server_test_1.id, srv2.id]})
+        )
+        # Compute show_servers under Bob as manager
+        wiz_mgr._compute_show_servers()
+        # Manager should also see both servers
+        self.assertTrue(wiz_mgr.show_servers)
+        # Enforcement should not override manager's choice of 'shared'
+        self.assertEqual(wiz_mgr.applicability, "shared")

--- a/cetmix_tower_server/tests/test_partner_server_btn.py
+++ b/cetmix_tower_server/tests/test_partner_server_btn.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import tagged
+
+from .common import TestTowerCommon
+
+
+@tagged("partner_servers_btn")
+class TestPartnerServers(TestTowerCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_a = cls.env["res.partner"].create({"name": "Partner A"})
+        cls.partner_b = cls.env["res.partner"].create({"name": "Partner B"})
+        cls.partner_b_child = cls.env["res.partner"].create(
+            {
+                "name": "Partner B Child",
+                "parent_id": cls.partner_b.id,
+            }
+        )
+
+        cls.server_defaults = {
+            "name": "Test Server",
+            "ssh_username": "root",
+            "ssh_port": 22,
+            "ssh_password": "Test-P@ssw0rd-123",
+            "ip_v4_address": "127.0.0.1",
+            "skip_host_key": True,
+        }
+
+        cls.Server.create({"partner_id": cls.partner_b.id, **cls.server_defaults})
+        cls.Server.create({"partner_id": cls.partner_b.id, **cls.server_defaults})
+        cls.Server.create({"partner_id": cls.partner_b_child.id, **cls.server_defaults})
+
+        key = cls.Key.create({"name": "SSH Token", "key_type": "s"})
+        cls.KeyValue.create(
+            {
+                "key_id": key.id,
+                "partner_id": cls.partner_b.id,
+                "secret_value": "TOPSECRET",
+            }
+        )
+
+    def test_server_count_compute(self):
+        """Server count: direct + one‑level child + zero if none."""
+        self.assertEqual(self.partner_b.server_count, 3)
+        self.assertEqual(self.partner_b_child.server_count, 1)
+        self.assertEqual(self.partner_a.server_count, 0)
+
+    def test_parent_with_only_child_servers(self):
+        """Parent without servers directs and with child_of."""
+        parent = self.env["res.partner"].create({"name": "Parent Only"})
+        child = self.env["res.partner"].create(
+            {"name": "Child with Server", "parent_id": parent.id}
+        )
+        self.Server.create({"partner_id": child.id, **self.server_defaults})
+        self.assertEqual(parent.server_count, 1)

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -162,6 +162,7 @@
                 <field name="name" />
                 <field name="reference" optional="hide" />
                 <field name="action" />
+                <field name="access_level" optional="hide" />
                 <field
                     name="server_ids"
                     widget="many2many_tags"
@@ -263,6 +264,12 @@
                         name="group_action"
                         domain="[]"
                         context="{'group_by': 'action'}"
+                    />
+                    <filter
+                        string="Access Level"
+                        name="group_access_level"
+                        domain="[]"
+                        context="{'group_by': 'access_level'}"
                     />
                 </group>
             </search>

--- a/cetmix_tower_server/views/cx_tower_key_view.xml
+++ b/cetmix_tower_server/views/cx_tower_key_view.xml
@@ -17,7 +17,10 @@
                                 options="{'string': 'Copy'}"
                                 invisible="key_type == 'k'"
                             />
-                            <field name="key_type" />
+                            <field
+                                name="key_type"
+                                invisible="context.get('secrets_only')"
+                            />
                         </group>
                         <group>
                             <field name="note" />

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -130,6 +130,7 @@
             <tree>
                 <field name="name" />
                 <field name="reference" optional="hide" />
+                <field name="access_level" optional="hide" />
                 <field
                     name="server_ids"
                     widget="many2many_tags"
@@ -177,6 +178,14 @@
                     name="archived"
                     domain="[('active', '=', False)]"
                 />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Access Level"
+                        name="group_access_level"
+                        domain="[]"
+                        context="{'group_by': 'access_level'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/cetmix_tower_server/views/cx_tower_server_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_template_view.xml
@@ -178,8 +178,10 @@
                                     <field name="ssh_username" />
                                     <field name="use_sudo" placeholder="No/Undefined" />
                                     <field name="ssh_password" password="True" />
-                                    <field name="ssh_key_id" />
-                                </group>
+                                    <field
+                                        name="ssh_key_id"
+                                        context="{'default_key_type': 'k', 'secrets_only': True}"
+                                    />                                </group>
                                 <field name="note" placeholder="Put your notes here" />
                             </group>
                         </page>

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -321,7 +321,7 @@
                                     <field
                                         name="ssh_key_id"
                                         required="ssh_auth_mode == 'k'"
-                                        context="{'default_key_type': 'k'}"
+                                        context="{'default_key_type': 'k', 'secrets_only': True}"
                                     />
                                 </group>
                                 <group name="extra">

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -403,14 +403,11 @@
                             string="Secrets"
                             groups="cetmix_tower_server.group_manager"
                         >
-                            <field
-                                name="secret_ids"
-                                context="{'default_key_type': 's', 'from_server': True}"
-                            >
+                            <field name="secret_ids">
                                 <tree editable="bottom">
                                     <field
                                         name="key_id"
-                                        domain="[('key_type', '=', 's')]"
+                                        context="{'default_key_type': 's', 'secrets_only': True}"
                                     />
                                     <field name="secret_value" />
                                 </tree>
@@ -453,9 +450,13 @@
             <search string="Search Servers">
                 <field name="name" />
                 <field name="reference" />
-                <field name="status" />
-                <field name="os_id" />
+                <field name="url" />
+                <field name="partner_id" />
                 <field name="tag_ids" />
+                <field name="ip_v4_address" />
+                <field name="ip_v6_address" />
+                <field name="os_id" />
+                <field name="status" />
                 <filter
                     string="Archived"
                     name="archived"

--- a/cetmix_tower_server/views/menuitems.xml
+++ b/cetmix_tower_server/views/menuitems.xml
@@ -31,6 +31,15 @@
         groups="group_manager"
         sequence="10"
     />
+    <menuitem
+        id="menu_cx_tower_partner"
+        name="Partners"
+        action="action_cx_cetmix_tower_partner"
+        parent="menu_cx_tower_server_root"
+        groups="cetmix_tower_server.group_user"
+        sequence="15"
+    />
+
     <!-- Commands -->
     <menuitem
         id="menu_cx_tower_command_root"

--- a/cetmix_tower_server/views/res_partner_view.xml
+++ b/cetmix_tower_server/views/res_partner_view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record id="view_res_partner_form_inherit_cetmix_tower" model="ir.ui.view">
+    <field name="name">res.partner.form.inherit.cetmix.tower</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_partner_form" />
+    <field name="arch" type="xml">
+
+      <xpath expr="//div[@name='button_box']" position="inside">
+        <button
+                    name="action_view_partner_servers"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-server"
+                    groups="cetmix_tower_server.group_user"
+                    invisible="server_count == 0"
+                >
+          <field name="server_count" widget="statinfo" string="Servers" />
+        </button>
+      </xpath>
+
+      <xpath expr="//sheet/notebook" position="inside">
+        <page string="Cetmix Tower" groups="cetmix_tower_server.group_user">
+          <group>
+              <group name="group_secrets" string="Secrets">
+                <field name="secret_ids" string="">
+                  <tree editable="bottom">
+                    <field
+                                        name="key_id"
+                                        context="{'default_key_type': 's', 'secrets_only': True}"
+                                    />
+                    <field name="server_id" />
+                    <field name="secret_value" />
+                  </tree>
+                  </field>
+              </group>
+          </group>
+        </page>
+      </xpath>
+
+    </field>
+  </record>
+</odoo>

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -94,20 +94,17 @@ class CxTowerCommandRunWizard(models.TransientModel):
         compute="_compute_have_access_to_server",
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if not self._is_privileged_user():
+            res["applicability"] = "this"
+        return res
+
     @api.depends("server_ids")
     def _compute_show_servers(self):
-        """
-        Show "Servers" field only if the number of servers is greater than 1.
-        """
-        for record in self:
-            show_servers = record.server_ids and len(record.server_ids) > 1
-            applicability = "shared" if show_servers else "this"
-            record.update(
-                {
-                    "show_servers": show_servers,
-                    "applicability": applicability,
-                }
-            )
+        for rec in self:
+            rec.show_servers = bool(rec.server_ids and len(rec.server_ids) > 1)
 
     @api.depends("command_id", "server_ids", "action")
     def _compute_code(self):
@@ -418,6 +415,12 @@ class CxTowerCommandRunWizard(models.TransientModel):
                 "view_mode": "form",
                 "target": "new",
             }
+
+    def _is_privileged_user(self):
+        """Return True if current user is in Manager or Root group."""
+        return self.env.user.has_group(
+            "cetmix_tower_server.group_manager"
+        ) or self.env.user.has_group("cetmix_tower_server.group_root")
 
 
 class CxTowerCommandRunWizardVariableValue(models.TransientModel):

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard_view.xml
@@ -45,6 +45,7 @@
                             options="{'horizontal': True}"
                             invisible="result"
                             readonly="show_servers"
+                            groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
                         />
                         <field
                             name="tag_ids"

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
@@ -58,20 +58,17 @@ class CxTowerPlanRunWizard(models.TransientModel):
         store=True,
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if not self._is_privileged_user():
+            res["applicability"] = "this"
+        return res
+
     @api.depends("server_ids")
     def _compute_show_servers(self):
-        """
-        Show "Servers" field only if the number of servers is greater than 1.
-        """
         for rec in self:
-            show_servers = True if rec.server_ids and len(rec.server_ids) > 1 else False
-            applicability = "shared" if show_servers else "this"
-            rec.update(
-                {
-                    "show_servers": show_servers,
-                    "applicability": applicability,
-                }
-            )
+            rec.show_servers = bool(rec.server_ids and len(rec.server_ids) > 1)
 
     @api.depends("plan_id")
     def _compute_plan_line_ids(self):
@@ -118,3 +115,9 @@ class CxTowerPlanRunWizard(models.TransientModel):
                 "target": "current",
                 "context": {"search_default_label": plan_label},
             }
+
+    def _is_privileged_user(self):
+        """Return True if current user is in Manager or Root group."""
+        return self.env.user.has_group(
+            "cetmix_tower_server.group_manager"
+        ) or self.env.user.has_group("cetmix_tower_server.group_root")

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard_view.xml
@@ -12,6 +12,7 @@
                         widget="many2many_tags"
                         required="1"
                         string="Run on"
+                        groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
                     />
                     <label for="applicability" string="Show Flight Plans" />
                     <div class="o_row">
@@ -20,6 +21,7 @@
                             widget="radio"
                             options="{'horizontal': True}"
                             readonly="show_servers"
+                            groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
                         />
                         <field
                             name="tag_ids"

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
@@ -40,7 +40,7 @@
                         <field
                             name="ssh_key_id"
                             invisible="ssh_auth_mode == 'p'"
-                            context="{'default_key_type': 'k'}"
+                            context="{'default_key_type': 'k', 'secrets_only': True}"
                         />
                         <field name="use_sudo" placeholder="No/Undefined" />
                     </group>

--- a/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_server_template_create_wizard_view.xml
@@ -37,7 +37,11 @@
                             placeholder="this can be changed later"
                         />
                         <field name="ssh_password" password="True" />
-                        <field name="ssh_key_id" invisible="ssh_auth_mode == 'p'" />
+                        <field
+                            name="ssh_key_id"
+                            invisible="ssh_auth_mode == 'p'"
+                            context="{'default_key_type': 'k'}"
+                        />
                         <field name="use_sudo" placeholder="No/Undefined" />
                     </group>
                     <field name="line_ids">

--- a/cetmix_tower_yaml/README.rst
+++ b/cetmix_tower_yaml/README.rst
@@ -13,7 +13,7 @@ Cetmix Tower YAML
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github

--- a/cetmix_tower_yaml/readme/newsfragments/4647.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/4647.feature
@@ -1,0 +1,1 @@
+User groups are visible without developer mode.

--- a/cetmix_tower_yaml/security/cetmix_tower_yaml_groups.xml
+++ b/cetmix_tower_yaml/security/cetmix_tower_yaml_groups.xml
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-<record id="ir_module_category_tower_yaml" model="ir.module.category">
+<record id="ir_module_category_tower_yaml_export" model="ir.module.category">
     <field name="parent_id" ref="cetmix_tower_server.ir_module_category_tower" />
-    <field name="name">Cetmix Tower YAML</field>
+    <field name="name">YAML Export</field>
+</record>
+
+<record id="ir_module_category_tower_yaml_import" model="ir.module.category">
+    <field name="parent_id" ref="cetmix_tower_server.ir_module_category_tower" />
+    <field name="name">YAML Import</field>
 </record>
 
 <record id="group_export" model="res.groups">
-    <field name="name">Export</field>
-    <field name="category_id" ref="ir_module_category_tower_yaml" />
+    <field name="name">Allow</field>
+    <field name="category_id" ref="ir_module_category_tower_yaml_export" />
     <field name="comment">
         Export data to YAML.
     </field>
 </record>
 
 <record id="group_import" model="res.groups">
-    <field name="name">Import</field>
-    <field name="category_id" ref="ir_module_category_tower_yaml" />
+    <field name="name">Allow</field>
+    <field name="category_id" ref="ir_module_category_tower_yaml_import" />
     <field name="comment">
         Import data from YAML.
     </field>

--- a/cetmix_tower_yaml/static/description/index.html
+++ b/cetmix_tower_yaml/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:c5b41107796edaac7f8444404dbb0489b9b31802a51d248fb1b6e46e10d51702
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/17.0/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/17.0/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>This module implements YAML format data import/export for <a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower</a>.</p>
 <p>Please refer to the <a class="reference external" href="https://cetmix.com/tower">official


### PR DESCRIPTION
Forward port updates from 16.0 https://github.com/cetmix/cetmix-tower/pull/278 

## Server

-  New 'Partners' submenu in 'Servers' menu.
- 'Cetmix Tower' tab in partner form showing all secret keys of this partner.
- 'Servers' button in partner form with that shows the number of servers of this partner.
- Search server by partner name or IP address.
- Show access level in the command and flight plan list views.
- Hide applicability selector for members of the 'User' group in the command and flight plan run wizards.
- Update demo date to improve user experience when testing command and plans as the "Demo" user.
- Hide key type selector value when key form is opened from another view.

## Yaml

Move groups to separate categories and rename them to "Allow" in order to
make them visible without enabling the developer mode.

Task: 4647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Partners" menu and view, allowing users to view and manage servers and secrets linked to partners.
  - Enhanced partner forms with a server count button and a dedicated "Cetmix Tower" tab for managing secrets.
  - Improved UI/UX across modules, including more visible user groups and refined access controls.
- **Improvements**
  - Added "access level" filters and grouping options to plan and command lists for easier management.
  - Expanded server search and filtering options.
  - Refined secret and SSH key selection behavior in forms.
- **Bug Fixes**
  - Corrected spelling of "license" to "licence" in various documentation and badge references.
- **Security & Access**
  - Refined group definitions and access controls for YAML import/export and wizard forms.
- **Tests**
  - Added tests for partner-server relationships and wizard behavior for different user roles.
- **Documentation**
  - Updated README files and added news fragments summarizing UI/UX improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->