### PR TITLE
[14.0][FIX] cetmix_tower_server: Python command

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -319,18 +319,9 @@ class CxTowerCommand(models.Model):
                 "import": float_compare,
                 "help": _("Float compare. Odoo helper function to compare floats."),
             },
-            "env": {"import": self.env, "help": _("Odoo Environment")},
             "UserError": {
                 "import": UserError,
                 "help": _("UserError. Helper to raise UserError."),
-            },
-            "tower": {
-                "import": self.env["cetmix.tower"],
-                "help": _(
-                    "Cetmix Tower "
-                    "<a href='https://cetmix.com/tower/documentation/odoo_automation'"
-                    " target='_blank'>helper class</a> shortcut"
-                ),
             },
             "hashlib": {
                 "import": hashlib,
@@ -413,9 +404,18 @@ class CxTowerCommand(models.Model):
         return {
             "uid": {"import": self._uid, "help": _("Current Odoo user ID")},
             "user": {"import": self.env.user, "help": _("Current Odoo user")},
+            "env": {"import": self.env, "help": _("Odoo Environment")},
             "server": {
                 "import": server,
                 "help": _("Current Cetmix Tower server this command is running on"),
+            },
+            "tower": {
+                "import": self.env["cetmix.tower"],
+                "help": _(
+                    "Cetmix Tower "
+                    "<a href='https://cetmix.com/tower/documentation/odoo_automation'"
+                    " target='_blank'>helper class</a> shortcut"
+                ),
             },
         }
 


### PR DESCRIPTION
Move `env` and `tower` out of the cached function. Because thy must not be cached due to the fact that they are not static.

Backported from https://github.com/cetmix/cetmix-tower/pull/349

Task: 4847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted how certain environment-dependent objects are accessed within the application to improve context accuracy. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->