### PR TITLE
[16.0][IMP] cetmix_tower_server,cetmix_tower_server_queue: run child flight plan commands one by one in job queue

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -74,7 +74,15 @@ class CxTowerPlanLog(models.Model):
         help="Custom message to be displayed in the plan log",
     )
     parent_flight_plan_log_id = fields.Many2one(
-        "cx.tower.plan.log", string="Main Log", ondelete="cascade"
+        "cx.tower.plan.log",
+        string="Main Log",
+        related="parent_command_log_id.plan_log_id",
+    )
+    parent_command_log_id = fields.Many2one(
+        "cx.tower.command.log",
+        readonly=True,
+        ondelete="cascade",
+        help="Command that triggered this flight plan",
     )
     scheduled_task_id = fields.Many2one(
         "cx.tower.scheduled.task",
@@ -203,6 +211,10 @@ class CxTowerPlanLog(models.Model):
             plan_status (Integer) plan execution code
             **kwargs (dict): optional values
         """
+        if not self.is_running:
+            # TODO: CHECK WHY IT POSSIBLE RUNNING FOR STOPPER PLAN
+            return
+
         values = {
             "is_running": False,
             "plan_status": plan_status,
@@ -228,6 +240,9 @@ class CxTowerPlanLog(models.Model):
             else:
                 # Set deletion error if flightplan failed
                 self.server_id.status = "delete_error"
+
+        if self.parent_command_log_id:
+            self.parent_command_log_id.finish(status=plan_status)
 
     def record(self, server, plan, status, start_date=None, finish_date=None, **kwargs):
         """

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1376,7 +1376,7 @@ class CxTowerServer(models.Model):
             # Generate custom label and add values for log
             kwargs["plan_log"] = {
                 "label": generate_random_id(4),
-                "parent_flight_plan_log_id": log_record.plan_log_id.id,
+                "parent_command_log_id": log_record.id,
             }
             # add executed command with action "plan" to save link to plan log
             kwargs["flight_plan_command_log"] = log_record
@@ -1397,7 +1397,7 @@ class CxTowerServer(models.Model):
                 error = _("Flight plan running error")
 
         result = {"status": status, "response": response, "error": error}
-        if log_record:
+        if log_record and not plan_log_record.is_running:
             log_record.finish(
                 finish_date=fields.Datetime.now(),
                 status=result["status"],

--- a/cetmix_tower_server/tests/common.py
+++ b/cetmix_tower_server/tests/common.py
@@ -138,7 +138,7 @@ class TestTowerCommon(BaseCommon):
         )
         cls.command_list_dir = cls.Command.create(
             {
-                "name": "Test create directory",
+                "name": "Test list directory",
                 "path": "/home/{{ tower.server.username }}",
                 "code": "cd {{ test_path_ }} && ls -l",
             }

--- a/cetmix_tower_server/tests/test_shortcut.py
+++ b/cetmix_tower_server/tests/test_shortcut.py
@@ -26,7 +26,7 @@ class TestTowerShortcut(TestTowerCommon):
         # Command
         cls.command_list_dir_pro = cls.Command.create(
             {
-                "name": "Test create directory",
+                "name": "Test list directory",
                 "code": "ls -l {{ test_path_ }}",
             }
         )

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -21,7 +21,7 @@ class CxTowerServer(models.Model):
         # this plan should be launched as a synchronous command to
         # preserve the order of execution of commands with action “Run flight plan”.
         # Use runner only if command log record is provided.
-        if log_record and not log_record.plan_log_id.parent_flight_plan_log_id:
+        if log_record.command_action != "plan":
             job = self.with_delay()._command_runner(
                 command=command,
                 log_record=log_record,

--- a/cetmix_tower_server_queue/tests/__init__.py
+++ b/cetmix_tower_server_queue/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_command
 from . import test_command_log
 from . import test_file
+from . import test_flight_plan_queue

--- a/cetmix_tower_server_queue/tests/test_flight_plan_queue.py
+++ b/cetmix_tower_server_queue/tests/test_flight_plan_queue.py
@@ -1,0 +1,219 @@
+from unittest.mock import patch
+
+from odoo.addons.cetmix_tower_server.tests.common import TestTowerCommon
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+
+class TestFlightPlanQueue(TestTowerCommon):
+    """End-to-end queue-job tests for flight-plan execution."""
+
+    def setUp(self):
+        super().setUp()
+
+        # 1️. Flight‑plans
+        self.fp1 = self.Plan.create({"name": "FP-1"})
+        self.fp2 = self.Plan.create({"name": "FP-2"})
+        self.fp3 = self.Plan.create({"name": "FP-3"})
+
+        # 2️. Commands “run another plan”
+        self.cmd_run_fp2 = self.Command.create(
+            {"name": "run FP-2", "action": "plan", "flight_plan_id": self.fp2.id}
+        )
+        self.cmd_run_fp3 = self.Command.create(
+            {"name": "run FP-3", "action": "plan", "flight_plan_id": self.fp3.id}
+        )
+
+        # 3️. Extra command used by FP‑1
+        self.cmd_list_all = self.Command.create(
+            {
+                "name": "list all",
+                "path": "/home/{{ tower.server.username }}",
+                "code": "cd {{ test_path_ }} && ls -al",
+            }
+        )
+
+    def _drain_queue(self, trap):
+        """Synchronously perform every job until the queue is empty."""
+        while trap.enqueued_jobs:
+            trap.perform_enqueued_jobs()
+
+    def _assert_jobs(self, trap, expected):
+        """Fail if the total number of delayed jobs is not *expected*."""
+        self.assertEqual(
+            len(trap.calls),
+            expected,
+            f"{expected} delayed jobs were expected, got {len(trap.calls)}",
+        )
+
+    def test_flight_plan_flat_chain_queue(self):
+        """Flat chain produces five delayed jobs."""
+        # Flight‑plan 1: FP‑2 (mkdir -> ls) -> list all -> FP‑3 (mkdir -> ls)
+
+        # ─ Flight‑plan 1:  FP‑2 -> list all -> FP‑3
+        self.plan_line.create(
+            {
+                "sequence": 5,
+                "plan_id": self.fp1.id,
+                "command_id": self.cmd_run_fp2.id,
+            }
+        )
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": self.fp1.id,
+                "command_id": self.cmd_list_all.id,
+            }
+        )
+        self.plan_line.create(
+            {
+                "sequence": 15,
+                "plan_id": self.fp1.id,
+                "command_id": self.cmd_run_fp3.id,
+            }
+        )
+        # ─ Flight‑plan 2:  mkdir -> ls
+        self.plan_line.create(
+            {
+                "sequence": 5,
+                "plan_id": self.fp2.id,
+                "command_id": self.command_create_dir.id,
+            }
+        )
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": self.fp2.id,
+                "command_id": self.command_list_dir.id,
+            }
+        )
+        # ─ Flight‑plan 3:  mkdir -> ls
+        self.plan_line.create(
+            {
+                "sequence": 5,
+                "plan_id": self.fp3.id,
+                "command_id": self.command_create_dir.id,
+            }
+        )
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": self.fp3.id,
+                "command_id": self.command_list_dir.id,
+            }
+        )
+
+        # Ensure no command logs exist yet
+        self.assertFalse(
+            self.env["cx.tower.command.log"].search(
+                [("plan_log_id.plan_id", "=", self.fp1.id)]
+            ),
+            "Command logs should be empty before run",
+        )
+
+        # Run FP‑1 and drain the queue
+        with trap_jobs() as trap:
+            self.fp1._run_single(self.server_test_1)
+            self._drain_queue(trap)
+
+            # Expected delayed commands:
+            #   FP‑2: mkdir, ls
+            #   FP‑1: list‑all
+            #   FP‑3: mkdir, ls
+            self._assert_jobs(trap, expected=5)
+
+    def test_flight_plan_nested_chain_queue(self):
+        """Nested chain produces three delayed jobs."""
+        # Flight‑plan 1: FP‑2 (FP‑3 (mkdir -> ls)) -> list all
+
+        # ─ Flight‑plan 1:  FP‑2 -> list all
+        self.plan_line.create(
+            {"sequence": 5, "plan_id": self.fp1.id, "command_id": self.cmd_run_fp2.id}
+        )
+        self.plan_line.create(
+            {"sequence": 10, "plan_id": self.fp1.id, "command_id": self.cmd_list_all.id}
+        )
+
+        # ─ Flight‑plan 2: FP‑3
+        self.plan_line.create(
+            {"sequence": 5, "plan_id": self.fp2.id, "command_id": self.cmd_run_fp3.id}
+        )
+
+        # ─ Flight‑plan 3: (mkdir -> ls)
+        self.plan_line.create(
+            {
+                "sequence": 5,
+                "plan_id": self.fp3.id,
+                "command_id": self.command_create_dir.id,
+            }
+        )
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": self.fp3.id,
+                "command_id": self.command_list_dir.id,
+            }
+        )
+
+        # No command logs expected yet
+        self.assertFalse(
+            self.env["cx.tower.command.log"].search(
+                [("plan_log_id.plan_id", "=", self.fp1.id)]
+            ),
+            "Command logs should be empty before run",
+        )
+
+        # Run FP‑1 and drain the queue
+        with trap_jobs() as trap:
+            self.fp1._run_single(self.server_test_1)
+            self._drain_queue(trap)
+            # Expected delayed commands:
+            #   FP‑1: list‑all
+            #   FP‑3: mkdir, ls
+            self._assert_jobs(trap, expected=3)
+
+    def test_flight_plan_failed_child_queue(self):
+        """Parent flight plan should not run if child flight plan failed."""
+
+        # Flight‑plan 1: list all -> FP‑2 (list all, list all)
+        # -> FP‑2 (list all, list all) -> list all
+        self.plan_line.create(
+            {"sequence": 5, "plan_id": self.fp1.id, "command_id": self.cmd_list_all.id}
+        )
+        self.plan_line.create(
+            {"sequence": 10, "plan_id": self.fp1.id, "command_id": self.cmd_run_fp2.id}
+        )
+        self.plan_line.create(
+            {"sequence": 15, "plan_id": self.fp1.id, "command_id": self.cmd_run_fp2.id}
+        )
+        self.plan_line.create(
+            {"sequence": 20, "plan_id": self.fp1.id, "command_id": self.cmd_list_all.id}
+        )
+
+        # ─ Flight‑plan 2: list all
+        self.plan_line.create(
+            {"sequence": 5, "plan_id": self.fp2.id, "command_id": self.cmd_list_all.id}
+        )
+        self.plan_line.create(
+            {"sequence": 10, "plan_id": self.fp2.id, "command_id": self.cmd_list_all.id}
+        )
+
+        cx_tower_plan_obj = self.registry["cx.tower.plan"]
+        _run_single_super = cx_tower_plan_obj._run_single
+
+        def _run_single(this, *args, **kwargs):
+            if this == self.fp2:
+                # Simulate a failed Plan 2. To achieve this, we need to update
+                # the command associated with Plan 2 to apply the desired side effect.
+                self.fp2.line_ids[1].command_id[0].code = "fail"
+            return _run_single_super(this, *args, **kwargs)
+
+        with patch.object(
+            cx_tower_plan_obj, "_run_single", _run_single
+        ), trap_jobs() as trap:
+            self.fp1._run_single(self.server_test_1)
+            self._drain_queue(trap)
+            self._assert_jobs(trap, expected=2)
+
+        # Check flight plan logs
+        fp_logs = self.PlanLog.search([("plan_id", "=", self.fp1.id)])
+        self.assertEqual(len(fp_logs.command_log_ids), 2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of flight plan and command log relationships to prevent premature completion of logs during execution.
  * Updated conditional logic to ensure correct asynchronous job execution based on command actions.
  * Corrected test command names for clarity and accuracy.

* **Tests**
  * Added comprehensive end-to-end tests for flight plan queue execution, including flat, nested, and failure scenarios.
  * Integrated new flight plan queue tests into the overall test suite for better coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->