### PR TITLE
[16.0][MIG] cetmix_tower_server: forward port updates

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -166,6 +166,26 @@ class CxTowerCommand(models.Model):
         column2="variable_id",
     )
 
+    if_file_exists = fields.Selection(
+        selection=[
+            ("skip", "Skip"),
+            ("overwrite", "Overwrite"),
+            ("raise", "Raise Error"),
+        ],
+        default="skip",
+        help="What to do if file already exists on the server.\n"
+        "- Skip: Do not create or update the file.\n"
+        "- Overwrite: Replace the existing file with the new one.\n"
+        "- Raise Error: Raise an error if the file already exists.",
+    )
+    disconnect_file = fields.Boolean(
+        string="Disconnect from Template",
+        help=(
+            "If enabled, disconnects the file from its template "
+            "after running the command.\n"
+        ),
+    )
+
     # ---- Access. Add relation for mixin fields
     user_ids = fields.Many2many(
         relation="cx_tower_command_user_rel",

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -127,7 +127,7 @@ class CxTowerFileTemplate(models.Model):
         return action
 
     # -- Business logic
-    def create_file(self, server, server_dir="", raise_if_exists=False):
+    def create_file(self, server, server_dir="", if_file_exists="raise"):
         """
         Create a new file using the current template for the selected server.
         If the same file already exists, just ignore it or raise an error based on the
@@ -136,45 +136,86 @@ class CxTowerFileTemplate(models.Model):
         :param server: recordset
             The server (cx.tower.server) on which the file should be created. This is a
             required parameter.
+        :param if_file_exists: str, optional
+            Defines the behavior if the file already exists on the server.
         :param server_dir: str, optional
             The directory on the server where the file should be created. If not set,
             the server_dir field of the template will be used.
-        :param raise_if_exists: bool, optional
-            If set to True, raises a ValidationError if the file already exists on the
-            server. Defaults to False.
 
         :return: cx.tower.file
             Returns the newly created file record (cx.tower.file) if the file was
-            created successfully. Returns the existing file record if the file already
-            exists and raise_if_exists is False.
+            created successfully or if_file_exists is set to "overwrite".
+            Returns the existing file record if the file already exists
+            and if_file_exists is set to "skip".
 
         :raises ValidationError:
-            If the file already exists on the server and raise_if_exists is True.
+            If the file already exists on the server if_file_exists is set to "raise".
         """
         self.ensure_one()
+        # Explicit guard against invalid behavior values
+        valid_behaviors = {"skip", "raise", "overwrite"}
+        if if_file_exists not in valid_behaviors:
+            raise ValidationError(
+                f"Invalid if_file_exists value: {if_file_exists}. "
+                f"Expected one of {valid_behaviors}."
+            )
         file_model = self.env["cx.tower.file"]
-        existing_file = file_model.search(
+        existing_files = file_model.search(
             [
-                ("template_id", "=", self.id),
                 ("server_id", "=", server.id),
-                ("server_dir", "=", server_dir or self.server_dir),
                 ("source", "=", self.source),
             ],
-            limit=1,
+            order="id DESC",
         )
-        if existing_file:
-            if raise_if_exists:
-                raise ValidationError(_("File already exists on server."))
+        existing_dir = server_dir or self.server_dir
+
+        # Render the server directory and file name from the template
+        variables = list(
+            set(
+                self.get_variables_from_code(self.file_name)
+                + self.get_variables_from_code(existing_dir)
+            )
+        )
+        var_vals = server.get_variable_values(variables).get(server.id) or {}
+
+        unrendered_path = f"{existing_dir}/{self.file_name}"
+        rendered_path = self.render_code_custom(unrendered_path, **var_vals)
+
+        # Filter existing files by rendered path
+        existing_files = existing_files.filtered(
+            lambda f: f.full_server_path == rendered_path
+        )
+
+        # Filter existing files by template if it exists, otherwise take the first one
+        existing_file = (
+            existing_files.filtered(lambda f: f.template_id == self)[:1]
+            or existing_files[:1]
+        )
+
+        if existing_file and if_file_exists == "skip":
+            return existing_file.with_context(file_creation_skipped=True)
+
+        if existing_file and if_file_exists == "raise":
+            raise ValidationError(_("File already exists on server."))
+
+        if existing_file and if_file_exists == "overwrite":
+            existing_file.with_context(is_custom_server_dir=True).write(
+                {
+                    "template_id": self.id,
+                }
+            )
             return existing_file
 
-        return file_model.with_context(is_custom_server_dir=True).create(
-            {
-                "template_id": self.id,
-                "server_id": server.id,
-                "name": self.file_name,
-                "code_on_server": self.code,
-                "server_dir": server_dir or self.server_dir,
-                "file_type": self.file_type,
-                "source": self.source,
-            }
-        )
+        vals = {
+            "name": self.file_name,
+            "server_id": server.id,
+            "server_dir": existing_dir,
+            "template_id": self.id,
+            "code": self.code,
+            "file_type": self.file_type,
+            "source": self.source,
+        }
+
+        new_file = file_model.with_context(is_custom_server_dir=True).create(vals)
+        # Return new_file if no file exists
+        return new_file

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1164,7 +1164,6 @@ class CxTowerServer(models.Model):
         elif command.action == "file_using_template":
             response = self._command_runner_file_using_template(
                 log_record,
-                command.file_template_id,
                 rendered_command_path,
                 **kwargs,
             )
@@ -1216,7 +1215,6 @@ class CxTowerServer(models.Model):
     def _command_runner_file_using_template(
         self,
         log_record,
-        file_template_id,
         server_dir,
         **kwargs,
     ):
@@ -1232,8 +1230,6 @@ class CxTowerServer(models.Model):
         Args:
             log_record (recordset): The log record to update with the command's
                 status.
-            file_template_id (recordset): The file template to use for creating
-                the new file.
             server_dir (str): The directory on the server where the file should be
                 created.
             **kwargs: Additional keyword arguments.
@@ -1248,10 +1244,10 @@ class CxTowerServer(models.Model):
         """
         try:
             # Attempt to create a new file using the template for the current server
-            file = file_template_id.create_file(
+            file = log_record.command_id.file_template_id.create_file(
                 server=self,
+                if_file_exists=log_record.command_id.if_file_exists,
                 server_dir=server_dir,
-                raise_if_exists=True,
             )
 
             # If file creation failed, log the failure and exit
@@ -1271,16 +1267,32 @@ class CxTowerServer(models.Model):
                 else:
                     return command_result
 
-            if file.source == "server":
-                file.action_pull_from_server()
-            elif file.source == "tower":
-                file.action_push_to_server()
-            else:
-                raise UserError(
-                    _(
-                        "File source cannot be determined: '%(source)s'",
-                        source=file.source,
+            # Context is used to detect a retry
+            # and avoid handling skip logic on first attempt
+            is_creation_skipped = file._context.get("file_creation_skipped")
+
+            if not is_creation_skipped:
+                if file.source == "server":
+                    file.action_pull_from_server()
+                elif file.source == "tower":
+                    file.action_push_to_server()
+                else:
+                    raise UserError(
+                        _(
+                            "File source cannot be determined: '%(source)s'",
+                            source=file.source,
+                        )
                     )
+
+            if log_record.command_id.disconnect_file:
+                file.action_unlink_from_template()
+
+            if is_creation_skipped:
+                return log_record.finish(
+                    fields.Datetime.now(),
+                    0,
+                    _("File already exists on server. Upload skipped"),
+                    None,
                 )
 
             # Log the successful creation and upload of the file

--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -313,7 +313,7 @@ class CxTowerServerTemplate(models.Model):
         logs = server.server_log_ids.filtered(lambda rec: rec.log_type == "file")
         for log in logs.sudo():
             log.file_id = log.file_template_id.create_file(
-                server=server, raise_if_exists=False
+                server=server, if_file_exists="skip"
             ).id
 
         flight_plan = server.server_template_id.flight_plan_id

--- a/cetmix_tower_server/readme/newsfragments/4740.feature
+++ b/cetmix_tower_server/readme/newsfragments/4740.feature
@@ -1,0 +1,1 @@
+Optional behaviour when file uploaded by command already exists on the server.

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -169,6 +169,7 @@ class TestTowerCommon(BaseCommon):
                 "path": "/home/{{ tower.server.username }}",
                 "action": "file_using_template",
                 "file_template_id": cls.template_file_tower.id,
+                "if_file_exists": "raise",
             }
         )
 
@@ -178,6 +179,7 @@ class TestTowerCommon(BaseCommon):
                 "path": "/home/{{ tower.server.username }}",
                 "action": "file_using_template",
                 "file_template_id": cls.template_file_server.id,
+                "if_file_exists": "raise",
             }
         )
 

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -1310,6 +1310,110 @@ result = re.sub(pattern, replacement, value)
         self.assertEqual(len(command_log), 1, "Must be a single log record")
         self.assertEqual(command_log.command_status, ANOTHER_COMMAND_RUNNING)
 
+    def test_file_using_template_create_if_exists(self):
+        """Test uploading file using template if it exists on server."""
+
+        command = self.command_create_file_with_template_server_source
+        command.write({"if_file_exists": "skip"})
+
+        # Create file to make sure that it exists on the server
+        file_template = command.file_template_id
+        orig_file = file_template.create_file(
+            server=self.server_test_1,
+            server_dir=file_template.server_dir,
+            if_file_exists=command.if_file_exists,
+        )
+
+        self.assertTrue(orig_file, "File must be created on the server")
+
+        # Test if file exists and command is set to "skip"
+        skipped_file = file_template.create_file(
+            server=self.server_test_1,
+            server_dir=file_template.server_dir,
+            if_file_exists=command.if_file_exists,
+        )
+        self.assertEqual(
+            orig_file,
+            skipped_file,
+            "Skip should return the existing file, not create a new one",
+        )
+        self.assertEqual(
+            self.env["cx.tower.file"].search_count(
+                [
+                    ("template_id", "=", file_template.id),
+                    ("server_id", "=", self.server_test_1.id),
+                ]
+            ),
+            1,
+            "There must be exactly one physical file record after skip",
+        )
+
+        # Change command to raise an error if file exists
+        command.write({"if_file_exists": "raise"})
+        with self.assertRaisesRegex(
+            ValidationError,
+            "File already exists on server.",
+        ):
+            file_template.create_file(
+                server=self.server_test_1,
+                server_dir=file_template.server_dir,
+                if_file_exists=command.if_file_exists,
+            )
+        # Change command to "overwrite" file if it exists
+        command.write({"if_file_exists": "overwrite"})
+        # Run command again, it should overwrite the file
+        file_template.create_file(
+            server=self.server_test_1,
+            server_dir=file_template.server_dir,
+            if_file_exists=command.if_file_exists,
+        )
+        self.assertEqual(
+            self.env["cx.tower.file"].search_count(
+                [
+                    ("template_id", "=", file_template.id),
+                    ("server_id", "=", self.server_test_1.id),
+                    ("server_dir", "=", file_template.server_dir),
+                ]
+            ),
+            1,
+            "There must be exactly one physical file record after overwrite",
+        )
+        self.assertEqual(
+            orig_file.code,
+            file_template.code,
+            "File code must match template after overwrite",
+        )
+        self.assertEqual(
+            orig_file.name,
+            file_template.file_name,
+            "File name must match template after overwrite",
+        )
+        self.assertEqual(
+            orig_file.source,
+            file_template.source,
+            "File source must match template after overwrite",
+        )
+
+    def test_is_file_disconnected_from_template(self):
+        """Test if file is disconnected from template after being created."""
+
+        initial_files = self.server_test_1.file_ids
+        command = self.command_create_file_with_template_server_source
+
+        command.disconnect_file = True
+        self.server_test_1.run_command(command=command)
+
+        new_files = self.server_test_1.file_ids - initial_files
+        self.assertEqual(len(new_files), 1, "Must be one new file created")
+        self.assertEqual(
+            new_files.code_on_server,
+            command.file_template_id.code,
+            "File code must match template",
+        )
+        self.assertFalse(
+            new_files.template_id, "File must be disconnected from template"
+        )
+
     # ---------------------
     # *********************
     #   Python commands

--- a/cetmix_tower_server/tests/test_file.py
+++ b/cetmix_tower_server/tests/test_file.py
@@ -305,7 +305,11 @@ class TestTowerFile(TestTowerCommon):
             }
         )
 
-        file = file_template.create_file(server=self.server_test_1)
+        file = file_template.create_file(
+            server=self.server_test_1,
+            server_dir=file_template.server_dir,
+            if_file_exists="overwrite",
+        )
         self.assertEqual(file.code, self.file_template.code)
         self.assertEqual(file.template_id, file_template)
         self.assertEqual(file.server_id, self.server_test_1)
@@ -313,10 +317,16 @@ class TestTowerFile(TestTowerCommon):
         self.assertEqual(file.server_dir, self.file_template.server_dir)
 
         with self.assertRaises(exceptions.ValidationError):
-            file_template.create_file(server=self.server_test_1, raise_if_exists=True)
+            file_template.create_file(
+                server=self.server_test_1,
+                server_dir=file_template.server_dir,
+                if_file_exists="raise",
+            )
 
         another_file = file_template.create_file(
-            server=self.server_test_1, raise_if_exists=False
+            server=self.server_test_1,
+            server_dir=file_template.server_dir,
+            if_file_exists="skip",
         )
         self.assertEqual(another_file, file)
 
@@ -346,13 +356,13 @@ class TestTowerFile(TestTowerCommon):
             file_template.create_file(
                 server=self.server_test_1,
                 server_dir="/var/tmp/custom",
-                raise_if_exists=True,
+                if_file_exists="raise",
             )
 
         another_file = file_template.create_file(
             server=self.server_test_1,
             server_dir="/var/tmp/custom",
-            raise_if_exists=False,
+            if_file_exists="skip",
         )
         self.assertEqual(another_file, file)
 

--- a/cetmix_tower_server/views/cx_tower_command_view.xml
+++ b/cetmix_tower_server/views/cx_tower_command_view.xml
@@ -72,6 +72,17 @@
                                 attrs="{'invisible': [('action', '=', 'python_code')]}"
                                 placeholder="optional, eg /home/{{ tower.server.username }}"
                             />
+                            <field
+                                name="if_file_exists"
+                                attrs="{
+                                    'invisible': [('action', '!=', 'file_using_template')],
+                                    'required': [('action', '=', 'file_using_template')],
+                                }"
+                            />
+                            <field
+                                name="disconnect_file"
+                                attrs="{'invisible': [('action', '!=', 'file_using_template')]}"
+                            />
                             <field name="allow_parallel_run" />
                             <field
                                 name="no_split_for_sudo"

--- a/cetmix_tower_yaml/models/cx_tower_command.py
+++ b/cetmix_tower_yaml/models/cx_tower_command.py
@@ -25,5 +25,7 @@ class CxTowerCommand(models.Model):
             "variable_ids",
             "secret_ids",
             "no_split_for_sudo",
+            "if_file_exists",
+            "disconnect_file",
         ]
         return res

--- a/cetmix_tower_yaml/readme/newsfragments/4740.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/4740.feature
@@ -1,0 +1,1 @@
+Optional behaviour when file uploaded by command already exists on the server.

--- a/cetmix_tower_yaml/tests/test_command.py
+++ b/cetmix_tower_yaml/tests/test_command.py
@@ -35,6 +35,8 @@ server_status: false
 variable_ids: false
 secret_ids: false
 no_split_for_sudo: false
+if_file_exists: skip
+disconnect_file: false
 """
 
         # YAML content translated into Python dict
@@ -112,6 +114,16 @@ Ensure all fields are rendered properly.""",
             self.command_test_yaml_dict["reference"],
             "YAML value doesn't match Cetmix Tower one",
         )
+        self.assertEqual(
+            command_test.if_file_exists,
+            self.command_test_yaml_dict["if_file_exists"],
+            "YAML value doesn't match Cetmix Tower one",
+        )
+        self.assertEqual(
+            command_test.disconnect_file,
+            self.command_test_yaml_dict["disconnect_file"],
+            "YAML value doesn't match Cetmix Tower one",
+        )
 
     def test_command_from_yaml(self):
         """Test if YAML is generated properly from a command"""
@@ -162,6 +174,16 @@ Ensure all fields are rendered properly.""",
             self.assertEqual(
                 command.reference,
                 self.command_test_yaml_dict["reference"],
+                "YAML value doesn't match Cetmix Tower one",
+            )
+            self.assertEqual(
+                command.if_file_exists,
+                self.command_test_yaml_dict["if_file_exists"],
+                "YAML value doesn't match Cetmix Tower one",
+            )
+            self.assertEqual(
+                command.disconnect_file,
+                self.command_test_yaml_dict["disconnect_file"],
                 "YAML value doesn't match Cetmix Tower one",
             )
 
@@ -249,6 +271,8 @@ server_status: false
 variable_ids: false
 secret_ids: false
 no_split_for_sudo: false
+if_file_exists: skip
+disconnect_file: false
 """
         # Add file template
         file_template = self.env["cx.tower.file.template"].create(
@@ -312,6 +336,8 @@ server_status: false
 variable_ids: false
 secret_ids: false
 no_split_for_sudo: false
+if_file_exists: skip
+disconnect_file: false
 """
         command_with_template.invalidate_recordset(["yaml_code"])
         self.assertEqual(

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -106,6 +106,8 @@ records:
   code: echo 'Test Command From Yaml'
   server_status: false
   no_split_for_sudo: false
+  if_file_exists: skip
+  disconnect_file: false
 - cetmix_tower_model: command
   access_level: manager
   reference: test_command_from_yaml_2
@@ -117,6 +119,8 @@ records:
   code: echo 'Test Command From Yaml 2'
   server_status: false
   no_split_for_sudo: false
+  if_file_exists: skip
+  disconnect_file: false
 """
 
         # -- 1 --


### PR DESCRIPTION
Forward port the following PR:

[[14.0][IMP] cetmix_tower_server: file create command update #309](https://github.com/cetmix/cetmix-tower/pull/309)

Task: 4871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to control file creation when using templates: users can now choose to skip, overwrite, or raise an error if a file already exists.
  * Introduced an option to disconnect created files from their templates after execution.
  * Updated user interface to display these new options when relevant.

* **Bug Fixes**
  * Improved handling and messaging when attempting to create files that already exist.

* **Tests**
  * Expanded test coverage for file existence handling and template disconnection scenarios.
  * Updated YAML-related tests to include new fields.

* **Documentation**
  * Enhanced help texts and YAML export to reflect new file handling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->