### PR TITLE
[16.0][FIX] cetmix_tower_yaml-export_files_issue

### DIFF
--- a/cetmix_tower_yaml/models/cx_tower_file.py
+++ b/cetmix_tower_yaml/models/cx_tower_file.py
@@ -33,3 +33,14 @@ class CxTowerFile(models.Model):
         if self.env.context.get("from_yaml"):
             return
         super()._post_create_write(op_type)
+
+    def _prepare_record_for_yaml(self):
+        """
+        Override to drop file `code` when the source is 'server'.
+        """
+        record_dict = super()._prepare_record_for_yaml()
+
+        if record_dict.get("source") == "server":
+            record_dict["code"] = False
+
+        return record_dict

--- a/cetmix_tower_yaml/models/cx_tower_server_log.py
+++ b/cetmix_tower_yaml/models/cx_tower_server_log.py
@@ -18,5 +18,6 @@ class CxTowerServerLog(models.Model):
             "command_id",
             "use_sudo",
             "file_template_id",
+            "file_id",
         ]
         return res

--- a/cetmix_tower_yaml/tests/__init__.py
+++ b/cetmix_tower_yaml/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_file_template
 from . import test_plan
 from . import test_yaml_export_wizard
 from . import test_yaml_import_wizard
+from . import test_server_log

--- a/cetmix_tower_yaml/tests/test_server_log.py
+++ b/cetmix_tower_yaml/tests/test_server_log.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+"""
+Tests for the cx.tower.server.log model YAML export/import.
+
+Covers:
+1. YAML export of a file-type log must include `file_id` and allow suffixes.
+2. A full round-trip (export → delete → import) preserves the `file_id` relation.
+3. Exporting a non-file log must include a falsy `file_id`.
+4. Importing YAML with a bogus `file_id` reference raises ValidationError.
+"""
+
+import yaml
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestServerLog(TransactionCase):
+    """YAML export/import tests for cx.tower.server.log."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        cls.File = env["cx.tower.file"]
+        cls.Server = env["cx.tower.server"]
+        cls.ServerLog = env["cx.tower.server.log"]
+
+        # Create a file to reference from the log
+        cls.file = cls.File.create(
+            {
+                "name": "repos.yaml",
+                "reference": "reposyaml",
+                "source": "tower",
+                "file_type": "text",
+                "server_dir": "/tmp",
+                "code": "# Example\nHello, Tower!",
+            }
+        )
+
+        # Create a server (use password auth to satisfy constraints)
+        cls.server = cls.Server.create(
+            {
+                "name": "Srv-YAML-Test",
+                "reference": "srv_yaml_test",
+                "ip_v4_address": "127.0.0.1",
+                "ssh_username": "admin",
+                "ssh_port": 22,
+                "ssh_auth_mode": "p",
+                "ssh_password": "dummy",
+                "use_sudo": False,
+            }
+        )
+
+        # Create a file-type log linked to the file above
+        cls.log = cls.ServerLog.create(
+            {
+                "name": "Log from file",
+                "reference": "log_from_file",
+                "log_type": "file",
+                "file_id": cls.file.id,
+                "server_id": cls.server.id,
+                "use_sudo": False,
+            }
+        )
+
+    def test_yaml_export_contains_file_id(self):
+        """Exported YAML must include a file_id starting with the file's reference."""
+        data = yaml.safe_load(self.log.yaml_code)
+        # Ensure file_id is present
+        self.assertIn("file_id", data, "`file_id` is missing from YAML export")
+        # Allow for auto-appended suffixes, so only check prefix
+        self.assertTrue(
+            data["file_id"].startswith(self.file.reference),
+            f"`file_id` value '{data['file_id']}' should start with "
+            f"'{self.file.reference}'",
+        )
+
+    def test_yaml_roundtrip_restores_file_id(self):
+        """A full export→delete→import cycle must restore the file_id relation."""
+        yaml_dict = yaml.safe_load(self.log.yaml_code)
+        # Remove the original log
+        self.log.unlink()
+        # Recreate from YAML
+        vals = self.ServerLog._post_process_yaml_dict_values(yaml_dict)
+        restored = self.ServerLog.with_context(from_yaml=True).create(vals)
+        # Verify relation restored
+        self.assertEqual(
+            restored.file_id.id,
+            self.file.id,
+            "`file_id` was not restored after round-trip",
+        )
+
+    def test_yaml_export_without_file_id(self):
+        """Logs of non-file type should not include file_id in YAML."""
+        cmd_log = self.ServerLog.create(
+            {
+                "name": "Log no file",
+                "reference": "log_no_file",
+                "log_type": "command",
+                "server_id": self.server.id,
+                "use_sudo": False,
+            }
+        )
+        data = yaml.safe_load(cmd_log.yaml_code)
+        # key is present, but must be falsy
+        self.assertIn("file_id", data, "`file_id` key is missing")
+        self.assertFalse(
+            data["file_id"],
+            "`file_id` for non-file log must be False/empty",
+        )
+
+    def test_yaml_import_with_missing_file_reference(self):
+        """Missing file reference is accepted, but file_id stays empty."""
+        yaml_dict = yaml.safe_load(self.log.yaml_code)
+        yaml_dict["file_id"] = "does_not_exist"
+
+        vals = self.ServerLog._post_process_yaml_dict_values(yaml_dict)
+        new_log = self.ServerLog.with_context(from_yaml=True).create(vals)
+
+        # Log is created, but the relation is not resolved
+        self.assertFalse(
+            new_log.file_id,
+            "file_id should be empty when reference cannot be resolved",
+        )

--- a/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
@@ -1,6 +1,10 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
 from odoo import _
 from odoo.exceptions import AccessError, ValidationError
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 
 class TestTowerYamlMixin(TransactionCase):
@@ -480,3 +484,42 @@ class TestTowerYamlMixin(TransactionCase):
             record.name, values_to_update["name"], "Value was not updated properly"
         )
         self.assertNotEqual(record.id, file_template.id, "New record must be created")
+
+    @tagged("post_install", "-at_install")
+    def test_prepare_record_truncates_code_for_server_files(self):
+        """Mixin must set code=False for cx.tower.file when source=='server'."""
+        File = self.env["cx.tower.file"]
+        srv_file = File.create(
+            {
+                "name": "srv.log",
+                "reference": "srvlog",
+                "source": "server",
+                "file_type": "text",
+                "server_dir": "/tmp",
+                "code": "BIG DATA",
+            }
+        )
+        rec = srv_file._prepare_record_for_yaml()
+        self.assertIn("code", rec)
+        self.assertFalse(rec["code"], "Expected code=False for server-sourced files")
+
+    @tagged("post_install", "-at_install")
+    def test_prepare_record_keeps_code_for_tower_files(self):
+        """Mixin must keep code for cx.tower.file when source=='tower'."""
+        File = self.env["cx.tower.file"]
+        tw_file = File.create(
+            {
+                "name": "local.txt",
+                "reference": "localtxt",
+                "source": "tower",
+                "file_type": "text",
+                "server_dir": "/etc",
+                "code": "SMALL DATA",
+            }
+        )
+        rec = tw_file._prepare_record_for_yaml()
+        self.assertEqual(
+            rec["code"],
+            "SMALL DATA",
+            "Expected original code for tower-sourced files",
+        )


### PR DESCRIPTION
Add "file_id" in cx_tower_server_log and tests unitaires

Task: 4782

Override `_prepare_record_for_yaml` to set `code=False` when `source=='server'`
Add tests in `test_tower_yaml_mixin.py`

Task: 4783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced YAML export/import to include file reference handling for server logs.
  - Added conditional YAML preparation for file records, clearing code content for server-sourced files.
- **Tests**
  - Added tests validating YAML export/import of server logs with file references and missing files.
  - Added tests verifying YAML preparation behavior based on file source type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->