### PR TITLE
[16.0][IMP] cetmix_tower_server References in files

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -732,3 +732,9 @@ class CxTowerFile(models.Model):
             if file.server_response == "ok":
                 vals.update({"sync_date_last": last_sync_date})
             file.sudo().write(vals)
+
+    # Check cx.tower.reference.mixin for the function documentation
+    def _get_pre_populated_model_data(self):
+        res = super()._get_pre_populated_model_data()
+        res.update({"cx.tower.file": ["cx.tower.server", "server_id"]})
+        return res

--- a/cetmix_tower_server/readme/newsfragments/4870.feature
+++ b/cetmix_tower_server/readme/newsfragments/4870.feature
@@ -1,0 +1,1 @@
+Make file references server dependent to be more unique

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -101,7 +101,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
-                <field name="reference" optional="show" />
+                <field name="reference" optional="hide" />
                 <field name="file_type" optional="show" />
                 <field name="file_name" optional="show" />
                 <field name="server_dir" optional="hide" />

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -28,7 +28,11 @@
                     <group>
                         <group>
                             <field name="name" widget="ace_tower" />
-                            <field name="reference" />
+                            <!-- This is done to get the priority to the auto generated reference -->
+                            <field
+                                name="reference"
+                                attrs="{'invisible': [('reference', '=', False)]}"
+                            />
                             <field name="source" required="1" />
                             <field name="file_type" />
                             <field name="id" invisible="1" />
@@ -148,10 +152,10 @@
             <tree>
                 <field name="name" optional="hide" />
                 <field name="rendered_name" optional="show" />
+                <field name="reference" optional="hide" />
                 <field name="full_server_path" optional="hide" />
                 <field name="source" />
                 <field name="file_type" optional="show" />
-                <field name="file" widget="binary" optional="hide" filename="name" />
                 <field name="server_id" />
                 <field name="sync_date_last" optional="show" />
                 <field name="template_id" optional="show" />
@@ -171,6 +175,7 @@
         <field name="arch" type="xml">
             <search string="Search Files">
                 <field name="name" />
+                <field name="reference" />
                 <field name="server_id" />
                 <field name="server_dir" />
                 <filter


### PR DESCRIPTION
Before this commit references for files were generated based on the file name. This was too generic and could lead to conflicts when importing servers together with files.
Because there could be another file with the same and reference belonging to another server.

After this commit references are generated based on the server reference thus minimizing the risk of conflicts.

File views are modified:

- List view: removed the file content field, added the reference field
- Form view: reference field is not shown for new records. This is done to give priority to the auto generated reference. However, the reference can be edited later if needed.
- Search view: search by reference

Task: 4870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the display and search options for the "reference" field in file-related views, making it easier to locate and manage references.
  * Made file references server-dependent to improve their uniqueness.

* **Style**
  * Adjusted default visibility of the "reference" field in file template lists; it is now shown by default but can be optionally hidden.

* **Bug Fixes**
  * Improved conditional display of the "reference" field in file forms to ensure it only appears when relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->