### PR TITLE
[16.0][MIG] cetmix_tower_server_queue: forward port updates

### DIFF
--- a/cetmix_tower/readme/newsfragments/3720.feature
+++ b/cetmix_tower/readme/newsfragments/3720.feature
@@ -1,0 +1,1 @@
+cetmix_tower_server_queue: Add async file upload/download via job queue

--- a/cetmix_tower_server/models/constants.py
+++ b/cetmix_tower_server/models/constants.py
@@ -63,6 +63,12 @@ PLAN_NOT_COMPATIBLE_WITH_SERVER = -306
 # Returned when the file could not be created on the server
 FILE_CREATION_FAILED = -400
 
+# Returned when the file could not be uploaded to the server
+FILE_UPLOAD_FAILED = -401
+
+# Returned when the file could not be downloaded from the server
+FILE_DOWNLOAD_FAILED = -402
+
 # -- Default values
 
 # Default SSH code used in SSH command

--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -100,9 +100,10 @@ class CxTowerFile(models.Model):
         help="Date and time of the latest successful synchronisation",
     )
     server_response = fields.Text(
+        copy=False,
         help="Server response received during the last operation.\n"
         "Default value if no error happened is 'ok'.\n"
-        "Otherwise there will be a server error message logged."
+        "Otherwise there will be a server error message logged.",
     )
     server_id = fields.Many2one(
         comodel_name="cx.tower.server", required=False, ondelete="cascade"

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -327,6 +327,11 @@ class TestTowerCommon(BaseCommon):
 
         # Patch file manipulation methods for testing
         def ssh_download_file(self, remote_path):
+            if hasattr(self, "env"):
+                error = self.env.context.get("raise_download_error")
+                if error:
+                    raise ValidationError(error)
+
             _, extension = os.path.splitext(remote_path)
             if extension == ".zip":
                 return b"ok\x00"
@@ -339,6 +344,10 @@ class TestTowerCommon(BaseCommon):
         cls.addClassCleanup(download_patch.stop)
 
         def ssh_upload_file(self, file, remote_path):
+            if hasattr(self, "env"):
+                error = self.env.context.get("raise_upload_error")
+                if error:
+                    raise ValidationError(error)
             return MagicMock()
 
         upload_patch = patch.object(SftpService, "upload_file", new=ssh_upload_file)

--- a/cetmix_tower_server_queue/__manifest__.py
+++ b/cetmix_tower_server_queue/__manifest__.py
@@ -14,5 +14,6 @@
     "depends": ["cetmix_tower_server", "queue_job"],
     "data": [
         "views/cx_tower_command_log_view.xml",
+        "views/cx_tower_file_view.xml",
     ],
 }

--- a/cetmix_tower_server_queue/models/__init__.py
+++ b/cetmix_tower_server_queue/models/__init__.py
@@ -1,3 +1,4 @@
 from . import cx_tower_command_log
 from . import cx_tower_server
 from . import queue_job
+from . import cx_tower_file

--- a/cetmix_tower_server_queue/models/__init__.py
+++ b/cetmix_tower_server_queue/models/__init__.py
@@ -1,2 +1,3 @@
 from . import cx_tower_command_log
 from . import cx_tower_server
+from . import queue_job

--- a/cetmix_tower_server_queue/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_queue/models/cx_tower_command_log.py
@@ -16,6 +16,18 @@ class CxTowerCommandLog(models.Model):
         groups="queue_job.group_queue_job_manager",
     )
 
+    command_status = fields.Integer(
+        help="0 if command finished successfully.\n"
+        "-100 general error,\n"
+        "-101 not found,\n"
+        "-201 another instance of this command is running,\n"
+        "-202 no runner found for the command action,\n"
+        "-203 Python code execution failed\n"
+        "-205 plan line condition check failed\n"
+        "503 if SSH connection error occurred\n"
+        "601 if queue job failed"
+    )
+
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs
     ):

--- a/cetmix_tower_server_queue/models/cx_tower_file.py
+++ b/cetmix_tower_server_queue/models/cx_tower_file.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class CxTowerFile(models.Model):
+    _inherit = "cx.tower.file"
+
+    is_being_processed = fields.Boolean(
+        copy=False,
+        help="File is currently being processed",
+    )
+
+    def _check_files_being_processed(self, raise_error):
+        """
+        Check if any file in the recordset is being processed.
+        True if at least one file is already processing and raise_error is False.
+        False if no files are currently being processed.
+        The caller uses the boolean to decide whether to continue or abort.
+        """
+        processing_files = self.filtered(lambda rec: rec.is_being_processed)
+        if processing_files:
+            if raise_error:
+                raise UserError(
+                    _(
+                        "The following files are already being processed: %(name)s",
+                        name=", ".join(processing_files.mapped("name")),
+                    )
+                )
+            else:
+                return True
+        return False
+
+    def upload(self, raise_error=False):
+        """
+        Trigger asynchronous upload via job queue.
+        """
+        # Check if the file is already being processed
+        if self._check_files_being_processed(raise_error):
+            return
+
+        self.write({"server_response": False, "is_being_processed": True})
+
+        # Enqueue the upload if not already in a queue job;
+        # otherwise, execute immediately
+        if not self.env.context.get("job_uuid"):
+            self.with_delay()._do_upload(raise_error=raise_error)
+        else:
+            self._do_upload(raise_error=raise_error)
+
+    def download(self, raise_error=False):
+        """
+        Trigger asynchronous download via job queue.
+        """
+
+        # Check if the file is already being processed
+        if self._check_files_being_processed(raise_error):
+            return
+
+        self.write({"server_response": False, "is_being_processed": True})
+
+        # Enqueue the download if not already in a queue job;
+        # otherwise, execute immediately
+        if not self.env.context.get("job_uuid"):
+            self.with_delay()._do_download(raise_error=raise_error)
+        else:
+            self._do_download(raise_error=raise_error)
+
+    def _do_upload(self, raise_error=True):
+        """
+        Uploads the file within a job context and notifies the user on success.
+        Logs the error if an exception occurs;
+        failure state is managed by the parent method.
+        """
+        try:
+            with self.env.cr.savepoint():
+                result = super().upload(raise_error=raise_error)
+                single_msg = _("File uploaded!")
+                plural_msg = _("Files uploaded!")
+                self.env["bus.bus"].sudo().sendone(
+                    (self._cr.dbname, "res.partner", self.env.user.partner_id.id),
+                    {
+                        "message": single_msg if len(self) == 1 else plural_msg,
+                        "title": _("Success"),
+                        "type": "success",
+                    },
+                )
+                return result
+        except Exception as e:
+            if not raise_error:
+                _logger.error("File %s upload failed: %s", str(self), str(e))
+            else:
+                raise
+        finally:
+            self.write({"is_being_processed": False})
+
+    def _do_download(self, raise_error=True):
+        """
+        Downloads the file within a job context and notifies the user on success.
+        Logs the error if an exception occurs;
+        failure state is managed by the parent method.
+        """
+        try:
+            with self.env.cr.savepoint():
+                result = super().download(raise_error=raise_error)
+                single_msg = _("File downloaded!")
+                plural_msg = _("Files downloaded!")
+                self.env["bus.bus"].sudo().sendone(
+                    (self._cr.dbname, "res.partner", self.env.user.partner_id.id),
+                    {
+                        "message": single_msg if len(self) == 1 else plural_msg,
+                        "title": _("Success"),
+                        "type": "success",
+                    },
+                )
+                return result
+        except Exception as e:
+            if not raise_error:
+                _logger.error("File %s download failed: %s", str(self), str(e))
+            else:
+                raise
+        finally:
+            self.write({"is_being_processed": False})
+
+    def action_pull_from_server(self):
+        """
+        Pull file from server without notification.
+        """
+        tower_files = self.filtered(lambda file_: file_.source == "tower")
+        server_files = self - tower_files
+
+        tower_files.action_get_current_server_code()
+
+        server_files.download(raise_error=False)
+
+    def action_push_to_server(self):
+        """
+        Push the file to server without success notification.
+        """
+        server_files = self.filtered(lambda file_: file_.source == "server")
+        if server_files:
+            return {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": _("Failure"),
+                    "message": _(
+                        "Unable to upload file '%(f)s'.\n"
+                        "Upload operation is not supported for 'server' type files.",
+                        f=server_files[0].rendered_name,
+                    ),
+                    "sticky": False,
+                },
+            }
+
+        self.upload(raise_error=False)

--- a/cetmix_tower_server_queue/models/queue_job.py
+++ b/cetmix_tower_server_queue/models/queue_job.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2020 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+from odoo import models
+
+
+class QueueJob(models.Model):
+    _inherit = "queue.job"
+
+    QUEUE_JOB_ERROR = 601
+
+    def write(self, vals):
+        """Override write method to update command status in the log record"""
+        if vals.get("state") == "failed":
+            log_record = self.kwargs.get("log_record")
+            if log_record:
+                log_record.finish(
+                    status=self.QUEUE_JOB_ERROR,
+                )
+        return super(QueueJob, self).write(vals)

--- a/cetmix_tower_server_queue/models/queue_job.py
+++ b/cetmix_tower_server_queue/models/queue_job.py
@@ -16,4 +16,4 @@ class QueueJob(models.Model):
                 log_record.finish(
                     status=self.QUEUE_JOB_ERROR,
                 )
-        return super(QueueJob, self).write(vals)
+        return super().write(vals)

--- a/cetmix_tower_server_queue/models/queue_job.py
+++ b/cetmix_tower_server_queue/models/queue_job.py
@@ -9,11 +9,15 @@ class QueueJob(models.Model):
     QUEUE_JOB_ERROR = 601
 
     def write(self, vals):
-        """Override write method to update command status in the log record"""
+        """
+        Override write method to update command status
+        and write error information in the log record
+        """
         if vals.get("state") == "failed":
             log_record = self.kwargs.get("log_record")
             if log_record:
                 log_record.finish(
                     status=self.QUEUE_JOB_ERROR,
+                    error=vals.get("exc_info"),
                 )
         return super().write(vals)

--- a/cetmix_tower_server_queue/readme/newsfragments/3720.feature
+++ b/cetmix_tower_server_queue/readme/newsfragments/3720.feature
@@ -1,0 +1,1 @@
+cetmix_tower_server_queue: Add async file upload/download via job queue

--- a/cetmix_tower_server_queue/readme/newsfragments/4718.feature
+++ b/cetmix_tower_server_queue/readme/newsfragments/4718.feature
@@ -1,0 +1,1 @@
+Terminate command with error if job has failed

--- a/cetmix_tower_server_queue/tests/__init__.py
+++ b/cetmix_tower_server_queue/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_command
 from . import test_command_log
+from . import test_file

--- a/cetmix_tower_server_queue/tests/__init__.py
+++ b/cetmix_tower_server_queue/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_command
+from . import test_command_log

--- a/cetmix_tower_server_queue/tests/test_command_log.py
+++ b/cetmix_tower_server_queue/tests/test_command_log.py
@@ -1,0 +1,43 @@
+from odoo.addons.cetmix_tower_server.tests.common import TestTowerCommon
+from odoo.addons.queue_job.job import Job
+
+
+class TestTowerCommand(TestTowerCommon):
+    """
+    Test cases for command log state on queue_job failure
+    """
+
+    def setUp(self):
+        super().setUp()
+
+    # Should match models.queue_job.QUEUE_JOB_ERROR
+    QUEUE_JOB_ERROR = 601
+
+    def test_command_log_state_on_job_fail(self):
+        command = self.env["cx.tower.command"].create(
+            {
+                "name": "Test Command",
+                "action": "ssh_command",
+                "code": "echo 'Hello World'",
+            }
+        )
+        self.assertTrue(command.id, "Command should be created successfully")
+
+        self.server_test_1.run_command(command=command)
+        command_log = self.env["cx.tower.command.log"].search(
+            [("command_id", "=", command.id)], order="id desc", limit=1
+        )
+        self.assertTrue(command_log, "Command log should be created")
+
+        job = command_log.queue_job_id
+        self.assertTrue(job, "Queue job should be associated with command log")
+
+        job_obj = Job.load(self.env, job.uuid)
+        job_obj.set_failed()
+        job_obj.store()
+        self.assertEqual(job.state, "failed", "Job should be in failed state")
+        self.assertEqual(
+            command_log.command_status,
+            self.QUEUE_JOB_ERROR,
+            "Command log should be in failed state",
+        )

--- a/cetmix_tower_server_queue/tests/test_file.py
+++ b/cetmix_tower_server_queue/tests/test_file.py
@@ -1,0 +1,196 @@
+from odoo import exceptions
+
+from odoo.addons.cetmix_tower_server.tests.common import TestTowerCommon
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+
+class TestCxTowerFileQueue(TestTowerCommon):
+    def setUp(self):
+        super().setUp()
+        self.file_template = self.FileTemplate.create(
+            {
+                "name": "Test",
+                "file_name": "test.txt",
+                "server_dir": "/var/tmp",
+                "code": "Hello, world!",
+            }
+        )
+
+    def test_async_upload_operations(self):
+        """Test that upload operations are processed asynchronously"""
+        # Create unique files specifically for this test
+        upload_file = self.File.create(
+            {
+                "source": "tower",
+                "template_id": self.file_template.id,
+                "server_id": self.server_test_1.id,
+                "name": "upload_test_1",
+            }
+        )
+
+        upload_file_2 = self.File.create(
+            {
+                "name": "upload_test_2",
+                "source": "server",
+                "server_id": self.server_test_1.id,
+                "server_dir": "/var/tmp",
+            }
+        )
+
+        with trap_jobs() as trap:
+            upload_file.upload()
+            upload_file_2.upload()
+
+            self.assertEqual(len(trap.enqueued_jobs), 2)
+
+            upload_file.write({"server_response": "ok", "is_being_processed": False})
+            upload_file_2.write({"server_response": "ok", "is_being_processed": False})
+
+            # Refresh records to get updated values
+            upload_file.refresh()
+            upload_file_2.refresh()
+
+            # Verify the expected state
+            self.assertEqual(upload_file.server_response, "ok")
+            self.assertFalse(upload_file.is_being_processed)
+
+            self.assertEqual(upload_file_2.server_response, "ok")
+            self.assertFalse(upload_file_2.is_being_processed)
+
+    def test_async_download_operations(self):
+        """Test that download operations are processed asynchronously"""
+        # Create unique files specifically for this test
+        download_file = self.File.create(
+            {
+                "source": "tower",
+                "template_id": self.file_template.id,
+                "server_id": self.server_test_1.id,
+                "name": "download_test_1",
+            }
+        )
+
+        download_file_2 = self.File.create(
+            {
+                "name": "download_test_2",
+                "source": "server",
+                "server_id": self.server_test_1.id,
+                "server_dir": "/var/tmp",
+            }
+        )
+
+        with trap_jobs() as trap:
+            download_file.download()
+            download_file_2.download()
+
+            # Verify jobs were created
+            self.assertEqual(len(trap.enqueued_jobs), 2)
+
+            download_file.write({"server_response": "ok", "is_being_processed": False})
+            download_file_2.write(
+                {"server_response": "ok", "is_being_processed": False}
+            )
+
+            # Refresh records to get updated values
+            download_file.refresh()
+            download_file_2.refresh()
+
+            # Verify the expected state
+            self.assertEqual(download_file.server_response, "ok")
+            self.assertFalse(download_file.is_being_processed)
+
+            self.assertEqual(download_file_2.server_response, "ok")
+            self.assertFalse(download_file_2.is_being_processed)
+
+    def test_upload_error_handling(self):
+        """Test error handling in async upload operations"""
+        error_file = self.File.create(
+            {
+                "source": "tower",
+                "template_id": self.file_template.id,
+                "server_id": self.server_test_1.id,
+                "name": "error_handling_test",
+            }
+        )
+
+        # Set context to force the mock in ssh_upload_file to raise error
+        error_context = {"raise_upload_error": "Forced upload error"}
+
+        with trap_jobs() as trap:
+            # This will trigger job creation but the job would fail if executed
+            error_file.with_context(error_context).upload(raise_error=True)
+
+            # Verify job was created
+            self.assertEqual(len(trap.enqueued_jobs), 1)
+
+            # Simulate what would happen if the job executed and failed
+            error_file.write({"server_response": "error", "is_being_processed": False})
+            error_file.refresh()
+
+            self.assertEqual(error_file.server_response, "error")
+            self.assertFalse(error_file.is_being_processed)
+
+    def test_download_error_handling(self):
+        """Test error handling in async download operations"""
+        error_file = self.File.create(
+            {
+                "source": "server",
+                "server_id": self.server_test_1.id,
+                "server_dir": "/var/tmp",
+                "name": "download_error_test",
+            }
+        )
+
+        # Set context to force the mock in ssh_download_file to raise error
+        error_context = {"raise_download_error": "Forced download error"}
+
+        with trap_jobs() as trap:
+            # This will trigger job creation but the job would fail if executed
+            error_file.with_context(error_context).download(raise_error=True)
+
+            # Verify job was created
+            self.assertEqual(len(trap.enqueued_jobs), 1)
+
+            # Simulate what would happen if the job executed and failed
+            error_file.write({"server_response": "error", "is_being_processed": False})
+            error_file.refresh()
+
+            self.assertEqual(error_file.server_response, "error")
+            self.assertFalse(error_file.is_being_processed)
+
+    def test_already_processing_check(self):
+        """Test that files being processed cannot be processed again"""
+        processing_file = self.File.create(
+            {
+                "source": "tower",
+                "template_id": self.file_template.id,
+                "server_id": self.server_test_1.id,
+                "name": "processing_test_file",
+                "is_being_processed": True,
+            }
+        )
+
+        self.assertTrue(processing_file.is_being_processed)
+
+        # Test with raising error
+        with self.assertRaises(exceptions.UserError):
+            processing_file.upload(raise_error=True)
+
+        # Test without raising error - should not create job
+        with trap_jobs() as trap:
+            processing_file.upload(raise_error=False)
+            # No job should be created since file is already being processed
+            self.assertEqual(len(trap.enqueued_jobs), 0)
+
+        # Verify still marked as processing
+        self.assertTrue(processing_file.is_being_processed)
+
+        # Same tests for download
+        with self.assertRaises(exceptions.UserError):
+            processing_file.download(raise_error=True)
+
+        with trap_jobs() as trap:
+            processing_file.download(raise_error=False)
+            # No job should be created
+            self.assertEqual(len(trap.enqueued_jobs), 0)
+
+        self.assertTrue(processing_file.is_being_processed)

--- a/cetmix_tower_server_queue/tests/test_file.py
+++ b/cetmix_tower_server_queue/tests/test_file.py
@@ -47,8 +47,8 @@ class TestCxTowerFileQueue(TestTowerCommon):
             upload_file_2.write({"server_response": "ok", "is_being_processed": False})
 
             # Refresh records to get updated values
-            upload_file.refresh()
-            upload_file_2.refresh()
+            upload_file.invalidate_recordset()
+            upload_file_2.invalidate_recordset()
 
             # Verify the expected state
             self.assertEqual(upload_file.server_response, "ok")
@@ -91,8 +91,8 @@ class TestCxTowerFileQueue(TestTowerCommon):
             )
 
             # Refresh records to get updated values
-            download_file.refresh()
-            download_file_2.refresh()
+            download_file.invalidate_recordset()
+            download_file_2.invalidate_recordset()
 
             # Verify the expected state
             self.assertEqual(download_file.server_response, "ok")
@@ -117,14 +117,14 @@ class TestCxTowerFileQueue(TestTowerCommon):
 
         with trap_jobs() as trap:
             # This will trigger job creation but the job would fail if executed
-            error_file.with_context(error_context).upload(raise_error=True)
+            error_file.with_context(**error_context).upload(raise_error=True)
 
             # Verify job was created
             self.assertEqual(len(trap.enqueued_jobs), 1)
 
             # Simulate what would happen if the job executed and failed
             error_file.write({"server_response": "error", "is_being_processed": False})
-            error_file.refresh()
+            error_file.invalidate_recordset()
 
             self.assertEqual(error_file.server_response, "error")
             self.assertFalse(error_file.is_being_processed)
@@ -145,14 +145,14 @@ class TestCxTowerFileQueue(TestTowerCommon):
 
         with trap_jobs() as trap:
             # This will trigger job creation but the job would fail if executed
-            error_file.with_context(error_context).download(raise_error=True)
+            error_file.with_context(**error_context).download(raise_error=True)
 
             # Verify job was created
             self.assertEqual(len(trap.enqueued_jobs), 1)
 
             # Simulate what would happen if the job executed and failed
             error_file.write({"server_response": "error", "is_being_processed": False})
-            error_file.refresh()
+            error_file.invalidate_recordset()
 
             self.assertEqual(error_file.server_response, "error")
             self.assertFalse(error_file.is_being_processed)

--- a/cetmix_tower_server_queue/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server_queue/views/cx_tower_file_view.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="cx_tower_file_view_form" model="ir.ui.view">
+        <field name="name">cx.tower.file.view.form</field>
+        <field name="model">cx.tower.file</field>
+        <field name="inherit_id" ref="cetmix_tower_server.cx_tower_file_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet/group" position="before">
+                <field name="is_being_processed" invisible="1" />
+                <field name="server_response" invisible="1" />
+                <widget
+                    name="web_ribbon"
+                    title="Processing"
+                    bg_color="bg-info"
+                    attrs="{'invisible': [('is_being_processed', '=', False)]}"
+                />
+                <widget
+                    name="web_ribbon"
+                    title="Success"
+                    bg_color="bg-success"
+                    attrs="{'invisible': ['|', ('is_being_processed', '=', True), ('server_response', '!=', 'ok')]}"
+                />
+                <widget
+                    name="web_ribbon"
+                    title="Error"
+                    bg_color="bg-danger"
+                    attrs="{'invisible': ['|', ('is_being_processed', '=', True), ('server_response', 'in', ('ok', False))]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="cx_tower_queue_file_view_tree" model="ir.ui.view">
+        <field name="name">cx.tower.queue.file.view.tree</field>
+        <field name="model">cx.tower.file</field>
+        <field name="inherit_id" ref="cetmix_tower_server.cx_tower_file_view_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="is_being_processed" invisible="1" />
+                <field name="server_response" invisible="1" />
+            </xpath>
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-info">
+                    is_being_processed == True
+                </attribute>
+                <attribute name="decoration-success">
+                    is_being_processed != True and server_response == 'ok'
+                </attribute>
+                <attribute name="decoration-danger">
+                    is_being_processed != True and server_response not in ('ok', False)
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Forward port the following PRs:
[[IMP] cetmix_tower_server_queue: copy job error to command log #311](https://github.com/cetmix/cetmix-tower/pull/311)
[[14.0][IMP] cetmix_tower_server_queue: fail command on job fail #300](https://github.com/cetmix/cetmix-tower/pull/300)
[[14.0][IMP] cetmix_tower_server_queue-async_file_operations #272](https://github.com/cetmix/cetmix-tower/pull/272)

Task: 4817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced asynchronous file upload and download capabilities managed through a job queue, enabling non-blocking file transfers.
  * Added visual indicators in the user interface to display file processing status, including ribbons and row highlights for processing, success, and error states.
  * Added detailed command execution status codes to improve feedback on command outcomes.

* **Bug Fixes**
  * Enhanced error handling for file operations, ensuring commands terminate with an error if a job fails and providing clear user notifications.

* **Tests**
  * Added comprehensive tests for asynchronous file upload/download operations, covering normal scenarios, error handling, and concurrency control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->