### PR TITLE
[16.0][FIX] cetmix_tower-restore_flight_plan_order

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -10,7 +10,7 @@ class CxTowerCommandLog(models.Model):
 
     _name = "cx.tower.command.log"
     _description = "Cetmix Tower Command Log"
-    _order = "id asc"
+    _order = "start_date desc, id desc"
 
     active = fields.Boolean(default=True)
     name = fields.Char(compute="_compute_name", store=True)

--- a/cetmix_tower_server/readme/newsfragments/4816.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4816.bugfix
@@ -1,0 +1,1 @@
+Command log sorting

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -109,7 +109,9 @@
                             string="Triggered Commands"
                             attrs="{'invisible': [('command_action','!=','plan')]}"
                         >
-                            <field name="triggered_plan_command_log_ids" />
+                                <field name="triggered_plan_command_log_ids">
+                                    <tree default_order="id asc" />
+                                </field>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Revert to previous global order and renforce id asc sorting only in Triggered Commands view.

Task: 4816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of command log records to prioritize the most recent entries.
  * Enhanced display order of related triggered command logs to show them sorted by ascending ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->