### PR TITLE
[17.0][MIG] cetmix_yaml_server: Forward port updates from 16.0

### DIFF
--- a/cetmix_tower_yaml/readme/newsfragments/4812.bugfix
+++ b/cetmix_tower_yaml/readme/newsfragments/4812.bugfix
@@ -1,0 +1,1 @@
+Import servers with `Password` ssh authentication mode

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
 import base64
 
 import yaml
@@ -599,4 +603,67 @@ records:
         # Check tag
         self.assertTrue(
             self.Tag.get_by_reference("such_much_tag"), "Tag must be created"
+        )
+
+    def test_yaml_import_server_without_password(self):
+        """Wizard should import server without ssh_password."""
+        yaml_code = (
+            "cetmix_tower_yaml_version: 1\n"
+            "records:\n"
+            "- reference: srv_nopass\n"
+            "  cetmix_tower_model: server\n"
+            "  name: YAML NoPass\n"
+            "  ssh_auth_mode: p\n"
+            "  ssh_username: root\n"
+            "  ip_v4_address: 10.0.0.3\n"
+        )
+        wiz = self.env["cx.tower.yaml.import.wiz"].create(
+            {
+                "yaml_code": yaml_code,
+                "if_record_exists": "create",
+            }
+        )
+        wiz.action_import_yaml()
+
+        srv = self.env["cx.tower.server"].get_by_reference("srv_nopass")
+        self.assertTrue(srv, "Server was not created")
+        self.assertFalse(srv.ssh_password, "ssh_password must stay empty after import")
+
+    def test_orm_create_server_requires_password(self):
+        """Creating a server via ORM/UI must fail when ssh_password is missing."""
+        with self.assertRaises(ValidationError) as err:
+            self.env["cx.tower.server"].create(
+                {
+                    "reference": "srv_ui",
+                    "name": "UI NoPass",
+                    "ssh_auth_mode": "p",
+                    "ssh_username": "root",
+                    "ip_v4_address": "10.0.0.2",
+                }
+            )
+        self.assertIn("Please provide SSH password", str(err.exception))
+
+    def test_yaml_import_server_with_skip_ssh_check(self):
+        """Explicit skip_ssh_settings_check also bypasses password validation."""
+        yaml_code = (
+            "cetmix_tower_yaml_version: 1\n"
+            "records:\n"
+            "- reference: srv_skip\n"
+            "  cetmix_tower_model: server\n"
+            "  name: YAML Skip Check\n"
+            "  ssh_auth_mode: p\n"
+            "  ssh_username: root\n"
+            "  ip_v4_address: 10.0.0.4\n"
+        )
+        wiz = self.env["cx.tower.yaml.import.wiz"].create(
+            {
+                "yaml_code": yaml_code,
+                "if_record_exists": "create",
+            }
+        )
+        wiz.with_context(skip_ssh_settings_check=True).action_import_yaml()
+
+        srv = self.env["cx.tower.server"].get_by_reference("srv_skip")
+        self.assertTrue(
+            srv, "Server must be created when skip_ssh_settings_check is set"
         )

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
 import logging
 
 import yaml
@@ -78,7 +82,9 @@ class CxTowerYamlImportWiz(models.TransientModel):
             # Get model from cache or create new one
             model = models.get(model_name)
             if not model:
-                model = self.env[f"cx.tower.{model_name.replace('_', '.')}"]
+                model = self.env[
+                    f"cx.tower.{model_name.replace('_', '.')}"
+                ].with_context(skip_ssh_settings_check=(model_name == "server"))
                 models[model_name] = model
 
             # Get existing record by reference
@@ -98,9 +104,11 @@ class CxTowerYamlImportWiz(models.TransientModel):
             elif self.if_record_exists == "update" and odoo_record:
                 try:
                     record_values = model.with_context(
-                        force_create_related_record=False
+                        force_create_related_record=False,
                     )._post_process_yaml_dict_values(record)
-                    odoo_record.with_context(from_yaml=True).write(record_values)
+                    odoo_record.with_context(
+                        from_yaml=True,
+                    ).write(record_values)
                     odoo_record_ids.append(odoo_record.id)
                 except Exception as e:
                     raise ValidationError(
@@ -120,7 +128,9 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 force_create_related_record=self.if_record_exists == "create",
             )._post_process_yaml_dict_values(record)
             try:
-                odoo_record = model.with_context(from_yaml=True).create(record_values)
+                odoo_record = model.with_context(
+                    from_yaml=True,
+                ).create(record_values)
                 odoo_record_ids.append(odoo_record.id)
             except Exception as e:
                 raise ValidationError(


### PR DESCRIPTION
Forward port the following PRs:

[[16.0][FIX] cetmix_tower_yaml-bypass_SSH_check#333](https://github.com/cetmix/cetmix-tower/pull/333/commits/f8b8067325ecedaae84d10d2276e10ac2cc55245)

Task: 4826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where importing servers using password-based SSH authentication was not supported. The import functionality now allows servers configured with password authentication to be imported successfully.

* **Tests**
  * Added new tests to verify server import behavior with and without SSH passwords, and to ensure correct validation when bypassing SSH checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->