### PR TITLE
[16.0][IMP] cetmix_tower_yaml-manifest_templates_for_YAML_export

### DIFF
--- a/cetmix_tower_yaml/__manifest__.py
+++ b/cetmix_tower_yaml/__manifest__.py
@@ -27,6 +27,8 @@
         "views/cx_tower_shortcut_view.xml",
         "views/cx_tower_scheduled_task_view.xml",
         "views/cx_tower_key_view.xml",
+        "views/cx_tower_yaml_manifest_template_views.xml",
+        "views/cx_tower_yaml_manifest_author_views.xml",
         "wizards/cx_tower_yaml_export_wiz.xml",
         "wizards/cx_tower_yaml_export_wiz_download.xml",
         "wizards/cx_tower_yaml_import_wiz_upload.xml",

--- a/cetmix_tower_yaml/models/__init__.py
+++ b/cetmix_tower_yaml/models/__init__.py
@@ -17,3 +17,5 @@ from . import cx_tower_shortcut
 from . import cx_tower_scheduled_task
 from . import cx_tower_file
 from . import cx_tower_server
+from . import cx_tower_yaml_manifest_template
+from . import cx_tower_yaml_manifest_author

--- a/cetmix_tower_yaml/models/cx_tower_yaml_manifest_author.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_manifest_author.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import fields, models
+
+
+class CxTowerYamlManifestAuthor(models.Model):
+    """Author of a YAML manifest (can be one or many)."""
+
+    _name = "cx.tower.yaml.manifest.author"
+
+    _sql_constraints = [
+        (
+            "yaml_manifest_author_name_uniq",
+            "unique(name)",
+            "Author name must be unique.",
+        )
+    ]
+    _description = "YAML Manifest Author"
+    _order = "name"
+
+    name = fields.Char(required=True, translate=False)

--- a/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import re
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class CxTowerYamlManifestTemplate(models.Model):
+    """Pre-defined YAML manifest template storing common metadata
+    such as authors, website, license, and currency for reuse
+    during YAML exports."""
+
+    _name = "cx.tower.yaml.manifest.tmpl"
+    _description = "YAML Manifest Template"
+    _order = "name"
+
+    name = fields.Char(
+        required=True,
+        help="Name of the manifest template.",
+    )
+    website = fields.Char(help="Website URL for the manifest.")
+
+    author_ids = fields.Many2many(
+        "cx.tower.yaml.manifest.author",
+        string="Authors",
+        help="List of author names to include in the YAML manifest.",
+    )
+
+    license = fields.Selection(
+        selection=lambda self: self._selection_license(),
+        help="License used for the code snippet.",
+    )
+    license_text = fields.Text(
+        help="Custom license text when license type is Custom.",
+    )
+
+    currency = fields.Selection(
+        selection=lambda self: self._selection_currency(),
+        help="Currency for pricing information.",
+    )
+
+    version = fields.Char(
+        help="Version in Major.Minor.Patch format, e.g. 1.0.0",
+        default="1.0.0",
+    )
+
+    @api.model
+    def _selection_license(self):
+        """Return available license options for manifest."""
+        return [
+            ("AGPL-3", "AGPL-3"),
+            ("LGPL-3", "LGPL-3"),
+            ("MIT", "MIT"),
+            ("Custom", "Custom"),
+        ]
+
+    @api.model
+    def _selection_currency(self):
+        """Return available currency options for manifest pricing."""
+        return [
+            ("EUR", "Euro"),
+            ("USD", "US Dollar"),
+        ]
+
+    @api.constrains("license", "license_text")
+    def _check_license_text_for_custom(self):
+        """Ensure that custom license text is provided when license is 'Custom'."""
+        for rec in self:
+            if rec.license == "Custom" and not rec.license_text:
+                raise ValidationError(
+                    _("Provide Custom License Text when License is set to “Custom”.")
+                )
+
+    @api.constrains("version")
+    def _check_version_format(self):
+        """Ensure the template version follows the x.y.z semantic format.
+
+        The version must consist of three non-negative integers (major, minor, patch)
+        separated by dots—for example, “1.2.3”. Raises a ValidationError otherwise.
+        """
+        semver = re.compile(r"^\d+\.\d+\.\d+$")
+        for rec in self:
+            if not semver.match(rec.version):
+                raise ValidationError(
+                    _("Version must be in the Major.Minor.Patch format, e.g. 1.2.3")
+                )

--- a/cetmix_tower_yaml/security/ir.model.access.csv
+++ b/cetmix_tower_yaml/security/ir.model.access.csv
@@ -3,3 +3,7 @@ access_yaml_export_wizard,Export YAML,model_cx_tower_yaml_export_wiz,group_expor
 access_yaml_export_wizard_download,Export YAML File,model_cx_tower_yaml_export_wiz_download,group_export,1,1,1,1
 access_yaml_import_wizard_upload,Import YAML,model_cx_tower_yaml_import_wiz_upload,group_import,1,1,1,1
 access_yaml_import_wizard,Import YAML,model_cx_tower_yaml_import_wiz,group_import,1,1,1,1
+access_manifest_tmpl_read_export,Manifest tmpl read (export),model_cx_tower_yaml_manifest_tmpl,cetmix_tower_yaml.group_export,1,0,0,0
+access_manifest_tmpl_admin,Manifest tmpl admin,model_cx_tower_yaml_manifest_tmpl,cetmix_tower_server.group_root,1,1,1,1
+access_manifest_author_read_export,Manifest author read (export),model_cx_tower_yaml_manifest_author,cetmix_tower_yaml.group_export,1,0,0,0
+access_manifest_author_admin,Manifest author admin,model_cx_tower_yaml_manifest_author,cetmix_tower_server.group_root,1,1,1,1

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -87,26 +87,12 @@ class TestYamlExportWizard(BaseCommon):
         with self.assertRaises(AccessError):
             self.test_wizard.with_user(self.user_yaml_export).read([])
 
-    def test_comment_inserted_into_yaml_code(self):
-        """Test if comment is inserted into YAML code"""
-
-        self.test_wizard.comment = "Test Comment"
-        self.test_wizard.onchange_explode_child_records()
-        # Because header takes 3 lines, we need to check the 4th line
-        fourth_line_of_yaml_code = self.test_wizard.yaml_code.split("\n")[3]
-        self.assertEqual(
-            fourth_line_of_yaml_code,
-            f"# {self.test_wizard.comment}",
-            "Comment should be properly prepended to YAML code",
-        )
-
     def test_yaml_export_wizard_yaml_generation(self):
         """Test code generation of YAML export wizard."""
 
         wizard_yaml = """
 # This file is generated with Cetmix Tower.
 # Details and documentation: https://cetmix.com/tower
-# Test Comment
 cetmix_tower_yaml_version: 1
 records:
 - cetmix_tower_model: command
@@ -137,7 +123,6 @@ records:
         # Test with two commands
         context = {
             "default_explode_child_records": True,
-            "default_comment": "Test Comment",
             "default_remove_empty_values": True,
             "active_model": "cx.tower.command",
             "active_ids": [self.command_test_wizard.id, self.command_test_wizard_2.id],
@@ -278,3 +263,59 @@ records:
         # check that the model name is present in the YAML file for each record
         for record in yaml_data["records"]:
             self.assertIn("cetmix_tower_model", record)
+
+    def test_default_yaml_file_name_is_used(self):
+        """
+        Wizard should pre-fill `yaml_file_name` with the auto-generated
+        value that ends with '.yaml' and contains the model prefix.
+        """
+        wiz = self.YamlExportWizard.with_context(
+            active_model="cx.tower.command",
+            active_ids=[self.command_test_wizard.id],
+        ).create({})
+
+        default_name = wiz.yaml_file_name
+
+        self.assertFalse(
+            default_name.endswith(".yaml"),
+            "Default file name must NO have .yaml suffix",
+        )
+        self.assertIn(
+            "command_",
+            default_name,
+            "Default file name should include model prefix",
+        )
+
+    def test_yaml_file_name_is_auto_fixed(self):
+        """
+        When the user assigns an invalid name, wizard should auto-sanitise
+        it to a safe *basename* (lowercase, underscores, no extension).
+        """
+        wiz = self.YamlExportWizard.with_context(
+            active_model="cx.tower.command",
+            active_ids=[self.command_test_wizard.id],
+        ).create({})
+
+        # user enters a 'dirty' name with spaces, capitals, symbols
+        wiz.write({"yaml_file_name": "My File!@# .YAML"})
+
+        # write() override strips to a basename WITHOUT '.yaml'
+        self.assertEqual(
+            wiz.yaml_file_name,
+            "my_file",
+            "Wizard field must hold only the cleaned basename, without extension",
+        )
+
+    def test_action_generate_appends_extension(self):
+        """
+        When generating the download record, the system must append
+        the `.yaml` extension to the sanitized basename.
+        """
+        wiz = self.YamlExportWizard.with_context(
+            active_model="cx.tower.command",
+            active_ids=[self.command_test_wizard.id],
+        ).create({})
+        wiz.onchange_explode_child_records()
+        act = wiz.action_generate_yaml_file()
+        download = self.env["cx.tower.yaml.export.wiz.download"].browse(act["res_id"])
+        self.assertTrue(download.yaml_file_name.endswith(".yaml"))

--- a/cetmix_tower_yaml/views/cx_tower_yaml_manifest_author_views.xml
+++ b/cetmix_tower_yaml/views/cx_tower_yaml_manifest_author_views.xml
@@ -1,0 +1,39 @@
+<odoo>
+    <record id="view_yaml_manifest_author_tree" model="ir.ui.view">
+        <field name="name">yaml.manifest.author.tree</field>
+        <field name="model">cx.tower.yaml.manifest.author</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_yaml_manifest_author_form" model="ir.ui.view">
+        <field name="name">yaml.manifest.author.form</field>
+        <field name="model">cx.tower.yaml.manifest.author</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_yaml_manifest_author" model="ir.actions.act_window">
+        <field name="name">YAML Manifest Authors</field>
+        <field name="res_model">cx.tower.yaml.manifest.author</field>
+        <field name="view_mode">tree,form</field>
+        <field name="target">current</field>
+    </record>
+    <menuitem
+        id="menu_yaml_manifest_author_action"
+        name="YAML Manifest Authors"
+        parent="cetmix_tower_server.menu_settings"
+        action="action_yaml_manifest_author"
+        sequence="17"
+    />
+</odoo>

--- a/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
+++ b/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
@@ -1,0 +1,56 @@
+<odoo>
+    <record id="view_yaml_manifest_template_tree" model="ir.ui.view">
+        <field name="name">cx.tower.yaml.manifest.tmpl.tree</field>
+        <field name="model">cx.tower.yaml.manifest.tmpl</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="author_ids" widget="many2many_tags" />
+                <field name="version" />
+                <field name="website" />
+                <field name="license" />
+                <field name="currency" />
+            </tree>
+        </field>
+    </record>
+    <record id="view_yaml_manifest_template_form" model="ir.ui.view">
+        <field name="name">cx.tower.yaml.manifest.tmpl.form</field>
+        <field name="model">cx.tower.yaml.manifest.tmpl</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="author_ids" widget="many2many_tags" />
+                        <field name="version" />
+                        <field name="website" />
+                        <field name="license" />
+                        <field
+                            name="license_text"
+                            attrs="{'invisible': [('license', '!=', 'Custom')]}"
+                        />
+                        <field
+                            name="currency"
+                            attrs="{'invisible': [('license', '!=', 'Custom')]}"
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="action_yaml_manifest_template" model="ir.actions.act_window">
+        <field name="name">YAML Manifest Templates</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">cx.tower.yaml.manifest.tmpl</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_yaml_manifest_template_tree" />
+        <field name="target">current</field>
+    </record>
+    <menuitem
+        id="menu_yaml_manifest_template"
+        name="YAML Manifest Templates"
+        parent="cetmix_tower_server.menu_settings"
+        action="action_yaml_manifest_template"
+        sequence="15"
+    />
+</odoo>

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import base64
+import re
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -12,6 +13,8 @@ FILE_HEADER = """
 # Details and documentation: https://cetmix.com/tower
 """
 
+CLEAN_STR = re.compile(r"[^a-z0-9_]")
+
 
 class CxTowerYamlExportWiz(models.TransientModel):
     """Cetmix Tower YAML Export Wizard"""
@@ -19,10 +22,14 @@ class CxTowerYamlExportWiz(models.TransientModel):
     _name = "cx.tower.yaml.export.wiz"
     _description = "Cetmix Tower YAML Export Wizard"
 
-    comment = fields.Text(
-        help="Comment to be added to the beginning of exported YAML file"
-    )
     yaml_code = fields.Text()
+    yaml_file_name = fields.Char(
+        string="YAML File Name",
+        size=255,
+        default=lambda self: self._default_yaml_file_name(),
+        help="Snippet file name without extension, eg 'my_snippet'",
+    )
+
     explode_child_records = fields.Boolean(
         default=True,
         help="Add entire child record definitions to the exported YAML file. "
@@ -35,10 +42,140 @@ class CxTowerYamlExportWiz(models.TransientModel):
         " field values from the exported YAML file.",
     )
     preview_code = fields.Boolean()
+    add_manifest = fields.Boolean()
 
-    @api.onchange("explode_child_records", "comment", "remove_empty_values")
+    MANIFEST_FIELDS = [
+        "manifest_template_id",
+        "manifest_name",
+        "manifest_author_ids",
+        "manifest_version",
+        "manifest_summary",
+        "manifest_description",
+        "manifest_website",
+        "manifest_license",
+        "manifest_license_text",
+        "manifest_currency",
+        "manifest_price",
+    ]
+
+    @api.model
+    def _get_manifest_license_selection(self):
+        return self.env["cx.tower.yaml.manifest.tmpl"]._selection_license()
+
+    @api.model
+    def _get_manifest_currency_selection(self):
+        return self.env["cx.tower.yaml.manifest.tmpl"]._selection_currency()
+
+    manifest_template_id = fields.Many2one(
+        "cx.tower.yaml.manifest.tmpl",
+    )
+    manifest_name = fields.Char(
+        compute="_compute_manifest",
+        readonly=False,
+        store=True,
+        string="Snippet Name",
+        help="Leave this field blank if you don't want to create a manifest",
+    )
+    manifest_website = fields.Char(
+        compute="_compute_manifest",
+        readonly=False,
+        string="Website",
+        store=True,
+    )
+    manifest_license = fields.Selection(
+        selection="_get_manifest_license_selection",
+        compute="_compute_manifest",
+        readonly=False,
+        string="License",
+        store=True,
+    )
+    manifest_author_ids = fields.Many2many(
+        "cx.tower.yaml.manifest.author",
+        compute="_compute_manifest",
+        readonly=False,
+        string="Authors",
+        store=True,
+    )
+    manifest_license_text = fields.Text(
+        compute="_compute_manifest", readonly=False, string="License Text", store=True
+    )
+    manifest_currency = fields.Selection(
+        selection="_get_manifest_currency_selection",
+        compute="_compute_manifest",
+        string="Currency",
+        readonly=False,
+        store=True,
+    )
+    manifest_summary = fields.Char(
+        string="Summary",
+        size=160,
+        help="Short summary that includes core information. 160 symbols max",
+    )
+    manifest_description = fields.Text("Description")
+    manifest_price = fields.Float("Price")
+
+    manifest_version = fields.Char(
+        compute="_compute_manifest",
+        readonly=False,
+        store=True,
+        string="Version",
+        help="Use the Major.Minor.Patch format, e.g. 1.2.3",
+    )
+
+    def _clean_yaml_basename(self, name: str) -> str:
+        """
+        Return *always-valid* basename (no extension) built from arbitrary *name*.
+        """
+        raw = (name or "").strip().lower()
+        base = raw[:-5] if raw.endswith(".yaml") else raw
+        base = CLEAN_STR.sub("_", base)
+        base = re.sub(r"_+", "_", base).strip("_") or "snippet"
+        return base
+
+    def _default_yaml_file_name(self):
+        """
+        Build the *initial* file name shown to the user.
+        Pattern: <model>_<reference>, without “.yaml” suffix.
+        """
+        records = self._get_model_record()
+        prefix = records._name.replace("cx.tower.", "").replace(".", "_")
+        ref = records.reference if len(records) == 1 else "selected"
+        return f"{prefix}_{ref}"
+
+    @api.depends("manifest_template_id")
+    def _compute_manifest(self):
+        mapping = {
+            "manifest_name": "name",
+            "manifest_author_ids": "author_ids",
+            "manifest_website": "website",
+            "manifest_license": "license",
+            "manifest_license_text": "license_text",
+            "manifest_currency": "currency",
+            "manifest_version": "version",
+        }
+        for rec in self:
+            tmpl = rec.manifest_template_id
+            if not tmpl:
+                continue
+            for wiz_field, tmpl_field in mapping.items():
+                if not rec[wiz_field]:
+                    rec[wiz_field] = tmpl[tmpl_field]
+
+    @api.onchange("manifest_license")
+    def _onchange_manifest_license(self):
+        """Drop price and currency when user switches off the 'Custom' license.
+
+        If manifest_license != 'Custom', reset manifest_price to 0.0 and
+        manifest_currency to False so they won’t appear in the generated YAML.
+        """
+        for rec in self:
+            if rec.manifest_license != "Custom":
+                rec.manifest_price = 0.0
+                rec.manifest_currency = False
+
+    @api.onchange("explode_child_records", "remove_empty_values", *MANIFEST_FIELDS)
     def onchange_explode_child_records(self):
-        """Compute YAML code and file content"""
+        """Compute YAML code and file content."""
 
         self.ensure_one()
 
@@ -51,58 +188,127 @@ class CxTowerYamlExportWiz(models.TransientModel):
         remove_empty_values = self.remove_empty_values
 
         # Prepare YAML header
-        yaml_header = (
-            FILE_HEADER + self._text_to_yaml_comment(self.comment)
-            if self.comment
-            else FILE_HEADER
-        )
-
+        yaml_header = FILE_HEADER.rstrip("\n")
         # Use the YAML export collector for unique records
         collector = YamlExportCollector()
         record_list = []
-        for record in records:
-            record_yaml_dict = record.with_context(
+        for rec in records:
+            record_yaml_dict = rec.with_context(
                 explode_related_record=explode_related_record,
                 remove_empty_values=remove_empty_values,
                 yaml_collector=collector,
             )._prepare_record_for_yaml()
-            if record_yaml_dict:
-                # Add model name to the record if it's not present
-                if "cetmix_tower_model" not in record_yaml_dict:
-                    record_yaml_dict["cetmix_tower_model"] = record._name.replace(
-                        "cx.tower.", ""
-                    ).replace(".", "_")
 
-                record_list.append(record_yaml_dict)
+            if not record_yaml_dict:
+                continue
+            if isinstance(record_yaml_dict, dict) and list(record_yaml_dict) == [
+                "reference"
+            ]:
+                continue
 
-        if record_list:
-            yaml_version = self.env["cx.tower.yaml.mixin"].CETMIX_TOWER_YAML_VERSION
-            yaml_code = records._convert_dict_to_yaml(
-                {"cetmix_tower_yaml_version": yaml_version, "records": record_list}
-            )
+            if "cetmix_tower_model" not in record_yaml_dict:
+                record_yaml_dict["cetmix_tower_model"] = rec._name.replace(
+                    "cx.tower.", ""
+                ).replace(".", "_")
+
+            record_list.append(record_yaml_dict)
+
+        if not record_list:
+            self.yaml_code = f"{yaml_header}\n"
+            return
+
+        if not self.manifest_name:
+            manifest = {}
         else:
-            yaml_code = ""
+            fields_order = [
+                ("name", self.manifest_name),
+                ("summary", self.manifest_summary),
+                ("description", self.manifest_description),
+                ("author", self.manifest_author_ids.mapped("name")),
+                ("version", self.manifest_version),
+                ("website", self.manifest_website),
+                ("license", self.manifest_license),
+                (
+                    "license_text",
+                    self.manifest_license_text
+                    if self.manifest_license == "Custom"
+                    else None,
+                ),
+                ("price", self.manifest_price),
+                (
+                    "currency",
+                    self.manifest_currency
+                    if self.manifest_license == "Custom"
+                    else None,
+                ),
+            ]
+            manifest = {k: v for k, v in fields_order if v not in (False, None, "", [])}
 
-        self.yaml_code = f"{yaml_header}\n{yaml_code}"
+        result_dict = {
+            "cetmix_tower_yaml_version": self.env[
+                "cx.tower.yaml.mixin"
+            ].CETMIX_TOWER_YAML_VERSION,
+        }
+        if manifest:
+            result_dict["manifest"] = manifest
+        result_dict["records"] = record_list
+
+        self.yaml_code = f"{yaml_header}\n{records._convert_dict_to_yaml(result_dict)}"
+
+    @api.onchange("yaml_file_name")
+    def _onchange_yaml_file_name(self):
+        """
+        Live-clean the YAML file name as the user types:
+        - lowercase, trim whitespace
+        - replace invalid characters with “_”
+        - collapse repeated underscores
+        - ensure a single “.yaml” suffix
+        """
+        for rec in self:
+            rec.yaml_file_name = rec._clean_yaml_basename(rec.yaml_file_name)
+
+    @api.constrains("manifest_version")
+    def _check_manifest_version_format(self):
+        """
+        Ensure the user types a semantic version (x.y.z) in the wizard itself.
+        """
+        semver = re.compile(r"^\d+\.\d+\.\d+$")
+        for rec in self:
+            if rec.manifest_version and not semver.match(rec.manifest_version):
+                raise ValidationError(
+                    _("Version must be in format Major.Minor.Patch, e.g. 1.2.3")
+                )
+
+    def _validate_manifest(self):
+        """Logical cross-checks before saving YAML."""
+        if self.manifest_price and not self.manifest_currency:
+            raise ValidationError(_("Currency is required when price is specified"))
+        if self.manifest_license == "Custom" and not self.manifest_license_text:
+            raise ValidationError(_("License text is required for a custom license"))
+
+    def write(self, vals):
+        """
+        Override write to always sanitize `yaml_file_name`
+        before persisting, making programmatic assignments safe.
+        """
+        if "yaml_file_name" in vals:
+            vals["yaml_file_name"] = self._clean_yaml_basename(vals["yaml_file_name"])
+        return super().write(vals)
 
     def action_generate_yaml_file(self):
         """Save YAML file"""
 
         self.ensure_one()
+
+        self._validate_manifest()
         if not self.yaml_code:
             raise ValidationError(_("No YAML code is present."))
-
-        # Get model records
-        records = self._get_model_record()
-
-        # Get model prefix
-        model_prefix = records._name.replace("cx.tower.", "").replace(".", "_")
 
         # Generate YAML file
         try:
             yaml_file = base64.encodebytes(self.yaml_code.encode("utf-8"))
             yaml_file_name = (
-                f"{model_prefix}_{records.reference if len(records) == 1 else 'selected'}.yaml"  # noqa: E501
+                f"{self.yaml_file_name or self._default_yaml_file_name()}.yaml"
             )
         except Exception as exc:
             raise ValidationError(
@@ -141,16 +347,3 @@ class CxTowerYamlExportWiz(models.TransientModel):
         if not model_name or not record_ids:
             raise ValidationError(_("No model or records selected"))
         return self.env[model_name].browse(record_ids)
-
-    def _text_to_yaml_comment(self, text):
-        """Convert multi line text into YAML comment
-
-        Args:
-            text (Char): Text to convert
-
-        Returns:
-            Text: Converted text
-        """
-        lines = text.splitlines()
-        yaml_comment = "\n".join([f"# {line}" for line in lines])
-        return yaml_comment

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.xml
@@ -7,31 +7,122 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="explode_child_records" />
-                    <field name="remove_empty_values" />
-                    <field name="preview_code" />
+                    <field name="yaml_file_name" placeholder="my_snippet.yaml" />
                 </group>
-                <field
-                    name="comment"
-                    placeholder="Comment to be added to the beginning of exported YAML file"
-                />
-                <field
-                    name="yaml_code"
-                    widget="ace"
-                    options="{'mode': 'yaml'}"
-                    readonly="1"
-                    force_save="1"
-                    attrs="{'invisible': [('preview_code', '=', False)]}"
-                />
-                <footer>
-                    <button
+                <group>
+                    <group>
+                        <field name="explode_child_records" />
+                        <field name="remove_empty_values" />
+                    </group>
+                    <group>
+                        <field name="add_manifest" />
+                        <field name="preview_code" />
+                    </group>
+                </group>
+
+                <group
+                    string="Manifest"
+                    attrs="{'invisible': [('add_manifest','=',False)]}"
+                >
+                    <field
+                        name="manifest_template_id"
+                        placeholder="Select a pre-defined template"
+                        help="Select a template to auto-populate manifest fields"
+                    />
+                    <group string="Information">
+
+                        <field
+                            name="manifest_name"
+                            attrs="{'required': [('add_manifest','!=',False)]}"
+                        />
+                        <field
+                            name="manifest_summary"
+                            attrs="{'required': [('manifest_name','!=',False)]}"
+                            placeholder="Short summary, 160 symbols max"
+                        />
+                        <field
+                            name="manifest_author_ids"
+                            widget="many2many_tags"
+                            attrs="{'required': [('manifest_name','!=',False)]}"
+                        />
+                        <field
+                            name="manifest_version"
+                            placeholder="Use the Major.Minor.Patch format, e.g. 1.2.3"
+                        />
+                        <field name="manifest_website" />
+                    </group>
+
+                    <group string="License and pricing">
+                        <field
+                            name="manifest_license"
+                            attrs="{'required': [('manifest_name','!=',False)]}"
+                        />
+                        <field
+                            name="manifest_price"
+                            attrs="{'invisible': [('manifest_license', '!=', 'Custom')]}"
+                        />
+                        <field
+                            name="manifest_currency"
+                            attrs="{'invisible': [('manifest_price', '=', 0)]}"
+                        />
+                    </group>
+                </group>
+
+                <notebook>
+
+                    <page
+                        string="Description"
+                        attrs="{'invisible': [('add_manifest','=',False)]}"
+                    >
+                        <field
+                            name="manifest_description"
+                            widget="text"
+                            nolabel="1"
+                            colspan="4"
+                            placeholder="Detailed description (optional)"
+                        />
+                    </page>
+
+                    <page
+                        string="License text"
+                        attrs="{'invisible': [('manifest_license', '!=', 'Custom')]}"
+                    >
+                        <field
+                            name="manifest_license_text"
+                            widget="text"
+                            nolabel="1"
+                            colspan="4"
+                            placeholder="License text"
+                            attrs="{'required': [('manifest_license', '=', 'Custom')]}"
+                        />
+                    </page>
+
+                    <page
+                        string="Preview code"
+                        attrs="{'invisible': [('preview_code','=',False)]}"
+                    >
+                        <field
+                            name="yaml_code"
+                            widget="ace"
+                            options="{'mode': 'yaml'}"
+                            force_save="1"
+                            nolabel="1"
+                            colspan="4"
+                            readonly="1"
+                        />
+                    </page>
+
+                </notebook>
+
+            <footer>
+                <button
                         string="Generate YAML file"
                         type="object"
                         name="action_generate_yaml_file"
                         class="oe_highlight"
                     />
-                    <button string="Close" special="cancel" />
-                </footer>
+                <button string="Close" special="cancel" />
+            </footer>
             </form>
         </field>
     </record>

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -39,6 +39,40 @@ class CxTowerYamlImportWiz(models.TransientModel):
     )
     preview_code = fields.Boolean()
 
+    manifest_name = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="Snippet Name"
+    )
+    manifest_summary = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="Summary"
+    )
+    manifest_description = fields.Text(
+        readonly=True, compute="_compute_yaml_data", string="Description"
+    )
+    manifest_author_string = fields.Char(
+        readonly=True,
+        compute="_compute_yaml_data",
+        help="Comma-separated list",
+        string="Author",
+    )
+    manifest_version = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="Version"
+    )
+    manifest_website = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="Website"
+    )
+    manifest_license = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="License"
+    )
+    manifest_license_text = fields.Text(
+        readonly=True, compute="_compute_yaml_data", string="License text"
+    )
+    manifest_price = fields.Float(
+        readonly=True, compute="_compute_yaml_data", string="Price"
+    )
+    manifest_currency = fields.Char(
+        readonly=True, compute="_compute_yaml_data", string="Currency"
+    )
+
     @api.depends("yaml_code")
     def _compute_secret_list(self):
         """Compute list of secrets present in the YAML file"""
@@ -52,6 +86,35 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 )
             else:
                 record.secret_list = False
+
+    @api.depends("yaml_code")
+    def _compute_yaml_data(self):
+        for record in self:
+            data = yaml.safe_load(record.yaml_code)
+
+            manifest = data.get("manifest", {}) if isinstance(data, dict) else {}
+            authors = manifest.get("author")
+            if isinstance(authors, list | tuple):
+                manifest_author_string = ", ".join(authors)
+            elif isinstance(authors, str):
+                manifest_author_string = authors
+            else:
+                manifest_author_string = False
+
+            record.update(
+                {
+                    "manifest_name": manifest.get("name"),
+                    "manifest_summary": manifest.get("summary"),
+                    "manifest_description": manifest.get("description"),
+                    "manifest_author_string": manifest_author_string,
+                    "manifest_version": manifest.get("version"),
+                    "manifest_website": manifest.get("website"),
+                    "manifest_license": manifest.get("license"),
+                    "manifest_license_text": manifest.get("license_text"),
+                    "manifest_price": manifest.get("price"),
+                    "manifest_currency": manifest.get("currency"),
+                }
+            )
 
     def action_import_yaml(self):
         """Process YAML data and create records in Odoo"""

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
@@ -9,6 +9,72 @@
                 <group>
                     <field name="if_record_exists" />
                 </group>
+                <group
+                    attrs="{'invisible': [
+                        ('manifest_name', '=', False),
+                    ]}"
+                >
+                    <group string="Information">
+                        <field name="manifest_name" string="Name" />
+                        <field name="manifest_summary" string="Summary" />
+                        <field name="manifest_author_string" string="Author" />
+                        <field name="manifest_version" string="Version" />
+                        <field
+                            name="manifest_website"
+                            string="Website"
+                            attrs="{'invisible': [('manifest_website', '=', False)]}"
+                        />
+                    </group>
+                    <group string="License and pricing">
+                        <field name="manifest_license" string="License" />
+                        <field
+                            name="manifest_price"
+                            string="Price"
+                            attrs="{'invisible': [('manifest_price', '=', False)]}"
+                        />
+                        <field
+                            name="manifest_currency"
+                            string="Currency"
+                            attrs="{'invisible': [('manifest_currency', '=', False)]}"
+                        />
+                    </group>
+                    <notebook>
+                        <page
+                            string="Description"
+                            attrs="{'invisible':[('manifest_description','=',False)]}"
+                        >
+                            <field
+                                name="manifest_description"
+                                widget="text"
+                                nolabel="1"
+                                colspan="4"
+                            />
+                        </page>
+                        <page
+                            string="License text"
+                            attrs="{'invisible':[('manifest_license_text','=',False)]}"
+                        >
+                            <field
+                                name="manifest_license_text"
+                                widget="text"
+                                nolabel="1"
+                                colspan="4"
+                            />
+                        </page>
+                        <page string="Preview code">
+                            <field
+                                name="yaml_code"
+                                widget="ace"
+                                options="{'mode': 'yaml'}"
+                                force_save="1"
+                                nolabel="1"
+                                colspan="4"
+                            />
+                        </page>
+                    </notebook>
+
+                </group>
+
                 <div
                     class="alert alert-warning"
                     role="alert"
@@ -50,16 +116,6 @@
                         attrs="{'invisible': [('secret_list', '=', False)]}"
                     />
                 </div>
-                <group>
-                    <field name="preview_code" />
-                </group>
-                <field
-                    name="yaml_code"
-                    widget="ace"
-                    options="{'mode': 'yaml'}"
-                    force_save="1"
-                    attrs="{'invisible': [('preview_code', '=', False)]}"
-                />
                 <footer>
                     <button
                         string="Import"


### PR DESCRIPTION
Allows users to reuse common metadata (license, author, etc.)
in YAML exports by selecting predefined manifest templates
and see this metadata in import wizard.

- New models: yaml.manifest.author, yaml.manifest.tmpl
- Export wizard:
  - Two-page notebook (“Settings” + “Manifest”)
  - M2O template selector to prefill manifest fields
  - Editable `yaml_file_name`
- Import wizard: grouped layout; hides manifest if absent
- Tests covering templates, filename defaults, sanitization, and manifest behavior

Task: 4787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced management for YAML Manifest Templates and Authors with dedicated UI menus.
  * Enhanced YAML export wizard with manifest template selection, author assignment, license and pricing fields, versioning, and customizable file naming.
  * YAML import wizard now displays manifest metadata when available.

* **Improvements**
  * Redesigned export and import wizard interfaces for clearer manifest handling and preview.
  * Filename sanitization and validation for YAML exports.
  * Added semantic versioning enforcement for manifest versions.

* **Bug Fixes**
  * Removed comment field and related logic from YAML export process.

* **Tests**
  * Added tests for filename generation and sanitization in YAML export wizard.
  * Removed obsolete test for YAML comment insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->