### PR TITLE
[14.0][REF] cetmix_tower_server Improve the way Python libraries are added using custom modules

### DIFF
--- a/cetmix_tower_aws/models/cx_tower_command.py
+++ b/cetmix_tower_aws/models/cx_tower_command.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, models
-from odoo.tools import ormcache
 from odoo.tools.safe_eval import wrap_module
 
 # Wrap boto3 safely
@@ -14,27 +13,28 @@ class CxTowerCommand(models.Model):
 
     _inherit = "cx.tower.command"
 
-    @ormcache()  # Use ormcache to cache the result
-    def _get_python_command_libraries(self):
+    def _custom_python_libraries(self):
         """
         Add the boto3 library to the available libraries.
         """
-        python_libraries = super()._get_python_command_libraries()
-        python_libraries.update(
+        custom_python_libraries = super()._custom_python_libraries()
+        custom_python_libraries.update(
             {
-                "boto3": {
-                    "import": boto3,
-                    "help": _(
-                        "Python 'boto3' library for AWS services. "
-                        "Available methods: 'client', 'resource', 'Session'<br/>"
-                        "Supports AWS services like EC2, S3, RDS, Lambda, "
-                        "CloudWatch, etc.<br/>"
-                        "Please check the <a "
-                        "href='https://boto3.amazonaws.com/v1/documentation/api/latest/index.html'"
-                        " target='_blank'>Boto3 Documentation</a> for the detailed "
-                        "information about the services and methods."
-                    ),
-                },
+                "cetmix_tower_aws": {
+                    "boto3": {
+                        "import": boto3,
+                        "help": _(
+                            "Python 'boto3' library for AWS services. "
+                            "Available methods: 'client', 'resource', 'Session'<br/>"
+                            "Supports AWS services like EC2, S3, RDS, Lambda, "
+                            "CloudWatch, etc.<br/>"
+                            "Please check the <a "
+                            "href='https://boto3.amazonaws.com/v1/documentation/api/latest/index.html'"
+                            " target='_blank'>Boto3 Documentation</a> for the detailed "
+                            "information about the services and methods."
+                        ),
+                    },
+                }
             }
         )
-        return python_libraries
+        return custom_python_libraries

--- a/cetmix_tower_aws/readme/newsfragments/4832.feature
+++ b/cetmix_tower_aws/readme/newsfragments/4832.feature
@@ -1,0 +1,1 @@
+Improve the way Python libraries are added using custom modules

--- a/cetmix_tower_ovh/models/cx_tower_command.py
+++ b/cetmix_tower_ovh/models/cx_tower_command.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, models
-from odoo.tools import ormcache
 from odoo.tools.safe_eval import wrap_module
 
 # Wrap ovh safely
@@ -14,25 +13,26 @@ class CxTowerCommand(models.Model):
 
     _inherit = "cx.tower.command"
 
-    @ormcache()  # Use ormcache to cache the result
-    def _get_python_command_libraries(self):
+    def _custom_python_libraries(self):
         """
         Add the ovh library to the available libraries.
         """
-        python_libraries = super()._get_python_command_libraries()
+        python_libraries = super()._custom_python_libraries()
         python_libraries.update(
             {
-                "ovh": {
-                    "import": ovh,
-                    "help": _(
-                        "Python 'ovh' library for OVH services. "
-                        "Available methods: 'Client'<br/>"
-                        "Supports OVH services<br/>"
-                        "Please check the <a "
-                        "href='https://eu.api.ovh.com/console/?section=%2FallDom&branch=v1'"
-                        " target='_blank'>OVH Documentation</a> for detailed "
-                        "information about the services and methods."
-                    ),
+                "cetmix_tower_ovh": {
+                    "ovh": {
+                        "import": ovh,
+                        "help": _(
+                            "Python 'ovh' library for OVH services. "
+                            "Available methods: 'Client'<br/>"
+                            "Supports OVH services<br/>"
+                            "Please check the <a "
+                            "href='https://eu.api.ovh.com/console/?section=%2FallDom&branch=v1'"
+                            " target='_blank'>OVH Documentation</a> for detailed "
+                            "information about the services and methods."
+                        ),
+                    }
                 }
             }
         )

--- a/cetmix_tower_ovh/readme/newsfragments/4832.feature
+++ b/cetmix_tower_ovh/readme/newsfragments/4832.feature
@@ -1,0 +1,1 @@
+Improve the way Python libraries are added using custom modules

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -287,7 +287,7 @@ class CxTowerCommand(models.Model):
                     "help": <library_help_html>
                 }}
         """
-        return {
+        python_libraries = {
             "time": {
                 "import": tools.safe_eval.time,
                 "help": _("Python 'time' library"),
@@ -387,6 +387,10 @@ class CxTowerCommand(models.Model):
                 ),
             },
         }
+        custom_python_libraries = self._custom_python_libraries()
+        for libraries in custom_python_libraries.values():
+            python_libraries.update(libraries)
+        return python_libraries
 
     def _get_python_command_odoo_objects(self, server=None):
         """
@@ -414,6 +418,55 @@ class CxTowerCommand(models.Model):
                 "help": _("Current Cetmix Tower server this command is running on"),
             },
         }
+
+    def _custom_python_libraries(self):
+        """
+        This function is designed to be used in custom modules
+        extending Cetmix Tower to add  custom python libraries
+        to the evaluation context.
+
+        Returns:
+            Dict: Custom python libraries.
+
+        The following format is used:
+        {
+            <module_name>: {"<library_name>": {
+                "import": <library_import>,
+                "help": <library_help_html>
+            }
+        }
+
+        Where:
+
+        <module_name> Odoo module technical name.
+        <library_name> is the name of the library how it will be used in the code.
+        <library_import> is the library to import.
+        <library_help_html> is the help text for the library shown in the "Help" tab.
+
+        Example:
+
+        ```python
+        # Custom module extending Cetmix Tower
+        custom_python_libraries = super()._custom_python_libraries()
+        custom_python_libraries.update({
+            "cetmix_tower_aws": {
+                "boto3": {
+                    "import": boto3,
+                    "help": "Python 'boto3' library. "
+                    "<a href='https://boto3.amazonaws.com/v1/documentation/api/latest/index.html'"
+                    " target='_blank'>Documentation</a>."
+                },
+                "custom_library_name": {
+                    "import": custom_library_import,
+                    "help": "Custom library help text"
+                }
+            }
+        })
+        return custom_python_libraries
+
+        ```
+        """
+        return {}
 
     def _get_python_command_eval_context(self, server=None):
         """

--- a/cetmix_tower_server/readme/newsfragments/4832.feature
+++ b/cetmix_tower_server/readme/newsfragments/4832.feature
@@ -1,0 +1,1 @@
+Improve the way Python libraries are added using custom modules


### PR DESCRIPTION
This is needed to be able to track which module is adding which library. So we can later include those modules in YAML file dependencies when exporting commands containing those libraries.

For example, when we use the 'boto3' library that is added by the 'cetmix_tower_aws' module in our command and later export that command, we should ensure that the destination Cetmix Tower instance where this command will be imported will have the 'cetmix_tower_aws' module installed as well.

Task: 4832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for adding Python libraries via custom modules, allowing for easier integration and management of additional libraries.
  * Enhanced documentation describing the new method for extending Python libraries in custom modules.

* **Documentation**
  * Added detailed docstrings and news fragments to explain the new extension mechanism for Python libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->