### PR TITLE
[17.0][MIG] cetmix_tower_server: Forward port updates from 16.0

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -1,7 +1,11 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
 from odoo import _, api, fields, models
 from odoo.tools.safe_eval import wrap_module
+
+_logger = logging.getLogger(__name__)
 
 re = wrap_module(
     __import__("re"),
@@ -268,6 +272,79 @@ class TowerVariable(models.Model):
         return {
             "re": re,
             "value": value_char,
+        }
+
+    #  Reference rename propagation
+
+    def write(self, vals):
+        """Override the write method to propagate variable reference updates.
+
+        Records the old reference values, performs the write, and if the reference
+        field has changed, initiates propagation to update related records.
+        """
+        old_refs = (
+            {rec.id: rec.reference for rec in self} if "reference" in vals else {}
+        )
+        res = super().write(vals)
+        if "reference" in vals:
+            for rec in self:
+                old_ref = old_refs.get(rec.id)
+                if old_ref and old_ref != rec.reference:
+                    rec._propagate_reference_change(old_ref, rec.reference)
+        return res
+
+    def _propagate_reference_change(self, old_ref, new_ref):
+        """Replace all occurrences of an old variable reference with a new one.
+
+        Compiles a pattern matching the old Jinja-style reference, then searches across
+        configured models and fields to substitute any matches, preserving formatting.
+        """
+        pattern = re.compile(r"(\{\{\s*)" + re.escape(old_ref) + r"(\s*\}\})")
+
+        def _replace(text):
+            """Helper to replace old_ref with new_ref in the given text."""
+            return pattern.sub(lambda m: f"{m.group(1)}{new_ref}{m.group(2)}", text)
+
+        model_fields_map = self._get_propagation_field_mapping()
+
+        for model_name, field_names in model_fields_map.items():
+            Model = self.env[model_name]
+
+            if model_name == "cx.tower.variable.value":
+                domain = [("variable_id", "=", self.id)]
+            else:
+                domain = [("variable_ids", "in", self.ids)]
+
+            for record in Model.search(domain):
+                vals = {}
+                for field_name in field_names:
+                    value = record[field_name]
+                    if isinstance(value, str) and old_ref in value:
+                        new_value = _replace(value)
+                        if new_value != value:
+                            vals[field_name] = new_value
+
+                if vals:
+                    record.with_context(skip_reference_propagation=True).write(vals)
+                    _logger.debug(
+                        "Variable reference updated in %s(%s): %s",
+                        model_name,
+                        record.id,
+                        ", ".join(vals.keys()),
+                    )
+
+    def _get_propagation_field_mapping(self):
+        """Return the mapping of models to fields for reference change propagation.
+
+        The returned dict maps each model name to a list of field names
+        that may contain variable references requiring updates.
+        """
+        return {
+            "cx.tower.command": ["code", "path"],
+            "cx.tower.file": ["code", "server_dir", "name"],
+            "cx.tower.file.template": ["code", "server_dir", "file_name"],
+            "cx.tower.variable.value": ["value_char"],
+            "cx.tower.plan.line": ["condition"],
         }
 
     def _validate_value(self, value_char=None):

--- a/cetmix_tower_server/tests/test_variable.py
+++ b/cetmix_tower_server/tests/test_variable.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from unittest.mock import patch
 
 from psycopg2 import IntegrityError
@@ -937,3 +940,151 @@ class TestTowerVariable(TestTowerCommon):
             f"{variable_default_message.DEFAULT_VALIDATION_MESSAGE}",
             "Default validation message doesn't match",
         )
+
+
+class TestVariableReferenceRename(TestTowerCommon):
+    """Ensure variable rename updates all Jinja references using shared fixtures."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.ref_old = cls.variable_version.reference
+        cls.ref_new = "software_version"
+
+        cls.command = cls.Command.create(
+            {
+                "name": "Show version (test)",
+                "code": f"echo {{ {{ {cls.ref_old} }} }}",
+                "variable_ids": [(6, 0, [cls.variable_version.id])],
+            }
+        )
+
+        cls.file = cls.File.create(
+            {
+                "name": "test_version.txt",
+                "server_dir": "/tmp",
+                "code": f"{{ {{ {cls.ref_old} }} }}",
+                "variable_ids": [(6, 0, [cls.variable_version.id])],
+            }
+        )
+
+    def _rename(self):
+        """Rename variable and invalidate caches for records under test."""
+        self.variable_version.write({"reference": self.ref_new})
+        self.command.invalidate_recordset()
+        self.file.invalidate_recordset()
+
+    def test_false_references_are_ignored(self):
+        """Ignore malformed or non-Jinja references."""
+        cmd_plain = self.Command.create(
+            {
+                "name": "Plain",
+                "code": "print(test_version)",
+                "variable_ids": [(6, 0, [self.variable_version.id])],
+            }
+        )
+        cmd_bad = self.Command.create(
+            {
+                "name": "BadBrackets",
+                "code": "{test_version}",
+                "variable_ids": [(6, 0, [self.variable_version.id])],
+            }
+        )
+
+        self._rename()
+        cmd_plain.invalidate_recordset()
+        cmd_bad.invalidate_recordset()
+
+        self.assertEqual(cmd_plain.code, "print(test_version)")
+        self.assertEqual(cmd_bad.code, "{test_version}")
+
+    def test_multiple_occurrences_replace_all(self):
+        """Replace all valid Jinja references in one field."""
+        code = "A: {{ test_version }}, B: {{  test_version   }}, C-end"
+        cmd_multi = self.Command.create(
+            {
+                "name": "Multi",
+                "code": code,
+                "variable_ids": [(6, 0, [self.variable_version.id])],
+            }
+        )
+
+        self._rename()
+        cmd_multi.invalidate_recordset()
+        actual_ref = self.variable_version.reference
+        expected = f"A: {{{{ {actual_ref} }}}}, " f"B: {{{{  {actual_ref}   }}}}, C-end"
+        self.assertEqual(cmd_multi.code, expected)
+
+    def test_template_files_updated(self):
+        """Propagate rename in template and generated file."""
+        tpl = self.env["cx.tower.file.template"].create(
+            {
+                "name": "TmpTpl",
+                "file_name": "tpl.txt",
+                "server_dir": "/tmp",
+                "code": "{{ test_version }}",
+                "variable_ids": [(6, 0, [self.variable_version.id])],
+            }
+        )
+        tpl_file = self.File.create(
+            {
+                "name": "from_tpl.txt",
+                "server_dir": "/tmp",
+                "template_id": tpl.id,
+                "code": "{{ test_version }}",
+            }
+        )
+
+        self._rename()
+        tpl.invalidate_recordset()
+        tpl_file.invalidate_recordset()
+
+        actual_ref = self.variable_version.reference
+        expected = f"{{{{ {actual_ref} }}}}"
+        self.assertEqual(tpl.code, expected)
+        self.assertEqual(tpl_file.code, expected)
+
+    def test_value_and_plan_line_update(self):
+        """Update value_char and plan line condition."""
+
+        def patched_mapping(_):
+            return {
+                "cx.tower.command": ["code", "path"],
+                "cx.tower.file": ["code", "server_dir", "name"],
+                "cx.tower.file.template": ["code", "server_dir", "file_name"],
+                "cx.tower.variable.value": ["value_char"],
+                "cx.tower.plan.line": ["condition"],
+            }
+
+        with patch.object(
+            type(self.variable_version),
+            "_get_propagation_field_mapping",
+            patched_mapping,
+        ):
+            val = self.env["cx.tower.variable.value"].create(
+                {
+                    "variable_id": self.variable_version.id,
+                    "value_char": "hello {{ test_version }} world",
+                }
+            )
+
+            pl = self.plan_line_1
+            pl.write(
+                {
+                    "variable_ids": [(6, 0, [self.variable_version.id])],
+                    "condition": "if {{ test_version }} then",
+                }
+            )
+
+            self.assertIn(self.variable_version.id, pl.variable_ids.ids)
+
+            self._rename()
+            val.invalidate_recordset()
+            pl.invalidate_recordset()
+
+            actual_ref = self.variable_version.reference
+            expected_val = f"hello {{{{ {actual_ref} }}}} world"
+            self.assertEqual(val.value_char, expected_val)
+            expected_cond = f"if {{{{ {actual_ref} }}}} then"
+            self.assertEqual(pl.condition, expected_cond)


### PR DESCRIPTION
Forward port the following PRs:

[   [16.0][FIX] cetmix_tower_server-variable_reference_change #321 ](https://github.com/cetmix/cetmix-tower/pull/321/commits/45c126602d3a101e02acf071d55ef45926346def)
    
Task: 4818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updates to variable references are now automatically propagated to all related fields and templates, ensuring consistency across the system.

* **Tests**
  * Added comprehensive tests to verify that renaming a variable reference correctly updates all relevant Jinja template references and related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->