### PR TITLE
[17.0][IMP] cetmix_tower_server File references

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -732,3 +732,9 @@ class CxTowerFile(models.Model):
             if file.server_response == "ok":
                 vals.update({"sync_date_last": last_sync_date})
             file.sudo().write(vals)
+
+    # Check cx.tower.reference.mixin for the function documentation
+    def _get_pre_populated_model_data(self):
+        res = super()._get_pre_populated_model_data()
+        res.update({"cx.tower.file": ["cx.tower.server", "server_id"]})
+        return res

--- a/cetmix_tower_server/readme/newsfragments/4870.feature
+++ b/cetmix_tower_server/readme/newsfragments/4870.feature
@@ -1,0 +1,1 @@
+Make file references server dependent to be more unique

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -101,7 +101,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
-                <field name="reference" optional="show" />
+                <field name="reference" optional="hide" />
                 <field name="file_type" optional="show" />
                 <field name="file_name" optional="show" />
                 <field name="server_dir" optional="hide" />

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -29,10 +29,7 @@
                         <group>
                             <field name="name" widget="ace_tower" />
                             <!-- This is done to get the priority to the auto generated reference -->
-                            <field
-                                name="reference"
-                                attrs="{'invisible': [('reference', '=', False)]}"
-                            />
+                            <field name="reference" invisible="not reference" />
                             <field name="source" required="1" />
                             <field name="file_type" />
                             <field name="id" invisible="1" />

--- a/cetmix_tower_server/views/cx_tower_file_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_view.xml
@@ -27,8 +27,12 @@
                 <sheet>
                     <group>
                         <group>
-                            <field name="name" />
-                            <field name="reference" />
+                            <field name="name" widget="ace_tower" />
+                            <!-- This is done to get the priority to the auto generated reference -->
+                            <field
+                                name="reference"
+                                attrs="{'invisible': [('reference', '=', False)]}"
+                            />
                             <field name="source" required="1" />
                             <field name="file_type" />
                             <field name="id" invisible="1" />
@@ -146,10 +150,10 @@
             <tree>
                 <field name="name" optional="hide" />
                 <field name="rendered_name" optional="show" />
+                <field name="reference" optional="hide" />
                 <field name="full_server_path" optional="hide" />
                 <field name="source" />
                 <field name="file_type" optional="show" />
-                <field name="file" widget="binary" optional="show" filename="name" />
                 <field name="server_id" />
                 <field name="sync_date_last" optional="show" />
                 <field name="template_id" optional="show" />
@@ -169,6 +173,7 @@
         <field name="arch" type="xml">
             <search string="Search Files">
                 <field name="name" />
+                <field name="reference" />
                 <field name="server_id" />
                 <field name="server_dir" />
                 <filter


### PR DESCRIPTION
Forward port https://github.com/cetmix/cetmix-tower/pull/361

Task 4874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File references are now server dependent, increasing their uniqueness.

* **User Interface**
  * The "name" field in file forms now uses the "ace_tower" widget.
  * The "reference" field is conditionally hidden in forms when empty and is optionally hidden by default in list views.
  * The "reference" field is now searchable.
  * The binary "file" field has been removed from the list view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->