### PR TITLE
[16.0][IMP]cetmix_tower_server: ace_tower add select secrets

### DIFF
--- a/cetmix_tower_server/readme/newsfragments/4853.feature.md
+++ b/cetmix_tower_server/readme/newsfragments/4853.feature.md
@@ -1,0 +1,1 @@
+Select secrets from dropdown list in the code fields

--- a/cetmix_tower_server/static/src/components/ace_variables/ace_variables.esm.js
+++ b/cetmix_tower_server/static/src/components/ace_variables/ace_variables.esm.js
@@ -20,17 +20,18 @@ class AceCommandField extends AceField {
         this.clickOutsideListener = null;
         this.inputTimeout = null;
         this.variables = [];
-        this.variablesLoaded = false;
+        this.secrets = [];
 
         // Use reactive state for properties that affect rendering
         this.state = useState({
             showPopup: false,
-            popupVariables: [],
+            popupItems: [],
             popupPosition: {},
             selectedIndex: 0,
+            // Add popup type to distinguish between variables and secrets
+            popupType: "variables",
         });
 
-        this.loadVariables();
         this.updateSelectedIndex = this.updateSelectedIndex.bind(this);
     }
 
@@ -45,16 +46,35 @@ class AceCommandField extends AceField {
                 [],
                 ["name", "reference"]
             );
-            this.variablesLoaded = true;
             console.log(`Loaded ${this.variables.length} variables for autocomplete`);
         } catch (error) {
             console.error("Failed to load variables for autocomplete:", error);
             this.variables = [];
-            this.variablesLoaded = false;
             this.env.services.notification.add(
                 "Failed to load autocomplete variables",
                 {type: "warning"}
             );
+        }
+    }
+
+    /**
+     * Load secrets from the backend using ORM service
+     * @returns {Promise<void>}
+     */
+    async loadSecrets() {
+        try {
+            this.secrets = await this.orm.searchRead(
+                "cx.tower.key",
+                [["key_type", "=", "s"]],
+                ["name", "reference"]
+            );
+            console.log(`Loaded ${this.secrets.length} secrets for autocomplete`);
+        } catch (error) {
+            console.error("Failed to load secrets for autocomplete:", error);
+            this.secrets = [];
+            this.env.services.notification.add("Failed to load autocomplete secrets", {
+                type: "warning",
+            });
         }
     }
 
@@ -87,7 +107,7 @@ class AceCommandField extends AceField {
             },
         });
 
-        // Set up input listener for {{ trigger
+        // Set up input listener for {{ and #! triggers
         this.inputListener = () => {
             // Clear any existing timeout
             if (this.inputTimeout) {
@@ -100,6 +120,7 @@ class AceCommandField extends AceField {
                 const line = session.getLine(cursor.row);
                 const textBeforeCursor = line.substring(0, cursor.column);
 
+                // Check for variables trigger {{
                 if (textBeforeCursor.endsWith("{{")) {
                     // Remove {{ symbols from editor
                     const startColumn = Math.max(0, cursor.column - 2);
@@ -115,7 +136,25 @@ class AceCommandField extends AceField {
                         column: startColumn,
                     };
                     this.aceEditor.moveCursorToPosition(newCursor);
-                    this.showCustomCompletions(this.aceEditor);
+                    this.showCustomCompletions(this.aceEditor, "variables");
+                }
+                // Check for secrets trigger !#
+                else if (textBeforeCursor.endsWith("#!")) {
+                    // Remove !# symbols from editor
+                    const startColumn = Math.max(0, cursor.column - 2);
+                    const range = {
+                        start: {row: cursor.row, column: startColumn},
+                        end: {row: cursor.row, column: cursor.column},
+                    };
+                    session.replace(range, "");
+
+                    // Update cursor position
+                    const newCursor = {
+                        row: cursor.row,
+                        column: startColumn,
+                    };
+                    this.aceEditor.moveCursorToPosition(newCursor);
+                    this.showCustomCompletions(this.aceEditor, "secrets");
                 }
             }, 10);
         };
@@ -124,40 +163,52 @@ class AceCommandField extends AceField {
     }
 
     /**
-     * Show custom completions popup with available variables
+     * Show custom completions popup with available variables or secrets
      * @param {Object} editor - ACE editor instance
+     * @param {String} type - Type of completion ('variables' or 'secrets')
      * @returns {Promise<void>}
      */
-    async showCustomCompletions(editor) {
+    async showCustomCompletions(editor, type = "variables") {
         const cursor = editor.getCursorPosition();
         const session = editor.getSession();
         const line = session.getLine(cursor.row);
         const textBeforeCursor = line.substring(0, cursor.column);
 
-        // Check if we're already in a variable context
-        const isInVariableContext = textBeforeCursor.endsWith("{{");
-        // Check if we're inside a variable (between {{ and }})
-        const lastOpenBrace = textBeforeCursor.lastIndexOf("{{");
-        const lastCloseBrace = textBeforeCursor.lastIndexOf("}}");
-        const isInsideVariable = lastOpenBrace > lastCloseBrace && lastOpenBrace !== -1;
+        let items = [];
+        let triggerLength = 0;
 
-        if (!this.variablesLoaded) {
+        if (type === "secrets") {
+            // Handle secrets
+            await this.loadSecrets();
+
+            if (!this.secrets.length) {
+                return;
+            }
+
+            items = this.secrets;
+        } else {
+            // Handle variables
             await this.loadVariables();
-        }
 
-        if (!this.variables.length) {
-            return;
+            if (!this.variables.length) {
+                return;
+            }
+
+            items = this.variables;
+            // Check if we're already in a variable context
+            const isInVariableContext = textBeforeCursor.endsWith("{{");
+
+            if (isInVariableContext) {
+                triggerLength = 2;
+            }
         }
 
         const position = this.calculatePopupPosition(editor, cursor);
 
-        // If we're already inside a variable context, just show popup
-        if (isInVariableContext || isInsideVariable) {
-            await this.showAutocompletePopup(this.variables, position, editor, 2);
-        } else {
-            // Just show popup without inserting anything
-            await this.showAutocompletePopup(this.variables, position, editor, 0);
-        }
+        // Set popup type in state
+        this.state.popupType = type;
+
+        await this.showAutocompletePopup(items, position, editor, triggerLength, type);
     }
 
     /**
@@ -218,22 +269,31 @@ class AceCommandField extends AceField {
     }
 
     /**
-     * Display the autocomplete popup with variables at the specified position
-     * @param {Array} variables - Array of available variables
+     * Display the autocomplete popup with variables or secrets at the specified position
+     * @param {Array} items - Array of available variables or secrets
      * @param {Object} position - Position object with left and top coordinates
      * @param {Object} editor - ACE editor instance
      * @param {Number} triggerLength - Length of trigger text that should be replaced
+     * @param {String} type - Type of completion ('variables' or 'secrets')
      * @returns {Promise<void>}
      */
-    async showAutocompletePopup(variables, position, editor, triggerLength) {
+    async showAutocompletePopup(
+        items,
+        position,
+        editor,
+        triggerLength,
+        type = "variables"
+    ) {
         this.hideAutocompletePopup();
 
-        this.state.popupVariables = variables;
+        this.state.popupItems = items;
         this.state.popupPosition = position;
         this.state.showPopup = true;
         this.state.selectedIndex = 0;
+        this.state.popupType = type;
         this.currentEditor = editor;
         this.currentTriggerLength = triggerLength;
+        this.currentType = type;
 
         // Add click outside listener
         this.clickOutsideListener = (event) => {
@@ -305,42 +365,101 @@ class AceCommandField extends AceField {
 
         // Get line length for validation
         const lineLength = session.getLine(cursor.row).length;
-
-        // Check if we're already in a variable context
-        const lastOpenBrace = textBeforeCursor.lastIndexOf("{{");
-        const lastCloseBrace = textBeforeCursor.lastIndexOf("}}");
-        const isInsideVariable = lastOpenBrace > lastCloseBrace && lastOpenBrace !== -1;
+        const currentType = this.currentType || this.state.popupType;
 
         let range = null;
         let insertText = "";
 
-        if (isInsideVariable) {
-            // We're inside a variable context, replace from after {{ to cursor
-            range = {
-                start: {row: cursor.row, column: lastOpenBrace + 2},
-                end: {row: cursor.row, column: cursor.column},
-            };
-            // Clamp range to valid bounds
-            range.start.column = Math.max(0, Math.min(range.start.column, lineLength));
-            range.end.column = Math.max(
-                range.start.column,
-                Math.min(range.end.column, lineLength)
-            );
-            insertText = ` ${command.reference} `;
+        if (currentType === "secrets") {
+            // Handle secrets insertion
+            // Check if we're inside a secret context (between #!cxtower.secret and !#)
+            const lastSecretStart = textBeforeCursor.lastIndexOf("#!cxtower.secret");
+            const lastSecretEnd = textBeforeCursor.lastIndexOf("!#");
+
+            // Count occurrences of start and end delimiters for more robust validation
+            const startCount = (textBeforeCursor.match(/#!cxtower\.secret/g) || [])
+                .length;
+            const endCount = (textBeforeCursor.match(/!#/g) || []).length;
+            const isInsideSecret =
+                startCount > endCount &&
+                lastSecretStart > lastSecretEnd &&
+                lastSecretStart !== -1;
+
+            if (isInsideSecret) {
+                // We're inside a secret context, replace from after #!cxtower to cursor
+                range = {
+                    start: {row: cursor.row, column: lastSecretStart + 16},
+                    end: {row: cursor.row, column: cursor.column},
+                };
+                // Clamp range to valid bounds
+                range.start.column = Math.max(
+                    0,
+                    Math.min(range.start.column, lineLength)
+                );
+                range.end.column = Math.max(
+                    range.start.column,
+                    Math.min(range.end.column, lineLength)
+                );
+                insertText = `${command.reference}!#`;
+            } else {
+                // We're not in a secret context, insert complete secret
+                const triggerLength = this.currentTriggerLength || 0;
+                range = {
+                    start: {row: cursor.row, column: cursor.column - triggerLength},
+                    end: {row: cursor.row, column: cursor.column},
+                };
+                // Clamp range to valid bounds
+                range.start.column = Math.max(
+                    0,
+                    Math.min(range.start.column, lineLength)
+                );
+                range.end.column = Math.max(
+                    range.start.column,
+                    Math.min(range.end.column, lineLength)
+                );
+                insertText = `#!cxtower.secret.${command.reference}!#`;
+            }
         } else {
-            // We're not in a variable context, insert complete variable
-            const triggerLength = this.currentTriggerLength || 0;
-            range = {
-                start: {row: cursor.row, column: cursor.column - triggerLength},
-                end: {row: cursor.row, column: cursor.column},
-            };
-            // Clamp range to valid bounds
-            range.start.column = Math.max(0, Math.min(range.start.column, lineLength));
-            range.end.column = Math.max(
-                range.start.column,
-                Math.min(range.end.column, lineLength)
-            );
-            insertText = `{{ ${command.reference} }}`;
+            // Handle variables insertion (existing logic)
+            const lastOpenBrace = textBeforeCursor.lastIndexOf("{{");
+            const lastCloseBrace = textBeforeCursor.lastIndexOf("}}");
+            const isInsideVariable =
+                lastOpenBrace > lastCloseBrace && lastOpenBrace !== -1;
+
+            if (isInsideVariable) {
+                // We're inside a variable context, replace from after {{ to cursor
+                range = {
+                    start: {row: cursor.row, column: lastOpenBrace + 2},
+                    end: {row: cursor.row, column: cursor.column},
+                };
+                // Clamp range to valid bounds
+                range.start.column = Math.max(
+                    0,
+                    Math.min(range.start.column, lineLength)
+                );
+                range.end.column = Math.max(
+                    range.start.column,
+                    Math.min(range.end.column, lineLength)
+                );
+                insertText = ` ${command.reference} `;
+            } else {
+                // We're not in a variable context, insert complete variable
+                const triggerLength = this.currentTriggerLength || 0;
+                range = {
+                    start: {row: cursor.row, column: cursor.column - triggerLength},
+                    end: {row: cursor.row, column: cursor.column},
+                };
+                // Clamp range to valid bounds
+                range.start.column = Math.max(
+                    0,
+                    Math.min(range.start.column, lineLength)
+                );
+                range.end.column = Math.max(
+                    range.start.column,
+                    Math.min(range.end.column, lineLength)
+                );
+                insertText = `{{ ${command.reference} }}`;
+            }
         }
 
         // Replace the text

--- a/cetmix_tower_server/static/src/components/ace_variables/ace_variables.xml
+++ b/cetmix_tower_server/static/src/components/ace_variables/ace_variables.xml
@@ -4,9 +4,10 @@
         <t t-call="web.AceField" />
         <t t-if="state.showPopup">
             <AutocompletePopup
-                commands="state.popupVariables"
+                commands="state.popupItems"
                 position="state.popupPosition"
                 selectedIndex="state.selectedIndex"
+                type="state.popupType"
                 onSelectedIndexChange="updateSelectedIndex"
                 onItemClick="(command) => this.handleCommandSelection(command, this.currentEditor)"
             />

--- a/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.esm.js
+++ b/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.esm.js
@@ -150,7 +150,7 @@ class AutocompletePopup extends Component {
             if (this.props.onSelectedIndexChange) {
                 this.props.onSelectedIndexChange(0);
             }
-        }, 150); // 150ms delay
+        }, 150);
     }
 
     /**
@@ -311,6 +311,7 @@ AutocompletePopup.props = {
     position: {type: Object},
     selectedIndex: {type: Number, optional: true},
     onSelectedIndexChange: {type: Function, optional: true},
+    type: {type: String, optional: true},
 };
 
 export {AutocompletePopup};

--- a/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.xml
+++ b/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.xml
@@ -6,10 +6,10 @@
             t-ref="popupRef"
             tabindex="0"
             role="combobox"
-            aria-label="Variable search"
+            t-att-aria-label="props.type === 'secrets' ? 'Secret search' : 'Variable search'"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-owns="variables-list"
+            t-att-aria-owns="props.type === 'secrets' ? 'secrets-list' : 'variables-list'"
         >
             <!-- Close button for mobile convenience -->
             <button
@@ -17,7 +17,7 @@
                 t-on-click="onCloseClick"
                 type="button"
                 title="Close"
-                aria-label="Close variable search"
+                t-att-aria-label="props.type === 'secrets' ? 'Close secret search' : 'Close variable search'"
             >
                 ×
             </button>
@@ -26,47 +26,48 @@
                 <input
                     type="text"
                     class="ace-autocomplete-search-input"
-                    placeholder="Search variables..."
+                    t-att-placeholder="props.type === 'secrets' ? 'Search secrets...' : 'Search variables...'"
                     t-model="state.searchTerm"
                     t-ref="searchInput"
                     t-on-input="onSearchInput"
                     t-on-keydown="onSearchKeyDown"
                     t-on-focus="onSearchFocus"
                     t-on-blur="onSearchBlur"
-                    aria-label="Search variables"
-                    aria-controls="variables-list"
+                    t-att-aria-label="props.type === 'secrets' ? 'Search secrets' : 'Search variables'"
+                    t-att-aria-controls="props.type === 'secrets' ? 'secrets-list' : 'variables-list'"
                     aria-autocomplete="list"
-                    t-att-aria-activedescendant="`var-opt-${state.selectedIndex}`"
+                    t-att-aria-activedescendant="`${props.type === 'secrets' ? 'sec' : 'var'}-opt-${props.selectedIndex}`"
                 />
             </div>
-            <!-- Variables list -->
+            <!-- Items list -->
             <div
                 class="ace-autocomplete-items"
                 t-ref="itemsContainer"
-                id="variables-list"
+                t-att-id="props.type === 'secrets' ? 'secrets-list' : 'variables-list'"
                 role="listbox"
             >
                 <div
                     t-foreach="filteredCommands"
                     t-as="command"
                     t-key="command.name"
-                    t-att-id="`var-opt-${command_index}`"
+                    t-att-id="`${props.type === 'secrets' ? 'sec' : 'var'}-opt-${command_index}`"
                     t-att-class="getItemClass(command_index)"
                     t-on-click="() => this.onItemClick(command)"
                     role="option"
-                    t-att-aria-selected="command_index === state.selectedIndex ? 'true' : 'false'"
+                    t-att-aria-selected="command_index === props.selectedIndex ? 'true' : 'false'"
                 >
                     <span class="command-name" t-esc="command.name" />
                     <span
                         class="command-description"
-                        t-esc="`{{ ${command.reference} }}`"
+                        t-esc="props.type === 'secrets' ? `${command.reference}` : `{{ ${command.reference} }}`"
                     />
                 </div>
                 <div
                     t-if="!filteredCommands.length"
                     class="ace-autocomplete-no-results"
                 >
-                    No variables found
+                    <t t-if="props.type === 'secrets'">No secrets found</t>
+                    <t t-else="">No variables found</t>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Modify the "ace_tower".

When typing a code and entering the #!​​ sequence a dropdown with secrets is displayed.  When a secret is selected from the dropdown its reference is automatically inserted into the code with the trailing !#​ symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added autocompletion support for "secrets" alongside existing "variables" in the ACE editor, triggered by `#!`.
  * Autocomplete popup dynamically adjusts labels, placeholders, and messages based on whether secrets or variables are displayed.

* **Accessibility & Usability**
  * Enhanced ARIA attributes and dynamic labeling in the autocomplete popup for clearer distinction between secrets and variables, improving accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->