### PR TITLE
[14.0][FIX] cetmix_tower_server Python imports

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -14,7 +14,7 @@
     "application": False,
     "installable": True,
     "external_dependencies": {
-        "python": ["paramiko", "tldextract", "dnspython"],
+        "python": ["paramiko<4", "tldextract", "dnspython"],
     },
     "depends": [
         "mail",

--- a/cetmix_tower_server/readme/newsfragments/4891.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4891.bugfix
@@ -1,0 +1,1 @@
+Pin paramiko version to "<4" to maintain compatibility with legacy installations

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 boto3
 dnspython
 ovh
-paramiko
+paramiko<4
 pyyaml
 tldextract


### PR DESCRIPTION
Pin 'paramiko' package version to "<4" to maintain compatibility with legacy installations.

Backport of https://github.com/cetmix/cetmix-tower/pull/371

Task: 4893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency on the paramiko package to restrict versions to less than 4, ensuring compatibility with legacy installations.
* **Documentation**
  * Added a note about the paramiko version restriction for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->