### PR TITLE
[16.0][IMP] cetmix_tower_server: Custom values for flight plan

### DIFF
--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -14,6 +14,7 @@ from . import cx_tower_server
 from . import cx_tower_os
 from . import cx_tower_tag
 from . import cx_tower_command
+from . import cx_tower_custom_variable_value_mixin
 from . import cx_tower_key
 from . import cx_tower_key_value
 from . import cx_tower_command_log

--- a/cetmix_tower_server/models/cetmix_tower.py
+++ b/cetmix_tower_server/models/cetmix_tower.py
@@ -79,12 +79,19 @@ class CetmixTower(models.AbstractModel):
                 "message": response or error,
             }
 
-    def server_run_flight_plan(self, server_reference, flight_plan_reference):
+    def server_run_flight_plan(
+        self, server_reference, flight_plan_reference, **variable_values
+    ):
         """Run flight plan on selected server.
 
         Args:
             server_reference (Char): Server reference
             flight_plan_reference (Char): Flight plan reference
+
+        **variable_values:
+            Dict: with variable values.
+            The keys are the variable references and the values are the variable values.
+            eg `{'odoo_version': '16.0'}`
 
         Returns:
             cx.tower.plan.log(): flight plan log record or False if error
@@ -99,7 +106,10 @@ class CetmixTower(models.AbstractModel):
             # This is not the best way to handle this, but it's the only way to
             # avoid complex response handling
             return False
-        return server.run_flight_plan(flight_plan)
+        return server.run_flight_plan(
+            flight_plan,
+            **{"variable_values": variable_values} if variable_values else {},
+        )
 
     @api.model
     def server_set_variable_value(self, server_reference, variable_reference, value):

--- a/cetmix_tower_server/models/constants.py
+++ b/cetmix_tower_server/models/constants.py
@@ -98,6 +98,7 @@ Here is an example of a python code command:
 <code style='white-space: pre-wrap'>
     server_name = server.name
     result = {"exit_code": 0, "message": "Server name is " + server_name}
+    custom_values["server_name"] = server_name
 </code>
 </p>
 <br>

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -224,6 +224,11 @@ class CxTowerCommand(models.Model):
         help_text_fragments = []
         for key, value in available_libraries.items():
             help_text_fragments.append(f"<li><code>{key}</code>: {value['help']}</li>")
+
+        help_text_fragments.append(
+            f"<li><code>custom_values</code>: {_('Flight plan custom values')}</li>"
+        )
+
         help_text = "<ul>" + "".join(help_text_fragments) + "</ul>"
         return f"{DEFAULT_PYTHON_CODE_HELP}{help_text}"
 
@@ -490,7 +495,7 @@ class CxTowerCommand(models.Model):
         """
         return {}
 
-    def _get_python_command_eval_context(self, server=None):
+    def _get_python_command_eval_context(self, server=None, **kwargs):
         """
         Get the evaluation context for the python command.
         This method is used to get the evaluation context for the python command.
@@ -508,4 +513,6 @@ class CxTowerCommand(models.Model):
         # Update with the libraries
         imports.update(self._get_python_command_libraries())
         eval_context = {key: value["import"] for key, value in imports.items()}
+
+        eval_context["custom_values"] = kwargs.get("variable_values", {})
         return eval_context

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -99,6 +99,10 @@ class CxTowerCommandLog(models.Model):
         ondelete="set null",
         help="Scheduled task that triggered this command",
     )
+    variable_values = fields.Json(
+        default={},
+        help="Custom variable values passed to the command",
+    )
 
     @api.depends("name", "command_id.name")
     def _compute_name(self):

--- a/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
@@ -1,0 +1,53 @@
+from odoo import api, fields, models
+
+
+class CxTowerCustomVariableValueMixin(models.AbstractModel):
+    """
+    Custom variable values.
+    """
+
+    _name = "cx.tower.custom.variable.value.mixin"
+    _description = "Custom variable values"
+
+    variable_id = fields.Many2one(
+        "cx.tower.variable",
+        readonly=True,
+    )
+    variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
+    value_char = fields.Char(
+        string="Value",
+        compute="_compute_value_char",
+        readonly=False,
+        store=True,
+        help="Automatically populated from selected option. "
+        "Manual edits will be overwritten when option changes.",
+    )
+    option_id = fields.Many2one(
+        "cx.tower.variable.option", domain="[('variable_id', '=', variable_id)]"
+    )
+
+    variable_value_id = fields.Many2one("cx.tower.variable.value")
+    required = fields.Boolean(
+        related="variable_value_id.required",
+        readonly=True,
+        store=True,
+    )
+
+    @api.depends("option_id", "variable_id", "variable_type")
+    def _compute_value_char(self):
+        """
+        Compute value_char based on selected option for option-type variables.
+        For non-option variables, value_char is cleared to allow manual input.
+        """
+        for rec in self:
+            if rec.variable_id and rec.variable_type == "o" and rec.option_id:
+                rec.value_char = rec.option_id.value_char
+            else:
+                rec.value_char = ""
+
+    @api.onchange("variable_id")
+    def _onchange_variable_id(self):
+        """
+        Reset option_id when variable changes.
+        """
+        self.update({"option_id": None})

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -208,6 +208,10 @@ class CxTowerPlan(models.Model):
                     - "plan_log": {values passed to flightplan logger}
                     - "log": {values passed to logger}
                     - "key": {values passed to key parser}
+                    - "variable_values", dict(): custom variable values
+                        in the format of `{variable_reference: variable_value}`
+                        eg `{'odoo_version': '16.0'}`
+                        Will be applied only if user has write access to the server.
 
         Returns:
             log_record (cx.tower.plan.log()): plan log record
@@ -379,7 +383,9 @@ class CxTowerPlan(models.Model):
         if action == "n" and plan_line_id:
             server = command_log.server_id
             if plan_line_id._is_executable_line(server):
-                plan_line_id._run(server, plan_log)
+                plan_line_id._run(
+                    server, plan_log, variable_values=plan_log.variable_values
+                )
             else:
                 plan_line_id._skip(server, plan_log)
 

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -81,6 +81,10 @@ class CxTowerPlanLog(models.Model):
         ondelete="set null",
         help="Scheduled task that triggered this flight plan",
     )
+    variable_values = fields.Json(
+        default={},
+        help="Custom variable values passed to the flight plan",
+    )
 
     @api.depends("server_id.name", "name")
     def _compute_name(self):
@@ -138,6 +142,10 @@ class CxTowerPlanLog(models.Model):
                 - "key": {values passed to key parser}
                 - "no_command_log" (bool): If True, no logs will be recorded for
                                    non-executable lines.
+                - "variable_values", dict(): custom variable values
+                    in the format of `{variable_reference: variable_value}`
+                    eg `{'odoo_version': '16.0'}`
+                    Will be applied only if user has write access to the server.
         Returns:
             cx.tower.plan.log(): New flightplan log record.
         """
@@ -160,6 +168,11 @@ class CxTowerPlanLog(models.Model):
         plan_log_kwargs = kwargs.get("plan_log")
         if plan_log_kwargs:
             vals.update(plan_log_kwargs)
+
+        # Extract and apply variable values
+        variable_values = kwargs.get("variable_values")
+        if variable_values:
+            vals["variable_values"] = variable_values
 
         plan_log = self.sudo().create(vals)
 
@@ -269,5 +282,9 @@ class CxTowerPlanLog(models.Model):
 
         """
         self.ensure_one()
+
+        # Update plan log variable values from command log
+        self.variable_values = command_log.variable_values
+
         # Get next line to execute
         self.plan_id._run_next_action(command_log)  # type: ignore

--- a/cetmix_tower_server/models/cx_tower_scheduled_task_cv.py
+++ b/cetmix_tower_server/models/cx_tower_scheduled_task_cv.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class CxTowerScheduledTaskCv(models.Model):
@@ -6,6 +6,7 @@ class CxTowerScheduledTaskCv(models.Model):
     Custom variable values for scheduled tasks.
     """
 
+    _inherit = "cx.tower.custom.variable.value.mixin"
     _name = "cx.tower.scheduled.task.cv"
     _description = "Custom variable values for scheduled tasks"
 
@@ -15,38 +16,3 @@ class CxTowerScheduledTaskCv(models.Model):
         required=True,
         ondelete="cascade",
     )
-    variable_id = fields.Many2one(
-        "cx.tower.variable",
-        string="Variable",
-        required=True,
-    )
-    variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
-    value_char = fields.Char(
-        string="Value",
-        compute="_compute_value_char",
-        readonly=False,
-        store=True,
-    )
-    option_id = fields.Many2one(
-        "cx.tower.variable.option",
-        string="Option",
-        domain="[('variable_id', '=', variable_id)]",
-    )
-
-    @api.depends("option_id", "variable_id", "variable_type")
-    def _compute_value_char(self):
-        """
-        Compute value_char based on variable type and option selection.
-        For option-type variables: sync value_char with selected option.
-        For other types: leave value_char untouched (user input).
-        """
-        for rec in self:
-            if rec.variable_type == "o":
-                rec.value_char = rec.option_id.value_char if rec.option_id else ""
-
-    @api.onchange("variable_id")
-    def _onchange_variable_id(self):
-        """
-        Reset option_id when variable changes.
-        """
-        self.update({"option_id": None})

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -857,7 +857,9 @@ class CxTowerServer(models.Model):
         # Prepare log object
         log_obj = self.env["cx.tower.command.log"]
         log_vals = kwargs.get("log", {})
-        log_vals.update({"use_sudo": sudo})
+        log_vals.update(
+            {"use_sudo": sudo, "variable_values": kwargs.get("variable_values", {})}
+        )
 
         # Check if no log record should be created
         no_command_log = self._context.get("no_command_log")
@@ -1050,6 +1052,10 @@ class CxTowerServer(models.Model):
                     - "plan_log": {values passed to flightplan logger}
                     - "log": {values passed to logger}
                     - "key": {values passed to key parser}
+                    - "variable_values", dict(): custom variable values
+                        in the format of `{variable_reference: variable_value}`
+                        eg `{'odoo_version': '16.0'}`
+                        Will be applied only if user has write access to the server.
         """
 
         self.ensure_one()
@@ -1381,6 +1387,7 @@ class CxTowerServer(models.Model):
                 status=result["status"],
                 response=result["response"],
                 error=result["error"],
+                variable_values=plan_log_record.variable_values,
             )
         else:
             return result
@@ -1421,6 +1428,7 @@ class CxTowerServer(models.Model):
                 status=result["status"],
                 response=result["response"],
                 error=result["error"],
+                variable_values=result["variable_values"],
             )
         else:
             return result
@@ -1562,7 +1570,9 @@ class CxTowerServer(models.Model):
             # Get the evaluation context for the python command
             eval_context = self.env[
                 "cx.tower.command"
-            ]._get_python_command_eval_context(server=self)
+            ]._get_python_command_eval_context(
+                server=self, variable_values=kwargs.get("variable_values", {})
+            )
 
             safe_eval(
                 code,
@@ -1570,6 +1580,7 @@ class CxTowerServer(models.Model):
                 mode="exec",
                 nocopy=True,
             )
+            kwargs["variable_values"] = eval_context.get("custom_values", {})
             result = eval_context.get("result")
             if result:
                 status = result.get("exit_code", 0)
@@ -1586,7 +1597,10 @@ class CxTowerServer(models.Model):
             else:
                 status = PYTHON_COMMAND_ERROR
                 error = [e]
-        return self._parse_command_results(status, response, error, secrets, **kwargs)
+
+        result = self._parse_command_results(status, response, error, secrets, **kwargs)
+        result["variable_values"] = kwargs.get("variable_values", {})
+        return result
 
     def _prepare_ssh_command(self, command_code, path=None, sudo=None, **kwargs):
         """Prepare ssh command

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -19,6 +19,7 @@ access_command_root,Command->Root,model_cx_tower_command,group_root,1,1,1,1
 access_run_command_user,Run Command->User,model_cx_tower_command_run_wizard,group_user,1,1,1,1
 access_run_command_variable_value_user,Run Command Variable Value->User,model_cx_tower_command_run_wizard_variable_value,group_user,1,1,1,1
 access_execute_plan_user,Run Plan->User,model_cx_tower_plan_run_wizard,group_user,1,1,1,1
+access_execute_plan_variable_value_user,Run Plan Variable Value->User,model_cx_tower_plan_run_wizard_variable_value,group_user,1,1,1,1
 access_key_user,Key->User,model_cx_tower_key,group_user,0,0,0,0
 access_key_manager,Key->Manager,model_cx_tower_key,group_manager,1,1,1,1
 access_key_root,Key->Root,model_cx_tower_key,group_root,1,1,1,1

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -22,7 +22,7 @@ class TestTowerPlan(TestTowerCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        # Command
+        # Commands
         cls.command_run_flight_plan_1 = cls.Command.create(
             {
                 "name": "Run Flight Plan",
@@ -30,7 +30,28 @@ class TestTowerPlan(TestTowerCommon):
                 "flight_plan_id": cls.plan_1.id,
             }
         )
-
+        cls.command_python_custom_variable_values_1 = cls.Command.create(
+            {
+                "name": "Python command to set custom variable values",
+                "action": "python_code",
+                "code": """
+custom_values['test_path_'] = '/test_path'
+custom_values['test_dir'] = 'test_dir'
+custom_values['_my_value'] = 'Just To Test'
+""",
+            }
+        )
+        cls.command_python_custom_variable_values_2 = cls.Command.create(
+            {
+                "name": "Python command to update custom variable values",
+                "action": "python_code",
+                "code": f"""
+custom_values['test_path_'] = '/another_test_path'
+custom_values['random_var_reference'] = 'random_var_value'
+custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
+""",
+            }
+        )
         # Flight plan
         cls.plan_2 = cls.Plan.create(
             {
@@ -1612,3 +1633,368 @@ class TestTowerPlan(TestTowerCommon):
         # Launch the same plan on the same server
         plan_log = self.server_test_1.run_flight_plan(self.plan_1)
         self.assertEqual(plan_log.plan_status, 0)
+
+    def test_plan_custom_variables(self):
+        """Test plan with custom variables"""
+        command_python_1_id = self.command_python_custom_variable_values_1.id
+        command_python_2_id = self.command_python_custom_variable_values_2.id
+
+        plan = self._create_plan(
+            **{
+                "name": "Plan with custom variables",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_1_id,
+                            "sequence": 1,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 2}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_2_id,
+                            "sequence": 3,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 4}),
+                ],
+            }
+        )
+
+        # Run plan
+        plan_log = self.server_test_1.run_flight_plan(plan)
+
+        # Check that custom variable values were updated correctly
+        # (The log of plan should contain the last updatedvalues)
+        self.assertEqual(plan_log.variable_values["test_path_"], "/another_test_path")
+        self.assertEqual(plan_log.variable_values["test_dir"], "test_dir")
+        self.assertEqual(
+            plan_log.variable_values["random_var_reference"], "random_var_value"
+        )
+        self.assertEqual(plan_log.variable_values["_my_value"], "Just To Test")
+
+        command_logs = plan_log.command_log_ids
+        self.assertEqual(
+            len(command_logs),
+            len(plan.line_ids),
+            f"Should be {len(plan.line_ids)} command logs.",
+        )
+
+        # Check that custom variable values were created correctly
+        # in first python command log
+        command_python_command_1_log = command_logs.filtered(
+            lambda log: log.command_id.id == command_python_1_id
+        )
+        self.assertEqual(
+            command_python_command_1_log.variable_values["test_path_"], "/test_path"
+        )
+        self.assertEqual(
+            command_python_command_1_log.variable_values["test_dir"], "test_dir"
+        )
+        self.assertEqual(
+            command_python_command_1_log.variable_values["_my_value"], "Just To Test"
+        )
+
+        # Check that custom variable values used in rendered command code
+        command_create_dir_logs = command_logs.filtered(
+            lambda log: log.command_id == self.command_create_dir
+        )
+        first_command_create_dir_log = command_create_dir_logs[0]
+        second_command_create_dir_log = command_create_dir_logs[1]
+
+        # the first_command_create_dir_log.code is equal to
+        # 'cd /test_path && mkdir test_dir'
+        # because rendered code contains custom variable values updated
+        # from first python command
+        self.assertEqual(
+            first_command_create_dir_log.code, "cd /test_path && mkdir test_dir"
+        )
+
+        # Check that custom variable values were updated correctly in command logs
+        command_python_command_2_log = command_logs.filtered(
+            lambda log: log.command_id.id == command_python_2_id
+        )
+        self.assertEqual(
+            command_python_command_2_log.variable_values["test_path_"],
+            "/another_test_path",
+        )
+        self.assertEqual(
+            command_python_command_2_log.variable_values["test_dir"], "test_dir"
+        )
+        self.assertEqual(
+            command_python_command_2_log.variable_values["random_var_reference"],
+            "random_var_value",
+        )
+        self.assertEqual(
+            command_python_command_2_log.variable_values["_my_value"], "Just To Test"
+        )
+        self.assertEqual(
+            command_python_command_2_log.variable_values[self.variable_url.reference],
+            "https://www.cetmix.com",
+        )
+
+        # the second_command_create_dir_log.code is equal to
+        # 'cd /another_test_path && mkdir test_dir'
+        # because rendered code contains custom variable values updated
+        # from second python command
+        self.assertEqual(
+            second_command_create_dir_log.code,
+            "cd /another_test_path && mkdir test_dir",
+        )
+
+    def test_plan_custom_variables_wizard(self):
+        """Test plan with custom variables from wizard"""
+        command_python_1_id = self.command_python_custom_variable_values_1.id
+        command_python_2_id = self.command_python_custom_variable_values_2.id
+        plan = self._create_plan(
+            **{
+                "name": "Plan with custom variables",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_1_id,
+                            "sequence": 1,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 2}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_2_id,
+                            "sequence": 3,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 4}),
+                ],
+            }
+        )
+
+        # Create wizard with custom variable values
+        wizard = self.env["cx.tower.plan.run.wizard"].create(
+            {
+                "plan_id": plan.id,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+                "custom_variable_value_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "variable_id": self.variable_version.id,
+                            "value_char": "16.0",
+                        },
+                    ),
+                ],
+            }
+        )
+
+        # Run wizard
+        action = wizard.run_flight_plan()
+        plan_log = self.PlanLog.search(
+            [("label", "=", action["context"]["search_default_label"])],
+            limit=1,
+        )
+        self.assertTrue(plan_log, "Plan log should be created")
+
+        # Check that custom variable values were updated correctly
+        # (The log of plan should contain the last updated
+        # values + custom variable value from wizard)
+        self.assertEqual(plan_log.variable_values["test_path_"], "/another_test_path")
+        self.assertEqual(plan_log.variable_values["test_dir"], "test_dir")
+        self.assertEqual(
+            plan_log.variable_values["random_var_reference"], "random_var_value"
+        )
+        self.assertEqual(plan_log.variable_values["_my_value"], "Just To Test")
+        self.assertEqual(
+            plan_log.variable_values[self.variable_version.reference], "16.0"
+        )
+
+    def test_plan_with_another_plan_custom_variables(self):
+        """Test plan with another plan with custom variables"""
+        # Create plan with next structure:
+        # Plan 1:
+        # - Command 1: Run plan 2
+        # - Command 2: Run Python command to set custom variable values
+        # - Command 3: Create directory
+        # Plan 2:
+        # - Command 1: Python command to set custom variable values
+        # - Command 2: Create directory
+        # - Command 3: Python command to update custom variable values
+
+        command_python_1_id = self.command_python_custom_variable_values_1.id
+        command_python_2_id = self.command_python_custom_variable_values_2.id
+        plan2 = self._create_plan(
+            **{
+                "name": "Plan 2",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_1_id,
+                            "sequence": 1,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 2}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_2_id,
+                            "sequence": 3,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        command_run_plan_2 = self.Command.create(
+            {
+                "name": "Run Flight Plan",
+                "action": "plan",
+                "flight_plan_id": plan2.id,
+            }
+        )
+        command_python_custom_variable_values_3 = self.Command.create(
+            {
+                "name": "Python command to update custom variable values",
+                "action": "python_code",
+                "code": """
+custom_values['random_var_reference'] = 'another_random_var_value'
+""",
+            }
+        )
+
+        plan1 = self._create_plan(
+            **{
+                "name": "Plan 1",
+                "line_ids": [
+                    (0, 0, {"command_id": command_run_plan_2.id, "sequence": 1}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": command_python_custom_variable_values_3.id,
+                            "sequence": 2,
+                        },
+                    ),
+                    (0, 0, {"command_id": self.command_create_dir.id, "sequence": 3}),
+                ],
+            }
+        )
+
+        # Create wizard with custom variable values
+        wizard = self.env["cx.tower.plan.run.wizard"].create(
+            {
+                "plan_id": plan1.id,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+                "custom_variable_value_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "variable_id": self.variable_version.id,
+                            "value_char": "16.0",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "variable_id": self.variable_url.id,
+                            "value_char": "https://www.test.com",
+                        },
+                    ),
+                ],
+            }
+        )
+
+        # Run wizard
+        action = wizard.run_flight_plan()
+        plan_log = self.PlanLog.search(
+            [("label", "=", action["context"]["search_default_label"])],
+            limit=1,
+        )
+        self.assertTrue(plan_log, "Plan log should be created")
+
+        command_logs = plan_log.command_log_ids
+        self.assertEqual(
+            len(command_logs),
+            len(plan1.line_ids),
+            f"Should be {len(plan1.line_ids)} command logs.",
+        )
+
+        # First command log is run plan 2 log that contains custom variable values
+        # updated from plan 2. This command log should contain the same custom
+        # variable values as from plan 2 log
+        run_plan2_command_log = command_logs[0]
+        run_plan2_command_log_variable_values = run_plan2_command_log.variable_values
+
+        plan2_log = run_plan2_command_log.triggered_plan_log_id
+        plan2_log_variable_values = plan2_log.variable_values
+
+        # check that variable values are the same
+        self.assertEqual(
+            run_plan2_command_log_variable_values, plan2_log_variable_values
+        )
+
+        # Before finished command (run child plan): we have next variable values:
+        # {'test_version': '16.0', 'test_url': 'https://www.test.com'}
+
+        # After finished command (run child plan): we have next variable values:
+        # {
+        #     'test_version': '16.0',
+        #     'test_url': 'https://www.cetmix.com',
+        #     'test_path_': '/another_test_path',
+        #     'test_dir': 'test_dir',
+        #     '_my_value': 'Just To Test',
+        #     'random_var_reference': 'random_var_value'
+        # }
+        self.assertEqual(
+            run_plan2_command_log_variable_values["test_path_"], "/another_test_path"
+        )
+        self.assertEqual(run_plan2_command_log_variable_values["test_dir"], "test_dir")
+        self.assertEqual(
+            run_plan2_command_log_variable_values["_my_value"], "Just To Test"
+        )
+        self.assertEqual(
+            run_plan2_command_log_variable_values["random_var_reference"],
+            "random_var_value",
+        )
+        self.assertEqual(
+            run_plan2_command_log_variable_values[self.variable_version.reference],
+            "16.0",
+        )
+        self.assertEqual(
+            run_plan2_command_log_variable_values[self.variable_url.reference],
+            "https://www.cetmix.com",
+        )
+
+        # After finished main plan: we have next variable values:
+        # {
+        #     'test_version': '16.0',
+        #     'test_url': 'https://www.cetmix.com',
+        #     'test_path_': '/another_test_path',
+        #     'test_dir': 'test_dir',
+        #     '_my_value': 'Just To Test',
+        #     'random_var_reference': 'another_random_var_value'
+        # }
+        self.assertEqual(plan_log.variable_values["test_path_"], "/another_test_path")
+        self.assertEqual(plan_log.variable_values["test_dir"], "test_dir")
+        self.assertEqual(plan_log.variable_values["_my_value"], "Just To Test")
+        self.assertEqual(
+            plan_log.variable_values["random_var_reference"], "another_random_var_value"
+        )
+        self.assertEqual(
+            plan_log.variable_values[self.variable_version.reference], "16.0"
+        )
+        self.assertEqual(
+            plan_log.variable_values[self.variable_url.reference],
+            "https://www.cetmix.com",
+        )

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -472,6 +472,7 @@ class CxTowerCommandRunWizardVariableValue(models.TransientModel):
     Custom variable values for command run wizard
     """
 
+    _inherit = "cx.tower.custom.variable.value.mixin"
     _name = "cx.tower.command.run.wizard.variable.value"
     _description = "Custom variable values for command run wizard"
 
@@ -479,39 +480,3 @@ class CxTowerCommandRunWizardVariableValue(models.TransientModel):
         "cx.tower.command.run.wizard",
         string="Wizard",
     )
-    variable_id = fields.Many2one(
-        "cx.tower.variable",
-        readonly=True,
-    )
-    variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
-    value_char = fields.Char(
-        string="Value",
-        compute="_compute_value_char",
-        readonly=False,
-        store=True,
-    )
-    option_id = fields.Many2one(
-        "cx.tower.variable.option", domain="[('variable_id', '=', variable_id)]"
-    )
-
-    variable_value_id = fields.Many2one("cx.tower.variable.value")
-    required = fields.Boolean(
-        related="variable_value_id.required",
-        readonly=True,
-        store=True,
-    )
-
-    @api.depends("option_id", "variable_id", "variable_type")
-    def _compute_value_char(self):
-        for rec in self:
-            if rec.variable_id and rec.variable_type == "o" and rec.option_id:
-                rec.value_char = rec.option_id.value_char
-            else:
-                rec.value_char = ""
-
-    @api.onchange("variable_id")
-    def _onchange_variable_id(self):
-        """
-        Reset option_id when variable changes.
-        """
-        self.update({"option_id": None})

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
@@ -57,6 +57,10 @@ class CxTowerPlanRunWizard(models.TransientModel):
         compute="_compute_show_servers",
         compute_sudo=True,
     )
+    custom_variable_value_ids = fields.One2many(
+        "cx.tower.plan.run.wizard.variable.value",
+        "wizard_id",
+    )
 
     @api.model
     def default_get(self, fields_list):
@@ -104,7 +108,14 @@ class CxTowerPlanRunWizard(models.TransientModel):
             # Generate custom label. Will be used later to locate the command log
             plan_label = generate_random_id(4)
             # Add custom values for log
-            custom_values = {"plan_log": {"label": plan_label}}
+            variable_values = {
+                value.variable_id.reference: value.value_char
+                for value in self.custom_variable_value_ids
+            }
+            custom_values = {
+                "plan_log": {"label": plan_label},
+                "variable_values": variable_values,
+            }
             for server in self.server_ids:
                 server.run_flight_plan(self.plan_id, **custom_values)
             return {
@@ -121,3 +132,23 @@ class CxTowerPlanRunWizard(models.TransientModel):
         return self.env.user.has_group(
             "cetmix_tower_server.group_manager"
         ) or self.env.user.has_group("cetmix_tower_server.group_root")
+
+
+class CxTowerPlanRunWizardVariableValue(models.TransientModel):
+    """
+    Custom variable values for flight plan run wizard
+    """
+
+    _inherit = "cx.tower.custom.variable.value.mixin"
+    _name = "cx.tower.plan.run.wizard.variable.value"
+    _description = "Custom variable values for plan run wizard"
+
+    wizard_id = fields.Many2one(
+        "cx.tower.plan.run.wizard",
+        string="Wizard",
+    )
+    # Override from mixin to make variable_id editable
+    variable_id = fields.Many2one(
+        "cx.tower.variable",
+        readonly=False,
+    )

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard_view.xml
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard_view.xml
@@ -45,23 +45,52 @@
                         readonly="1"
                         attrs="{'invisible': [('note', '=', False)]}"
                     />
-                    <field
-                        name="plan_line_ids"
+                </group>
+                <notebook>
+                    <page
+                        name="commands"
+                        string="Commands"
                         attrs="{'invisible': [('plan_id', '=', False)]}"
                     >
-                        <tree decoration-bf="action=='plan'">
-                            <field name="name" />
-                            <field name="action" optional="show" />
-                            <field
-                                name="tag_ids"
-                                optional="show"
-                                groups="cetmix_tower_server.group_manager"
-                                widget="many2many_tags"
-                                options="{'color_field': 'color'}"
-                            />
-                        </tree>
-                    </field>
-                </group>
+                        <field
+                            name="plan_line_ids"
+                            attrs="{'invisible': [('plan_id', '=', False)]}"
+                        >
+                            <tree decoration-bf="action=='plan'">
+                                <field name="name" />
+                                <field name="action" optional="show" />
+                                <field
+                                    name="tag_ids"
+                                    optional="show"
+                                    groups="cetmix_tower_server.group_manager"
+                                    widget="many2many_tags"
+                                    options="{'color_field': 'color'}"
+                                />
+                            </tree>
+                        </field>
+                    </page>
+                    <page
+                        name="configuration_values"
+                        string="Configuration Values"
+                        attrs="{'invisible': [('plan_id', '=', False)]}"
+                    >
+                        <field name="custom_variable_value_ids">
+                            <tree editable="bottom">
+                                <field name="variable_id" />
+                                <field name="variable_type" invisible="1" />
+                                <field
+                                    name="value_char"
+                                    attrs="{'readonly': [('variable_type', '!=', 's')]}"
+                                />
+                                <field
+                                    name="option_id"
+                                    attrs="{'readonly': [('variable_type', '!=', 'o')]}"
+                                    options="{'no_create': True}"
+                                />
+                            </tree>
+                        </field>
+                    </page>
+                </notebook>
                 <footer>
                     <button
                         name="run_flight_plan"


### PR DESCRIPTION
**Why do we need this feature?**

To be able to pass custom variable values to flight plans.

**API/Backend**

- Added a new variable_values parameter to the `run_flight_plan` function of the `cx.tower.server` model. This value is used to override default variable values from the renderer.
- Added posibility to change variable values within Python commands and retain the changed values throughout the execution of the plan.
- Added a new “Custom Values” tab to the flight plan run wizard, where the user can select which variable values to pass to the flight plan as custom values.

Task: 4752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom variable values in command and flight plan execution, allowing users to inject and track configuration values dynamically.
  * Enhanced flight plan and command logs to store and display custom variable values.
  * Updated wizards and forms to allow entry and management of custom variable values through the user interface.

* **Documentation**
  * Improved help texts and docstrings to clarify usage of custom variable values in commands and flight plans.

* **Tests**
  * Introduced comprehensive tests to verify the correct handling and propagation of custom variable values across commands, plans, and wizards.

* **Refactor**
  * Unified custom variable value handling by introducing a reusable mixin, reducing code duplication across models and wizards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->