### PR TITLE
[16.0][IMP] cetmix_tower_yaml: Performance export

### DIFF
--- a/cetmix_tower_yaml/README.rst
+++ b/cetmix_tower_yaml/README.rst
@@ -13,7 +13,7 @@ Cetmix Tower YAML
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -1,12 +1,15 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
 from builtins import UnicodeEncodeError
 
 import yaml
 
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class CustomDumper(yaml.Dumper):
@@ -18,6 +21,35 @@ class CustomDumper(yaml.Dumper):
         if isinstance(value, str) and "\n" in value:
             style = "|"
         return super().represent_scalar(tag, value, style)
+
+
+class YamlExportCollector:
+    """
+    Collector for YAML export.
+    Tracks unique records by their (model_name, reference) tuple to avoid duplicates.
+    """
+
+    def __init__(self):
+        """
+        Initialize the collector.
+        """
+        self.added_references = set()
+
+    def add(self, key):
+        """
+        Add a record to the collector if its reference is unique.
+        :param key: tuple, key of the record
+        """
+        if key and key not in self.added_references:
+            self.added_references.add(key)
+
+    def is_added(self, key):
+        """
+        Check by (model, reference) tuple.
+        :param key: tuple, key of the record
+        :return: bool
+        """
+        return key in self.added_references
 
 
 class CxTowerYamlMixin(models.AbstractModel):
@@ -189,6 +221,13 @@ class CxTowerYamlMixin(models.AbstractModel):
         Returns:
             dict(): processed values
         """
+        collector = self._context.get("yaml_collector")
+        ref = values.get("reference")
+        collector_key = (self._name, ref) if ref else None
+
+        if collector and collector_key and collector.is_added(collector_key):
+            return {"reference": ref}
+
         # We don't need id because we are not using it
         values.pop("id", None)
 
@@ -234,6 +273,9 @@ class CxTowerYamlMixin(models.AbstractModel):
                         explode_related_record=explode_related_record
                     )._process_relation_field_value(key, value, record_mode=True)
                     new_values.update({key: processed_value})
+
+        if collector and collector_key:
+            collector.add(collector_key)
 
         return new_values
 
@@ -376,6 +418,7 @@ class CxTowerYamlMixin(models.AbstractModel):
         # If the value is a dictionary, extract the reference from it
         elif isinstance(value, dict):
             reference = value.get("reference")
+
             record = self._update_or_create_related_record(
                 comodel, reference, value, create_immediately=True
             )
@@ -510,6 +553,19 @@ class CxTowerYamlMixin(models.AbstractModel):
         # If there's no reference but value is a dict, create a new record
         else:
             if create_immediately:
+                # Only 'reference' provided, no other data: do not create,
+                # just log warning
+                if set(values.keys()) == {"reference"}:
+                    _logger.warning(
+                        "Attempted to import a record for model '%s' with reference "
+                        "'%s', but only the 'reference' field was provided. "
+                        "It is possible that this record has already been imported. "
+                        "Creation will be skipped.",
+                        model._name,
+                        reference,
+                    )
+                    return False
+
                 record = model.with_context(from_yaml=True).create(
                     model._post_process_yaml_dict_values(values)
                 )

--- a/cetmix_tower_yaml/readme/newsfragments/4728.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/4728.feature
@@ -1,0 +1,1 @@
+YAML code optimisation

--- a/cetmix_tower_yaml/static/description/index.html
+++ b/cetmix_tower_yaml/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:5833e388796fc614b68a3cac1a138f09d47787f9b98af71a939141fa286dbcdb
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/16.0/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/cetmix/cetmix-tower/tree/16.0/cetmix_tower_yaml"><img alt="cetmix/cetmix-tower" src="https://img.shields.io/badge/github-cetmix%2Fcetmix--tower-lightgray.png?logo=github" /></a></p>
 <p>This module implements YAML format data import/export for <a class="reference external" href="https://cetmix.com/tower">Cetmix
 Tower</a>.</p>
 <p>Please refer to the <a class="reference external" href="https://cetmix.com/tower">official

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import base64
 
+import yaml
+
 from odoo.exceptions import AccessError, ValidationError
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -188,3 +190,65 @@ records:
         self.test_wizard.yaml_code = ""
         with self.assertRaises(ValidationError):
             self.test_wizard.action_generate_yaml_file()
+
+    def test_reference_object_uniqueness(self):
+        """
+        Ensure each reference is exported as a full object only once
+        (other times only as ref).
+        """
+
+        # Prepare YAML export for flight_plan with two same commands
+        self.flight_plan_test_wizard.line_ids = [
+            (0, 0, {"command_id": self.command_test_wizard.id}),
+            (0, 0, {"command_id": self.command_test_wizard.id}),
+        ]
+
+        # Prepare YAML code
+        self.test_wizard.onchange_explode_child_records()
+        yaml_data = yaml.safe_load(self.test_wizard.yaml_code)
+
+        # reference counters
+        ref_full = set()
+        ref_refs = set()
+
+        # Recursively walk through the YAML data and count references
+        def walk(obj):
+            if isinstance(obj, dict):
+                ref = obj.get("reference")
+                # dict only with "reference" = ref, otherwise — full object
+                if ref:
+                    if list(obj.keys()) == ["reference"]:
+                        ref_refs.add(ref)
+                    else:
+                        ref_full.add(ref)
+                for v in obj.values():
+                    walk(v)
+            elif isinstance(obj, list):
+                for v in obj:
+                    walk(v)
+
+        # Walk through the YAML data
+        walk(yaml_data["records"])
+
+        # Each reference as a full object — only once
+        for ref in ref_full:
+            self.assertEqual(
+                list(ref_full).count(ref),
+                1,
+                f"Reference '{ref}' appears as a full object more than once",
+            )
+        # Check that no full objects appear more than once
+        self.assertEqual(
+            len(ref_full),
+            len(set(ref_full)),
+            "Some full objects appear more than once",
+        )
+
+        # Check that for each ref there is no only reference, but no full object
+        for ref in ref_refs:
+            self.assertIn(
+                ref,
+                ref_full,
+                f"Reference '{ref}' is used only as a reference, "
+                "but no full object present",
+            )

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -5,6 +5,7 @@ import yaml
 from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase
+from odoo.tools import mute_logger
 
 
 class TestTowerYamlImportWizUpload(TransactionCase):
@@ -357,7 +358,8 @@ class TestTowerYamlImportWizUpload(TransactionCase):
     def test_action_import_yaml_create_new_record(self):
         """Test YAML import wizard action when creating a new record"""
         self.import_wizard.if_record_exists = "create"
-        import_wizard_result_action = self.import_wizard.action_import_yaml()
+        with mute_logger("odoo.addons.cetmix_tower_yaml.models.cx_tower_yaml_mixin"):
+            import_wizard_result_action = self.import_wizard.action_import_yaml()
 
         # -- 1 --
         # Test if new record is created instead of updating existing one

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -5,6 +5,8 @@ import base64
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
+from ..models.cx_tower_yaml_mixin import YamlExportCollector
+
 FILE_HEADER = """
 # This file is generated with Cetmix Tower.
 # Details and documentation: https://cetmix.com/tower
@@ -55,12 +57,14 @@ class CxTowerYamlExportWiz(models.TransientModel):
             else FILE_HEADER
         )
 
-        # Compose list of dictionaries ready for YAML conversion
+        # Use the YAML export collector for unique records
+        collector = YamlExportCollector()
         record_list = []
         for record in records:
             record_yaml_dict = record.with_context(
                 explode_related_record=explode_related_record,
                 remove_empty_values=remove_empty_values,
+                yaml_collector=collector,
             )._prepare_record_for_yaml()
             if record_yaml_dict:
                 record_list.append(record_yaml_dict)

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -95,7 +95,7 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 continue
 
             # Update existing record
-            if self.if_record_exists == "update" and odoo_record:
+            elif self.if_record_exists == "update" and odoo_record:
                 try:
                     record_values = model.with_context(
                         force_create_related_record=False
@@ -117,7 +117,7 @@ class CxTowerYamlImportWiz(models.TransientModel):
 
             # Or create a new record
             record_values = model.with_context(
-                force_create_related_record=(self.if_record_exists == "create")
+                force_create_related_record=self.if_record_exists == "create",
             )._post_process_yaml_dict_values(record)
             try:
                 odoo_record = model.with_context(from_yaml=True).create(record_values)


### PR DESCRIPTION
**Why do we need this feature?**

When exporting complex YAML flies in the "Exploded" mode  some records can be added to the same file multiple times. For example if the same command or variable are used in different flight plans they will be added as many times as they are used including with all their details included. Although this doesn't create any issues, this renders the final file bulky and less readable.

**API/Backend**

During the record export using "exploded" mode:

- Check if the same record was already added to the final JSON before.
- If it was already added, do not add the entire object, just the reference.

Task: 4728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved YAML export to prevent duplicate records by introducing a mechanism that tracks and includes only unique entries.
- **Bug Fixes**
	- Enhanced record creation logic to avoid unnecessary or duplicate creation when only a reference is provided.
	- Adjusted import process to ensure exclusive handling of existing and new records, preventing overlapping updates.
- **Other Improvements**
	- Added logging for better traceability during record creation and export processes.
	- Suppressed logging noise during YAML import tests for cleaner test output.
	- Corrected spelling of "license" to "licence" in documentation and badges.
- **Tests**
	- Added a test to verify that YAML export includes each referenced object only once, ensuring uniqueness in exported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->