### PR TITLE
[14.0][IMP] cetmix_tower_yaml: Back port from 16.0

### DIFF
--- a/cetmix_tower_yaml/readme/newsfragments/4820.bugfix
+++ b/cetmix_tower_yaml/readme/newsfragments/4820.bugfix
@@ -1,0 +1,1 @@
+Fix missing model names in YAML exports when exporting multiple commands with flight plans

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -260,3 +260,29 @@ records:
                 f"Reference '{ref}' is used only as a reference, "
                 "but no full object present",
             )
+
+    def test_export_required_model_name_in_yaml(self):
+        """
+        Test that the model name is required in the YAML file for each record
+        """
+        # create a command to run flight plan
+        command_run_flight_plan = self.TowerCommand.create(
+            {
+                "name": "Run Flight Plan",
+                "action": "plan",
+                "flight_plan_id": self.flight_plan_test_wizard.id,
+            }
+        )
+        # export 2 commands: command_run_flight_plan and command_test_wizard
+        wizard = self.YamlExportWizard.with_context(
+            active_model="cx.tower.command",
+            active_ids=[command_run_flight_plan.id, self.command_test_wizard.id],
+        ).create({})
+
+        wizard.onchange_explode_child_records()
+
+        yaml_data = yaml.safe_load(wizard.yaml_code)
+
+        # check that the model name is present in the YAML file for each record
+        for record in yaml_data["records"]:
+            self.assertIn("cetmix_tower_model", record)

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -67,6 +67,12 @@ class CxTowerYamlExportWiz(models.TransientModel):
                 yaml_collector=collector,
             )._prepare_record_for_yaml()
             if record_yaml_dict:
+                # Add model name to the record if it's not present
+                if "cetmix_tower_model" not in record_yaml_dict:
+                    record_yaml_dict["cetmix_tower_model"] = record._name.replace(
+                        "cx.tower.", ""
+                    ).replace(".", "_")
+
                 record_list.append(record_yaml_dict)
 
         if record_list:


### PR DESCRIPTION
Back port the following PRs:

- https://github.com/cetmix/cetmix-tower/pull/335

Please refer to the commit messaged for changelog.

Task: 4830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that model names are included in YAML exports when exporting multiple commands with flight plans.

* **Tests**
  * Added a test to verify that exported YAML records always contain the required model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->