### PR TITLE
[17.0][FIX] cetmix_tower_server Python imports

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -14,7 +14,7 @@
     "application": False,
     "installable": True,
     "external_dependencies": {
-        "python": ["paramiko", "tldextract", "dnspython"],
+        "python": ["paramiko<4", "tldextract", "dnspython"],
     },
     "depends": [
         "mail",

--- a/cetmix_tower_server/readme/newsfragments/4891.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4891.bugfix
@@ -1,0 +1,1 @@
+Pin paramiko version to "<4" to maintain compatibility with legacy installations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # generated from manifests external_dependencies
 boto3
 dnspython
-paramiko
+paramiko<4
 pyyaml
 tldextract


### PR DESCRIPTION
Pin 'paramiko' package version to "<4" to maintain compatibility with legacy installations.

Task: 4891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the paramiko package dependency to limit versions to below 4, ensuring compatibility with legacy installations.

* **Documentation**
  * Added a note explaining the paramiko version pinning for compatibility purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->