### PR TITLE
[17.0][MIG] cetmix_tower_server: forward port updates from 16.0

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -97,6 +97,18 @@ class CxTowerCommand(models.Model):
         comodel_name="cx.tower.file.template",
         help="This template will be used to create or update the pushed file",
     )
+    template_code = fields.Text(
+        string="Template Code",
+        related="file_template_id.code",
+        readonly=True,
+        help="Code of the associated file template",
+    )
+    flight_plan_line_ids = fields.One2many(
+        comodel_name="cx.tower.plan.line",
+        related="flight_plan_id.line_ids",
+        readonly=True,
+        help="Lines of the associated flight plan",
+    )
     code = fields.Text(
         compute="_compute_code",
         store=True,

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -91,6 +91,14 @@ class CxTowerCommandLog(models.Model):
         help="Scheduled task that triggered this command",
     )
 
+    triggered_plan_command_log_ids = fields.One2many(
+        comodel_name="cx.tower.command.log",
+        inverse_name="plan_log_id",
+        related="triggered_plan_log_id.command_log_ids",
+        readonly=True,
+        string="Triggered Flight Plan Commands",
+    )
+
     @api.depends("name", "command_id.name")
     def _compute_name(self):
         for rec in self:

--- a/cetmix_tower_server/readme/newsfragments/4697.feature
+++ b/cetmix_tower_server/readme/newsfragments/4697.feature
@@ -1,0 +1,1 @@
+Improve command log and flight plan form views

--- a/cetmix_tower_server/readme/newsfragments/4753.feature
+++ b/cetmix_tower_server/readme/newsfragments/4753.feature
@@ -1,0 +1,1 @@
+Command view improvements

--- a/cetmix_tower_server/readme/newsfragments/4816.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4816.bugfix
@@ -1,0 +1,1 @@
+Command log sorting

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -43,18 +43,9 @@
                                 widget="ace"
                                 options="{'mode': 'python'}"
                             />
-                            <field
-                                name="path"
-                                attrs="{'invisible': [('path', '=', False)]}"
-                            />
-                            <field
-                                name="is_running"
-                                attrs="{'invisible': [('is_running', '=', False)]}"
-                            />
-                            <field
-                                name="use_sudo"
-                                attrs="{'invisible': [('use_sudo', '=', False)]}"
-                            />
+                            <field name="path" invisible="not path" />
+                            <field name="is_running" invisible="not is_running" />
+                            <field name="use_sudo" invisible="not use_sudo" />
                             <field
                                 name="plan_log_id"
                                 invisible="context.get('opened_from_plan', False)"
@@ -73,17 +64,14 @@
                             <field name="start_date" />
                             <field name="finish_date" />
                             <field name="duration_current" />
-                             <field
-                                name="command_status"
-                                attrs="{'invisible': [('is_running', '=', True)]}"
-                            />
+                            <field name="command_status" invisible="is_running" />
                         </group>
                     </group>
                     <notebook>
                         <page
                             name="result"
                             string="Result"
-                            attrs="{'invisible': [('command_action', '=', 'plan')]}"
+                            invisible="command_action == 'plan'"
                         >
                             <field
                                 name="command_response"
@@ -94,13 +82,14 @@
                         <page
                             name="code"
                             string="Command"
-                            attrs="{'invisible': [('command_action', '=', 'plan')]}"
+                            invisible="command_action == 'plan'"
                         >
                             <field name="code" />
                         </page>
-                          <page
+                        <page
+                            name="triggered"
                             string="Triggered Commands"
-                            attrs="{'invisible': [('command_action','!=','plan')]}"
+                            invisible="command_action != 'plan'"
                         >
                                 <field name="triggered_plan_command_log_ids">
                                     <tree default_order="id asc" />

--- a/cetmix_tower_server/views/cx_tower_command_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_log_view.xml
@@ -43,10 +43,22 @@
                                 widget="ace"
                                 options="{'mode': 'python'}"
                             />
-                            <field name="path" invisible="not path" />
-                            <field name="is_running" invisible="not is_running" />
-                            <field name="use_sudo" invisible="not use_sudo" />
-                            <field name="command_status" invisible="is_running" />
+                            <field
+                                name="path"
+                                attrs="{'invisible': [('path', '=', False)]}"
+                            />
+                            <field
+                                name="is_running"
+                                attrs="{'invisible': [('is_running', '=', False)]}"
+                            />
+                            <field
+                                name="use_sudo"
+                                attrs="{'invisible': [('use_sudo', '=', False)]}"
+                            />
+                            <field
+                                name="plan_log_id"
+                                invisible="context.get('opened_from_plan', False)"
+                            />
                             <field
                                 name="triggered_plan_log_id"
                                 invisible="not triggered_plan_log_id"
@@ -61,21 +73,38 @@
                             <field name="start_date" />
                             <field name="finish_date" />
                             <field name="duration_current" />
+                             <field
+                                name="command_status"
+                                attrs="{'invisible': [('is_running', '=', True)]}"
+                            />
                         </group>
                     </group>
-                    <group>
-                        <field name="plan_log_id" invisible="not plan_log_id" />
-                    </group>
-                    <notebook invisible="command_action == 'plan'">
-                        <page name="result" string="Result">
+                    <notebook>
+                        <page
+                            name="result"
+                            string="Result"
+                            attrs="{'invisible': [('command_action', '=', 'plan')]}"
+                        >
                             <field
                                 name="command_response"
                                 invisible="not command_response"
                             />
                             <field name="command_error" invisible="not command_error" />
                         </page>
-                        <page name="code" string="Command">
+                        <page
+                            name="code"
+                            string="Command"
+                            attrs="{'invisible': [('command_action', '=', 'plan')]}"
+                        >
                             <field name="code" />
+                        </page>
+                          <page
+                            string="Triggered Commands"
+                            attrs="{'invisible': [('command_action','!=','plan')]}"
+                        >
+                                <field name="triggered_plan_command_log_ids">
+                                    <tree default_order="id asc" />
+                                </field>
                         </page>
                     </notebook>
                 </sheet>

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -74,7 +74,7 @@
                             <field name="allow_parallel_run" />
                             <field
                                 name="no_split_for_sudo"
-                                attrs="{'invisible': [('action', '!=', 'ssh_command')]}"
+                                invisible="action != 'ssh_command'"
                             />
                             <field name="note" />
                         </group>
@@ -135,7 +135,7 @@
                         <page
                             name="plan_lines"
                             string="Flight Plan Lines"
-                            attrs="{'invisible': [('action', '!=', 'plan')]}"
+                            invisible="action != 'plan'"
                         >
                             <field name="flight_plan_line_ids">
                                 <tree>
@@ -147,7 +147,7 @@
                         <page
                             name="template_code"
                             string="Template Code"
-                            attrs="{'invisible': [('action', '!=', 'file_using_template')]}"
+                            invisible="action != 'file_using_template'"
                         >
                             <field
                                 name="template_code"

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -72,7 +72,10 @@
                                 placeholder="optional, eg /home/{{ tower.server.username }}"
                             />
                             <field name="allow_parallel_run" />
-                            <field name="no_split_for_sudo" />
+                            <field
+                                name="no_split_for_sudo"
+                                attrs="{'invisible': [('action', '!=', 'ssh_command')]}"
+                            />
                             <field name="note" />
                         </group>
                         <group>
@@ -128,6 +131,30 @@
                             invisible="action != 'python_code'"
                         >
                             <field name="command_help" />
+                        </page>
+                        <page
+                            name="plan_lines"
+                            string="Flight Plan Lines"
+                            attrs="{'invisible': [('action', '!=', 'plan')]}"
+                        >
+                            <field name="flight_plan_line_ids">
+                                <tree>
+                                    <field name="command_id" />
+                                    <field name="tag_ids" widget="many2many_tags" />
+                                </tree>
+                            </field>
+                        </page>
+                        <page
+                            name="template_code"
+                            string="Template Code"
+                            attrs="{'invisible': [('action', '!=', 'file_using_template')]}"
+                        >
+                            <field
+                                name="template_code"
+                                widget="ace"
+                                readonly="1"
+                                options="{'mode': 'jinja2'}"
+                            />
                         </page>
                         <page
                             name="access"

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -152,8 +152,8 @@
                             <field
                                 name="template_code"
                                 widget="ace"
+                                options="{'mode': 'python'}"
                                 readonly="1"
-                                options="{'mode': 'jinja2'}"
                             />
                         </page>
                         <page

--- a/cetmix_tower_server/views/cx_tower_plan_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_log_view.xml
@@ -49,7 +49,10 @@
                             <field name="finish_date" />
                             <field name="duration_current" />
                         </group>
-                        <field name="command_log_ids">
+                        <field
+                            name="command_log_ids"
+                            context="{'opened_from_plan': True}"
+                        >
                             <tree
                                 decoration-danger="command_status not in [0, -205]"
                                 decoration-info="is_running == True"

--- a/cetmix_tower_server/views/cx_tower_plan_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_view.xml
@@ -72,7 +72,7 @@
                         </group>
                     </group>
                     <notebook>
-                        <page name="plan_lines" string="Code">
+                        <page name="plan_lines" string="Commands">
                             <field name="line_ids">
                                 <tree decoration-bf="action=='plan'">
                                     <field name="sequence" widget="handle" />


### PR DESCRIPTION
Forward port the following PRs:

[ [16.0][IMP] cetmix_tower_server-command_log_view_update #295 ](https://github.com/cetmix/cetmix-tower/pull/295/commits/939fe0b1a9a7cec1f044b6778ca7b080b429f428)
[ [16.0][IMP] cetmix_tower_server-improve_UX_of_command_form #318 ](https://github.com/cetmix/cetmix-tower/pull/318/commits/2e24ead20e8714fbd04660c8f3bba076c4aae0b8)
with this fix:  
[[16.0][FIX] cetmix_tower-restore_flight_plan_order #329 ](
https://github.com/cetmix/cetmix-tower/pull/329/commits/a3325cb6bdfd58c55f80b5d509feb08b4150706a)

Task: 4823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced command view with additional pages for Flight Plan Lines and Template Code, featuring syntax highlighting.
  * Added a contextual "Triggered Commands" page in the command log view to display related triggered commands.
  * Improved visibility and conditional display of fields in command and command log forms.
  * Included more related information in command records, such as template code and flight plan lines.
  * Added context-aware display for command logs accessed from flight plans.
  * Renamed notebook page label from "Code" to "Commands" in flight plan view.

* **Bug Fixes**
  * Improved sorting in the command log view.

* **Documentation**
  * Updated feature documentation to reflect improvements in command and flight plan form views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->