### PR TITLE
[14.0][MIG] cetmix_tower: back port updates from 16.0

### DIFF
--- a/cetmix_tower_git/readme/newsfragments/4849.feature
+++ b/cetmix_tower_git/readme/newsfragments/4849.feature
@@ -1,0 +1,1 @@
+Export related commands and flight plans together with server

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -233,6 +233,22 @@ class CxTowerServer(models.Model):
         string="Shortcuts",
     )
 
+    command_ids = fields.Many2many(
+        comodel_name="cx.tower.command",
+        relation="cx_tower_server_command_rel",
+        column1="server_id",
+        column2="command_id",
+        string="Commands",
+    )
+
+    plan_ids = fields.Many2many(
+        comodel_name="cx.tower.plan",
+        relation="cx_tower_plan_cx_tower_server_rel",
+        column1="cx_tower_server_id",
+        column2="cx_tower_plan_id",
+        string="Flight Plans",
+    )
+    
     def _selection_status(self):
         """
         Status selection options

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -248,7 +248,7 @@ class CxTowerServer(models.Model):
         column2="cx_tower_plan_id",
         string="Flight Plans",
     )
-    
+
     def _selection_status(self):
         """
         Status selection options

--- a/cetmix_tower_yaml/models/cx_tower_server.py
+++ b/cetmix_tower_yaml/models/cx_tower_server.py
@@ -33,6 +33,8 @@ class CxTowerServer(models.Model):
             "shortcut_ids",
             "plan_delete_id",
             "file_ids",
+            "command_ids",
+            "plan_ids",
         ]
         return res
 
@@ -40,5 +42,10 @@ class CxTowerServer(models.Model):
         res = super()._get_force_x2m_resolve_models()
 
         # This is useful to avoid duplicating existing plans
-        res += ["cx.tower.shortcut"]
+        res += [
+            "cx.tower.shortcut",
+            "cx.tower.scheduled.task",
+            "cx.tower.command",
+            "cx.tower.plan",
+        ]
         return res

--- a/cetmix_tower_yaml/tests/__init__.py
+++ b/cetmix_tower_yaml/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_plan
 from . import test_yaml_export_wizard
 from . import test_yaml_import_wizard
 from . import test_server_log
+from . import test_server_yaml

--- a/cetmix_tower_yaml/tests/test_server_yaml.py
+++ b/cetmix_tower_yaml/tests/test_server_yaml.py
@@ -13,16 +13,15 @@ from odoo.tests import TransactionCase, tagged
 class TestServerYAML(TransactionCase):
     """YAML export/import tests for cx.tower.server with commands and plans."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        env = cls.env
-        cls.Server = env["cx.tower.server"]
-        cls.Command = env["cx.tower.command"]
-        cls.Plan = env["cx.tower.plan"]
+    def setUp(self):
+        super().setUp()
+        env = self.env
+        self.Server = env["cx.tower.server"]
+        self.Command = env["cx.tower.command"]
+        self.Plan = env["cx.tower.plan"]
 
         # Create a command to attach (use defaults for access_level)
-        cls.command = cls.Command.create(
+        self.command = self.Command.create(
             {
                 "name": "Test Command",
                 "reference": "test_command",
@@ -32,7 +31,7 @@ class TestServerYAML(TransactionCase):
         )
 
         # Create a flight plan to attach
-        cls.plan = cls.Plan.create(
+        self.plan = self.Plan.create(
             {
                 "name": "Test Flight Plan",
                 "reference": "test_plan",
@@ -42,7 +41,7 @@ class TestServerYAML(TransactionCase):
         )
 
         # Create server and link command and plan
-        cls.server = cls.Server.create(
+        self.server = self.Server.create(
             {
                 "name": "Server YAML Test",
                 "reference": "srv_yaml_test",
@@ -53,14 +52,19 @@ class TestServerYAML(TransactionCase):
                 "ssh_password": "dummy",
                 "use_sudo": False,
                 # Link the m2m fields
-                "command_ids": [(6, 0, [cls.command.id])],
-                "plan_ids": [(6, 0, [cls.plan.id])],
+                "command_ids": [(6, 0, [self.command.id])],
+                "plan_ids": [(6, 0, [self.plan.id])],
             }
         )
 
     def test_yaml_export_contains_command_and_plan(self):
         """Exported YAML include command_ids and plan_ids with correct references."""
-        data = yaml.safe_load(self.server.yaml_code)
+        # Support both field names: yaml (older) and yaml_code (newer)
+        if hasattr(self.server, "yaml"):
+            yaml_text = self.server.yaml
+        else:
+            yaml_text = self.server.yaml_code
+        data = yaml.safe_load(yaml_text)
         # Check command_ids
         self.assertIn(
             "command_ids",
@@ -102,14 +106,21 @@ class TestServerYAML(TransactionCase):
 
     def test_yaml_roundtrip_restores_command_and_plan(self):
         """A full export→delete→import cycle must restore the m2m relations."""
-        yaml_dict = yaml.safe_load(self.server.yaml_code)
+        # Support both field names: yaml and yaml_code
+        if hasattr(self.server, "yaml"):
+            yaml_text = self.server.yaml
+        else:
+            yaml_text = self.server.yaml_code
+        yaml_dict = yaml.safe_load(yaml_text)
         # Remove original server
         self.server.unlink()
         # Prepare values and import
         vals = self.Server._post_process_yaml_dict_values(yaml_dict)
-        restored = self.Server.with_context(
-            from_yaml=True, skip_ssh_settings_check=True
-        ).create(vals)
+        ctx = {
+            "from_yaml": True,
+            "skip_ssh_settings_check": True,
+        }
+        restored = self.Server.with_context(**ctx).create(vals)
 
         # Verify m2m links restored
         self.assertEqual(

--- a/cetmix_tower_yaml/tests/test_server_yaml.py
+++ b/cetmix_tower_yaml/tests/test_server_yaml.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+"""
+Tests for cx.tower.server YAML export/import covering command_ids and plan_ids.
+"""
+import yaml
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestServerYAML(TransactionCase):
+    """YAML export/import tests for cx.tower.server with commands and plans."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        cls.Server = env["cx.tower.server"]
+        cls.Command = env["cx.tower.command"]
+        cls.Plan = env["cx.tower.plan"]
+
+        # Create a command to attach (use defaults for access_level)
+        cls.command = cls.Command.create(
+            {
+                "name": "Test Command",
+                "reference": "test_command",
+                "action": "ssh_command",
+                "allow_parallel_run": False,
+            }
+        )
+
+        # Create a flight plan to attach
+        cls.plan = cls.Plan.create(
+            {
+                "name": "Test Flight Plan",
+                "reference": "test_plan",
+                "allow_parallel_run": False,
+                "color": 0,
+            }
+        )
+
+        # Create server and link command and plan
+        cls.server = cls.Server.create(
+            {
+                "name": "Server YAML Test",
+                "reference": "srv_yaml_test",
+                "ip_v4_address": "127.0.0.1",
+                "ssh_username": "admin",
+                "ssh_port": 22,
+                "ssh_auth_mode": "p",
+                "ssh_password": "dummy",
+                "use_sudo": False,
+                # Link the m2m fields
+                "command_ids": [(6, 0, [cls.command.id])],
+                "plan_ids": [(6, 0, [cls.plan.id])],
+            }
+        )
+
+    def test_yaml_export_contains_command_and_plan(self):
+        """Exported YAML include command_ids and plan_ids with correct references."""
+        data = yaml.safe_load(self.server.yaml_code)
+        # Check command_ids
+        self.assertIn(
+            "command_ids",
+            data,
+            "`command_ids` is missing from YAML export",
+        )
+        self.assertIsInstance(
+            data["command_ids"], list, "`command_ids` should be a list in YAML"
+        )
+        self.assertTrue(
+            data["command_ids"],
+            "`command_ids` list should not be empty",
+        )
+        # Only reference should be exported
+        self.assertEqual(
+            data["command_ids"][0],
+            self.command.reference,
+            "Exported command reference does not match",
+        )
+
+        # Check plan_ids
+        self.assertIn(
+            "plan_ids",
+            data,
+            "`plan_ids` is missing from YAML export",
+        )
+        self.assertIsInstance(
+            data["plan_ids"], list, "`plan_ids` should be a list in YAML"
+        )
+        self.assertTrue(
+            data["plan_ids"],
+            "`plan_ids` list should not be empty",
+        )
+        self.assertEqual(
+            data["plan_ids"][0],
+            self.plan.reference,
+            "Exported plan reference does not match",
+        )
+
+    def test_yaml_roundtrip_restores_command_and_plan(self):
+        """A full export→delete→import cycle must restore the m2m relations."""
+        yaml_dict = yaml.safe_load(self.server.yaml_code)
+        # Remove original server
+        self.server.unlink()
+        # Prepare values and import
+        vals = self.Server._post_process_yaml_dict_values(yaml_dict)
+        restored = self.Server.with_context(
+            from_yaml=True, skip_ssh_settings_check=True
+        ).create(vals)
+
+        # Verify m2m links restored
+        self.assertEqual(
+            restored.command_ids.ids,
+            [self.command.id],
+            "`command_ids` were not restored correctly",
+        )
+        self.assertEqual(
+            restored.plan_ids.ids,
+            [self.plan.id],
+            "`plan_ids` were not restored correctly",
+        )


### PR DESCRIPTION
Back port the following PR:

[[16.0][IMP] cetmix_tower_yaml: export server’s command_ids and plan_ids](https://github.com/cetmix/cetmix-tower/pull/358/commits/9ba4ba368b074f4c47781813a74efa1a05bba57a)

Task: 4872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Servers now support grouping and exporting related commands and flight plans together.
* **Bug Fixes**
  * Improved YAML export and import to include commands and flight plans, ensuring relationships are preserved.
* **Tests**
  * Added tests to verify correct YAML export and import of server-related commands and flight plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->