### PR TITLE
[16.0][IMP] cetmix_tower: Search servers by git remote

### DIFF
--- a/cetmix_tower_git/models/__init__.py
+++ b/cetmix_tower_git/models/__init__.py
@@ -8,3 +8,4 @@ from . import cx_tower_git_project
 from . import cx_tower_git_remote
 from . import cx_tower_git_source
 from . import cx_tower_server
+from . import cetmix_tower

--- a/cetmix_tower_git/models/cetmix_tower.py
+++ b/cetmix_tower_git/models/cetmix_tower.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class CetmixTower(models.AbstractModel):
+    _inherit = "cetmix.tower"
+
+    @api.model
+    def server_get_by_git_ref(self, repository_url, head=None, head_type=None):
+        """
+        Return servers linked to a given Git repository reference.
+
+        This is a thin shortcut that delegates to
+        :meth:`cx.tower.server.get_servers_by_git_ref`.
+
+        Parameters
+        ----------
+        repository_url : str
+            Pre-normalized canonical Git URL
+            (e.g. ``https://host/owner/repo.git``).
+        head : str, optional
+            Branch name, commit SHA, or PR identifier.
+        head_type : {'branch', 'commit', 'pr'}, optional
+            Type of the ``head`` argument.
+
+        Returns
+        -------
+        recordset of cx.tower.server
+            Matching servers. Empty recordset if no matches.
+        """
+        return self.env["cx.tower.server"].get_servers_by_git_ref(
+            repository_url, head, head_type
+        )

--- a/cetmix_tower_git/models/cx_tower_server.py
+++ b/cetmix_tower_git/models/cx_tower_server.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CxTowerServer(models.Model):
@@ -59,3 +59,41 @@ class CxTowerServer(models.Model):
         return super()._update_or_create_related_record(
             model, reference, values, create_immediately=create_immediately
         )
+
+    @api.model
+    def get_servers_by_git_ref(self, repository_url, head=None, head_type=None):
+        """
+        Return servers linked to a given Git repository reference.
+
+        Parameters
+        ----------
+        repository_url : str
+            Pre-normalized canonical Git URL
+            (e.g. ``https://host/owner/repo.git``).
+        head : str, optional
+            Branch name, commit SHA, or PR identifier.
+        head_type : {'branch', 'commit', 'pr'}, optional
+            Type of the ``head`` argument.
+            If only ``head`` is provided, it will match across all head types.
+            If only ``head_type`` is provided, it will filter by type regardless of head
+
+        Returns
+        -------
+        recordset of cx.tower.server
+            Matching servers. Empty recordset if no matches.
+        """
+        # URL MUST be already canonical.
+        if not repository_url:
+            return self.env["cx.tower.server"].browse()
+
+        Remote = self.env["cx.tower.git.remote"]
+        domain = [("url", "=", repository_url)]
+        if head:
+            domain.append(("head", "=", head))
+        if head_type:
+            domain.append(("head_type", "=", head_type))
+
+        matching = Remote.search(domain)
+
+        servers = matching.mapped("git_project_id.git_project_rel_ids.server_id")
+        return servers

--- a/cetmix_tower_git/readme/newsfragments/4838.feature
+++ b/cetmix_tower_git/readme/newsfragments/4838.feature
@@ -1,0 +1,1 @@
+Search servers by git reference

--- a/cetmix_tower_git/tests/__init__.py
+++ b/cetmix_tower_git/tests/__init__.py
@@ -3,3 +3,5 @@ from . import test_source
 from . import test_project
 from . import test_file_rel
 from . import test_file_template_rel
+from . import test_tower_git_ref
+from . import test_cetmix_tower

--- a/cetmix_tower_git/tests/test_cetmix_tower.py
+++ b/cetmix_tower_git/tests/test_cetmix_tower.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from .common import CommonTest
+
+
+class TestTowerGitShortcut(CommonTest):
+    """Ensure the cetmix.tower shortcut delegates correctly."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Link the Git project to Server 1 so the lookup can find it
+        cls.GitProjectRel.create(
+            {
+                "git_project_id": cls.git_project_1.id,
+                "server_id": cls.server_test_1.id,
+                "file_id": cls.server_1_file_1.id,
+            }
+        )
+
+    def test_shortcut_returns_same_servers(self):
+        """Shortcut must return exactly the same servers as the model API."""
+        url = self.remote_github_https.url
+        head = self.remote_github_https.head
+        head_type = self.remote_github_https.head_type
+
+        servers_model = self.env["cx.tower.server"].get_servers_by_git_ref(
+            url, head, head_type
+        )
+        servers_shortcut = self.env["cetmix.tower"].server_get_by_git_ref(
+            url, head, head_type
+        )
+        self.assertCountEqual(servers_model.ids, servers_shortcut.ids)

--- a/cetmix_tower_git/tests/test_tower_git_ref.py
+++ b/cetmix_tower_git/tests/test_tower_git_ref.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from .common import CommonTest
+
+
+class TestGetServersByGitRef(CommonTest):
+    """Unit tests for cx.tower.server.get_servers_by_git_ref()."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # canonical repo URL used in the tests
+        cls.repo_slug = "testorg/test_repo_123"
+        cls.canonical = f"https://github.com/{cls.repo_slug}.git"
+
+        # Git objects
+        GitProject = cls.GitProject
+        GitSource = cls.GitSource
+        GitRemote = cls.GitRemote
+        GitProjRel = cls.GitProjectRel
+        File = cls.File
+
+        cls.project = GitProject.create({"name": "Demo"})
+        cls.src = GitSource.create(
+            {
+                "name": "Local",
+                "git_project_id": cls.project.id,
+            }
+        )
+
+        GitRemote.create(
+            {
+                "git_project_id": cls.project.id,
+                "source_id": cls.src.id,
+                "url": cls.canonical,
+                "head": "main",
+                "head_type": "branch",
+            }
+        )
+
+        file = File.create(
+            {
+                "server_id": cls.server_test_1.id,
+                "source": "tower",
+                "file_type": "text",
+                "name": "dummy.txt",
+            }
+        )
+        GitProjRel.create(
+            {
+                "git_project_id": cls.project.id,
+                "server_id": cls.server_test_1.id,
+                "file_id": file.id,
+            }
+        )
+
+    # Positive
+    def test_success(self):
+        """Canonical URL must return the linked server."""
+        servers = self.Server.get_servers_by_git_ref(self.canonical, "main", "branch")
+        self.assertEqual(servers, self.server_test_1)
+
+    # Negative
+    def test_no_match(self):
+        """Foreign repo URL must return an empty recordset."""
+        other = "https://github.com/another/repo.git"
+        servers = self.Server.get_servers_by_git_ref(other, "main", "branch")
+        self.assertFalse(servers)


### PR DESCRIPTION
Add a new method cx.tower.server.get_servers_by_git_ref(repository_url, head, head_type)
that takes a Git URL and returns a recordset of all related servers.

Task: 4838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Search and list servers by Git repository reference (URL, head/branch, head type).
  - Added a Tower-level shortcut to fetch servers by Git reference.

- Documentation
  - Added release-note fragment announcing server search by Git reference.

- Tests
  - Added tests validating server lookup by Git reference and parity of the Tower shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->