### PR TITLE
[14.0] update i18n italy

### DIFF
--- a/cetmix_tower_aws/i18n/it.po
+++ b/cetmix_tower_aws/i18n/it.po
@@ -1,0 +1,68 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* cetmix_tower_aws
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.3\n"
+"Last-Translator: \n"
+"Language: it\n"
+
+#. module: cetmix_tower_aws
+#: code:addons/cetmix_tower_aws/models/constants.py:0
+#, python-format
+msgid ""
+"#  - boto3: Python 'boto3' library for AWS services. Available methods: "
+"'client', 'resource', 'Session'\n"
+"#    Supports AWS services like EC2, S3, RDS, Lambda, CloudWatch, etc."
+msgstr ""
+"#  - boto3: libreria Python 'boto3' per i servizi AWS. Metodi disponibili: "
+"'client', 'resource', 'Session'\n"
+"#    Supporta servizi AWS come EC2, S3, RDS, Lambda, CloudWatch, ecc."
+
+#. module: cetmix_tower_aws
+#: code:addons/cetmix_tower_aws/models/constants.py:0
+#, python-format
+msgid ""
+"<ul><li><code>boto3</code>: Python 'boto3' library for AWS services. "
+"Available methods: 'client', 'resource', 'Session'<br/>Supports AWS services "
+"like EC2, S3, RDS, Lambda, CloudWatch, etc.<br/>Please check the <a "
+"href='https://boto3.amazonaws.com/v1/documentation/api/latest/index.html' "
+"target='_blank'>Boto3 Documentation</a> for the detailed information about "
+"the services and methods.</li></ul>"
+msgstr ""
+"<ul><li><code>boto3</code>: libreria Python 'boto3' per servizi AWS. Metodi "
+"disponibili: 'client', 'resource', 'Session'<br/>Supporta servizi AES come "
+"EC2, S3, RDS, Lambda, CloudWatch, ecc.<br/>Controllare la <a href='https://"
+"boto3.amazonaws.com/v1/documentation/api/latest/index.html' "
+"target='_blank'>documentazione Boto3</a> per informazioni dettagliate sui "
+"servizi e i metodi.</li></ul>"
+
+#. module: cetmix_tower_aws
+#: model:ir.model,name:cetmix_tower_aws.model_cx_tower_command
+msgid "Cetmix Tower Command"
+msgstr "Comando Cetmix Tower"
+
+#. module: cetmix_tower_aws
+#: model:ir.model.fields,field_description:cetmix_tower_aws.field_cx_tower_command__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: cetmix_tower_aws
+#: model:ir.model.fields,field_description:cetmix_tower_aws.field_cx_tower_command__id
+msgid "ID"
+msgstr "ID"
+
+#. module: cetmix_tower_aws
+#: model:ir.model.fields,field_description:cetmix_tower_aws.field_cx_tower_command____last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"

--- a/cetmix_tower_ovh/i18n/it.po
+++ b/cetmix_tower_ovh/i18n/it.po
@@ -1,0 +1,77 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* cetmix_tower_ovh
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.3\n"
+"Last-Translator: \n"
+"Language: it\n"
+
+#. module: cetmix_tower_ovh
+#: code:addons/cetmix_tower_ovh/models/constants.py:0
+#, python-format
+msgid ""
+"#  - ovh: Python 'ovh' library for OVH services. Available methods: "
+"'Client'\n"
+"#    Supports OVH services\n"
+"#  - tldextract: Python 'tldextract' library. Available methods: 'extract'\n"
+"#    Supports domain extraction"
+msgstr ""
+"#  - ovh: libreria Python 'ovh' per i servizi OVH. Metodi disponibili: "
+"'Client'\n"
+"#    Supporta servizi OVH\n"
+"#  - tldextract: libreria Python 'tldextract'. Metodi disponibili: "
+"'extract'\n"
+"#    Supporta estrazione dominio"
+
+#. module: cetmix_tower_ovh
+#: code:addons/cetmix_tower_ovh/models/constants.py:0
+#, python-format
+msgid ""
+"<ul><li><code>ovh</code>: Python 'ovh' library for OVH services.  Available "
+"methods: 'Client'<br/>Supports OVH services<br/>Please check the <a "
+"href='https://eu.api.ovh.com/console/?section=%2FallDom&branch=v1' "
+"target='_blank'>OVH Documentation</a> for the detailed information about the "
+"services and methods.</li><li><code>tldextract</code>: Python 'tldextract' "
+"library.  Available methods: 'extract'<br/>Supports domain extraction. See "
+"<a href='https://tldextract.readthedocs.io/' target='_blank'>tldextract "
+"docs</a></li></ul>"
+msgstr ""
+"<ul><li><code>ovh</code>: libreria Python 'ovh' per servizi OVH.  Metodi "
+"disponibili: 'Client'<br/>Supporta servizi OVH<br/>Controllare la <a "
+"href='https://eu.api.ovh.com/console/?section=%2FallDom&branch=v1' "
+"target='_blank'>documentazione OVH</a> per informazioni dettagliate sui "
+"servizi e i metodi.</li><li><code>tldextract</code>: libreria Python "
+"'tldextract' . Metodi disponibili: 'extract'<br/>Supporta estrazione "
+"dominio. Vedi <a href='https://tldextract.readthedocs.io/' "
+"target='_blank'>documenti tldextract</a></li></ul>"
+
+#. module: cetmix_tower_ovh
+#: model:ir.model,name:cetmix_tower_ovh.model_cx_tower_command
+msgid "Cetmix Tower Command"
+msgstr "Comando Cetmix Tower"
+
+#. module: cetmix_tower_ovh
+#: model:ir.model.fields,field_description:cetmix_tower_ovh.field_cx_tower_command__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: cetmix_tower_ovh
+#: model:ir.model.fields,field_description:cetmix_tower_ovh.field_cx_tower_command__id
+msgid "ID"
+msgstr "ID"
+
+#. module: cetmix_tower_ovh
+#: model:ir.model.fields,field_description:cetmix_tower_ovh.field_cx_tower_command____last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"

--- a/cetmix_tower_server/i18n/it.po
+++ b/cetmix_tower_server/i18n/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2025-05-03 15:52+0200\n"
+"PO-Revision-Date: 2025-05-29 22:45+0200\n"
 "Last-Translator: Stefano Consolaro <stefano.consolaro@mymage.it>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/tower-server-14/"
 "cetmix_tower_server/it/>\n"
@@ -286,6 +286,19 @@ msgstr ""
 "# Esegui qualsiasi comando SSH sul sistema di destinazione\n"
 "# Esempi: ls, cd, pwd, mkdir, rm\n"
 "# Adatta i comandi al tuo sistema operativo specifico.\n"
+
+#. module: cetmix_tower_server
+#: code:addons/cetmix_tower_server/models/cx_tower_reference_mixin.py:0
+#, python-format
+#| msgid "%(name)s (copy)"
+msgid "%(name)s (copy %(number)s)"
+msgstr "%(name)s (copia %(number)s)"
+
+#. module: cetmix_tower_server
+#: code:addons/cetmix_tower_server/models/cx_tower_reference_mixin.py:0
+#, python-format
+msgid "%(name)s (copy)"
+msgstr "%(name)s (copia)"
 
 #. module: cetmix_tower_server
 #: code:addons/cetmix_tower_server/models/cx_tower_shortcut.py:0
@@ -649,8 +662,10 @@ msgstr "Binario"
 
 #. module: cetmix_tower_server
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_command__reference
+#: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_file__reference
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_file_template__reference
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_key__reference
+#: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_key_value__reference
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_os__reference
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_plan__reference
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_plan_line__reference
@@ -1249,9 +1264,9 @@ msgid "Custom Exit Code"
 msgstr "Codice uscita personalizzato"
 
 #. module: cetmix_tower_server
-#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command_run_wizard__custom_variable_values
-msgid "Custom Variable Values"
-msgstr "Valori variabile predefiiti"
+#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command_run_wizard__custom_variable_value_ids
+msgid "Custom Variable Value"
+msgstr "Valore variabile predefinito"
 
 #. module: cetmix_tower_server
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_command_log__label
@@ -2006,6 +2021,15 @@ msgid "If enabled file will be synced automatically using cron"
 msgstr "Se abilitata il file verrà sincronizzato automaticamente usando cron"
 
 #. module: cetmix_tower_server
+#: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_command__no_split_for_sudo
+msgid ""
+"If enabled, do not split command on '&&' when using sudo.Prepend sudo once "
+"to the whole command."
+msgstr ""
+"Se abilitata, non dividere il comando su '&&' quando si usa sudo. Anteporre "
+"sudo una volta a tutto il comando."
+
+#. module: cetmix_tower_server
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_command__allow_parallel_run
 msgid ""
 "If enabled, multiple instances of the same command can be run on the same "
@@ -2415,6 +2439,7 @@ msgstr "Scadenza mia attività"
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_file__name
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_file_template__name
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_key__name
+#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_key_value__name
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_os__name
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_plan__name
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_plan_line__name
@@ -2465,6 +2490,11 @@ msgstr "Data sincronizzazione successiva"
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_server_view_form
 msgid "No"
 msgstr "No"
+
+#. module: cetmix_tower_server
+#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command__no_split_for_sudo
+msgid "No Split for sudo"
+msgstr "Non dividere per sudo"
 
 #. module: cetmix_tower_server
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_file_view_search
@@ -2919,8 +2949,10 @@ msgstr "Rilevata chiamata piano ricorsiva nel piano %(name)s."
 
 #. module: cetmix_tower_server
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command__reference
+#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_file__reference
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_file_template__reference
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_key__reference
+#: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_key_value__reference
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_os__reference
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_plan__reference
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_plan_line__reference
@@ -2946,11 +2978,14 @@ msgstr "Codice riferimento"
 
 #. module: cetmix_tower_server
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_command_reference_unique
+#: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_file_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_file_template_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_git_project_reference_unique
+#: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_git_project_rel_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_git_remote_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_git_source_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_key_reference_unique
+#: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_key_value_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_os_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_plan_line_action_reference_unique
 #: model:ir.model.constraint,message:cetmix_tower_server.constraint_cx_tower_plan_line_reference_unique
@@ -4659,9 +4694,6 @@ msgstr "con etichette"
 
 #~ msgid "sudo password was not provided!"
 #~ msgstr "la password sudo non è stata fornita!"
-
-#~ msgid "%(name)s (copy)"
-#~ msgstr "%(name)s (copia)"
 
 #~ msgid "SSH execute command error"
 #~ msgstr "Errore comando esecuzione SSH"

--- a/cetmix_tower_yaml/i18n/it.po
+++ b/cetmix_tower_yaml/i18n/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2025-05-03 15:53+0200\n"
+"PO-Revision-Date: 2025-05-29 22:40+0200\n"
 "Last-Translator: Stefano Consolaro <stefano.consolaro@mymage.it>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/tower-"
 "server-14-0-dev/cetmix_tower_yaml/it/>\n"
@@ -92,6 +92,11 @@ msgid "Cetmix Tower Command"
 msgstr "Comando Cetmix Tower"
 
 #. module: cetmix_tower_yaml
+#: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_file
+msgid "Cetmix Tower File"
+msgstr "File di Cetmix Tower"
+
+#. module: cetmix_tower_yaml
 #: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_file_template
 msgid "Cetmix Tower File Template"
 msgstr "Modello file Cetmix Tower"
@@ -120,6 +125,16 @@ msgstr "Deposito chiave/segreto Cetmix Tower"
 #: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_os
 msgid "Cetmix Tower Operating System"
 msgstr "Sistema operativo Cetmix Tower"
+
+#. module: cetmix_tower_yaml
+#: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_key_value
+msgid "Cetmix Tower Secret Value Storage"
+msgstr "Deposito valore segreto Cetmix Tower"
+
+#. module: cetmix_tower_yaml
+#: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_server
+msgid "Cetmix Tower Server"
+msgstr "Server Cetmix Tower"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model,name:cetmix_tower_yaml.model_cx_tower_server_log
@@ -223,12 +238,15 @@ msgstr "Creato il"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_command__display_name
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file_template__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key__display_name
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key_value__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_os__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line_action__display_name
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_log__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_template__display_name
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_shortcut__display_name
@@ -282,6 +300,7 @@ msgstr "Esplodi record figli"
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_key_export_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_os_export_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_plan_export_yaml
+#: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_server_export_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_server_template_export_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_shortcut_export_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_cx_tower_tag_export_yaml
@@ -291,6 +310,7 @@ msgstr "Esplodi record figli"
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_file_template_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_plan_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_template_view_form
+#: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_shortcut_view_form
 msgid "Export YAML"
 msgstr "Esporta YAML"
@@ -330,12 +350,15 @@ msgstr "Genera file YAML"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_command__id
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file_template__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key__id
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key_value__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_os__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line_action__id
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_log__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_template__id
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_shortcut__id
@@ -386,12 +409,15 @@ msgstr "Chiave/segreto"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_command____last_update
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file_template____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key____last_update
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key_value____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_os____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line_action____last_update
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_log____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_template____last_update
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_shortcut____last_update
@@ -437,8 +463,8 @@ msgstr "Il modello '%s' non supporta l'importazione YAML"
 #. module: cetmix_tower_yaml
 #: code:addons/cetmix_tower_yaml/tests/test_yaml_import_wizard.py:0
 #, python-format
-msgid "Model 'server' does not support YAML import"
-msgstr "Il modello 'server' non supporta l'importazione YAML"
+msgid "Model 'command_run_wizard' does not support YAML import"
+msgstr "Il modello 'command_run_wizard' non supporta l'importazione YAML"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_yaml_import_wiz__model_names
@@ -601,6 +627,7 @@ msgstr "Valore errato per 'access_level' key: %(acv)s"
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_file_template_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_plan_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_template_view_form
+#: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_shortcut_view_form
 msgid "YAML"
 msgstr "YAML"
@@ -643,12 +670,15 @@ msgstr ""
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_command__yaml_code
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_file_template__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key__yaml_code
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_key_value__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_os__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_plan_line_action__yaml_code
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_log__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_server_template__yaml_code
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_shortcut__yaml_code
@@ -691,6 +721,7 @@ msgstr "Non si è autorizzati a creare record da YAML"
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_file_template_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_plan_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_template_view_form
+#: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_server_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_shortcut_view_form
 msgid ""
 "You must be a member of the \"YAML/Export\" group to export data as YAML."


### PR DESCRIPTION
Updated it.po for v.14.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Italian translations for the cetmix_tower_aws and cetmix_tower_ovh modules, providing localized user interface and descriptions.
- **Enhancements**
  - Expanded and updated Italian translations in cetmix_tower_server and cetmix_tower_yaml modules, including new field descriptions, model references, and improved translation coverage.
  - Added new translation entries related to command copying and sudo command splitting behavior in cetmix_tower_server.
- **Bug Fixes**
  - Corrected a test-related translation message in cetmix_tower_yaml for YAML import support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->