### PR TITLE
[16.0][FIX] cetmix_tower_server: important updates

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -42,6 +42,7 @@
         "security/cx_tower_key_value_security.xml",
         "security/cx_tower_tag_security.xml",
         "security/cx_tower_shortcut_security.xml",
+        "security/cx_tower_server_wizard_access_rules.xml",
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",
         "data/ir_config_parameter.xml",

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, fields, models
+from odoo.exceptions import AccessError
 from odoo.tools import plaintext2html
 
 
@@ -43,7 +44,7 @@ class CxTowerServerLog(models.Model):
         groups="cetmix_tower_server.group_root,cetmix_tower_server.group_manager",
         help="File that will be executed to get the log data",
     )
-    log_text = fields.Html(readonly=True)
+    log_text = fields.Html(readonly=True, copy=False)
 
     # --- Server template related
     server_template_id = fields.Many2one("cx.tower.server.template", ondelete="cascade")
@@ -86,11 +87,19 @@ class CxTowerServerLog(models.Model):
             "target": "current",
         }
 
+    def write(self, vals):
+        """Override to protect log_text from direct modifications.
+        Bypass with context key 'cx_allow_log_text_update' for internal updates.
+        """
+        if "log_text" in vals and not self.env.context.get("cx_allow_log_text_update"):
+            raise AccessError(_("You are not allowed to modify the server log output."))
+        return super().write(vals)
+
     def action_get_log_text(self):
         """Update log text from source"""
 
         # We are using `sudo` to override command/file access limitations
-        for rec in self.sudo():
+        for rec in self.sudo().with_context(cx_allow_log_text_update=True):
             if rec.log_type == "file" and rec.file_id:
                 log_text = rec._get_log_from_file()
             elif rec.log_type == "command" and rec.command_id:

--- a/cetmix_tower_server/models/res_partner.py
+++ b/cetmix_tower_server/models/res_partner.py
@@ -24,7 +24,7 @@ class ResPartner(models.Model):
         "partner_id",
         string="Secrets",
         domain=[("key_id.key_type", "=", "s")],
-        groups="cetmix_tower_server.group_user",
+        groups="cetmix_tower_server.group_manager",
     )
 
     @api.depends("server_ids", "child_ids.server_count")

--- a/cetmix_tower_server/readme/newsfragments/4866.feature
+++ b/cetmix_tower_server/readme/newsfragments/4866.feature
@@ -1,0 +1,1 @@
+Improve access settings for logs

--- a/cetmix_tower_server/security/cx_tower_server_wizard_access_rules.xml
+++ b/cetmix_tower_server/security/cx_tower_server_wizard_access_rules.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+
+        <!-- cx.tower.command.run.wizard -->
+        <record id="rule_cx_tower_command_run_wizard_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_command_run_wizard" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+        <!-- cx.tower.plan.run.wizard -->
+        <record id="rule_cx_tower_plan_run_wizard_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_plan_run_wizard" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+        <!-- cx.tower.server.host.key.wizard -->
+        <record id="rule_cx_tower_server_host_key_wizard_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_server_host_key_wizard" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+        <!-- cx.tower.server.template.create.wizard -->
+        <record
+        id="rule_cx_tower_server_template_create_wizard_creator_only"
+        model="ir.rule"
+    >
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_server_template_create_wizard" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+</odoo>

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -26,7 +26,8 @@ access_key_root,Key->Root,model_cx_tower_key,group_root,1,1,1,1
 access_key_value_manager,Key Value->Manager,model_cx_tower_key_value,group_manager,1,1,1,1
 access_key_value_root,Key Value->Root,model_cx_tower_key_value,group_root,1,1,1,1
 access_command_log_user,Command Log->User,model_cx_tower_command_log,group_user,1,0,0,0
-access_command_log_root,Command Log->User,model_cx_tower_command_log,group_root,1,1,1,1
+access_command_log_manager,Command Log->Manager,model_cx_tower_command_log,group_user,1,0,0,0
+access_command_log_root,Command Log->User,model_cx_tower_command_log,group_root,1,0,0,0
 access_plan_user,Plan->User,model_cx_tower_plan,group_user,1,0,0,0
 access_plan_manager,Plan->Manager,model_cx_tower_plan,group_manager,1,1,1,1
 access_plan_root,Plan->Root,model_cx_tower_plan,group_root,1,1,1,1
@@ -37,7 +38,8 @@ access_plan_line_action_user,Plan Line Action->User,model_cx_tower_plan_line_act
 access_plan_line_action_manager,Plan Line Action->Manager,model_cx_tower_plan_line_action,group_manager,1,1,1,1
 access_plan_line_action_root,Plan Line Action->Root,model_cx_tower_plan_line_action,group_root,1,1,1,1
 access_plan_log_user,Plan Log->User,model_cx_tower_plan_log,group_user,1,0,0,0
-access_plan_log_root,Plan Log->User,model_cx_tower_plan_log,group_root,1,1,1,1
+access_plan_log_manager,Plan Log->Manager,model_cx_tower_plan_log,group_manager,1,0,0,0
+access_plan_log_root,Plan Log->User,model_cx_tower_plan_log,group_root,1,0,0,0
 access_file_user,File->User,model_cx_tower_file,group_user,1,0,0,0
 access_file_manager,File->Manager,model_cx_tower_file,group_manager,1,1,1,1
 access_file_root,File->Root,model_cx_tower_file,group_root,1,1,1,1

--- a/cetmix_tower_server/tests/test_command_log.py
+++ b/cetmix_tower_server/tests/test_command_log.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
+from odoo.exceptions import AccessError
 
 from .common import TestTowerCommon
 
@@ -224,10 +225,10 @@ class TestTowerCommandLog(TestTowerCommon):
             " in users_ids or manager_ids",
         )
 
-    def test_root_unrestricted_access(self):
-        """Test root user unrestricted access"""
-        # Create test logs with various conditions
-        test_logs = self.CommandLog.with_user(self.root).create(
+    def test_root_read_only_access(self):
+        """Root can read all command logs, but cannot create/modify/delete"""
+        # Create test logs with sudo()
+        test_logs = self.CommandLog.sudo().create(
             [
                 {
                     "server_id": self.server_2.id,
@@ -241,6 +242,23 @@ class TestTowerCommandLog(TestTowerCommon):
                 ]
             ]
         )
+        # Root cannot create logs
+        with self.assertRaises(AccessError):
+            self.CommandLog.with_user(self.root).create(
+                {
+                    "server_id": self.server_2.id,
+                    "command_id": self.command_level_1.id,
+                    "start_date": fields.Datetime.now(),
+                }
+            )
+
+        # Root cannot modify logs
+        with self.assertRaises(AccessError):
+            test_logs.with_user(self.root).write({"start_date": fields.Datetime.now()})
+
+        # Root cannot delete logs
+        with self.assertRaises(AccessError):
+            test_logs.with_user(self.root).unlink()
 
         # Root should be able to read all logs regardless of:
         # - access_level

--- a/cetmix_tower_server/tests/test_plan_log.py
+++ b/cetmix_tower_server/tests/test_plan_log.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
+from odoo.exceptions import AccessError
 
 from .common import TestTowerCommon
 
@@ -221,10 +222,10 @@ class TestTowerPlanLog(TestTowerCommon):
             " in users_ids or manager_ids",
         )
 
-    def test_root_unrestricted_access(self):
-        """Test root user unrestricted access"""
-        # Create test logs with various conditions
-        test_logs = self.PlanLog.with_user(self.root).create(
+    def test_root_read_only_access(self):
+        """Root can read all plan logs, but cannot create/modify/delete"""
+        # Create test logs with sudo()
+        test_logs = self.PlanLog.sudo().create(
             [
                 {
                     "server_id": self.server_2.id,
@@ -245,6 +246,24 @@ class TestTowerPlanLog(TestTowerCommon):
             3,
             "Root should have unrestricted read access to all logs",
         )
+
+        # Root can't create logs
+        with self.assertRaises(AccessError):
+            self.PlanLog.with_user(self.root).create(
+                {
+                    "server_id": self.server_2.id,
+                    "plan_id": self.plan_level_1.id,
+                    "start_date": fields.Datetime.now(),
+                }
+            )
+
+        # Root cannot modify logs
+        with self.assertRaises(AccessError):
+            test_logs.with_user(self.root).write({"start_date": fields.Datetime.now()})
+
+        # Root cannot delete logs
+        with self.assertRaises(AccessError):
+            test_logs.with_user(self.root).unlink()
 
         # Test read on all records
         all_recs = self.PlanLog.with_user(self.root).search([])

--- a/cetmix_tower_server/tests/test_server_log.py
+++ b/cetmix_tower_server/tests/test_server_log.py
@@ -237,3 +237,79 @@ class TestTowerServerLog(TestTowerCommon):
             test_logs.unlink()
         except AccessError:
             self.fail("Root should be able to unlink any logs")
+
+    def test_log_text_access_restrictions(self):
+        """Test log_text field access controls"""
+        test_log = self.ServerLog.create(
+            {
+                "name": "Access Test Log",
+                "server_id": self.server_test_1.id,
+                "log_type": "file",
+                "access_level": "1",
+                "log_text": "<p>Test content</p>",
+            }
+        )
+
+        # 1. Verify read access for all roles
+        for user in (self.root, self.manager, self.user):
+            content = test_log.with_user(user).log_text
+            self.assertEqual(
+                content, "<p>Test content</p>", f"{user.name} should read log_text"
+            )
+
+        # 2. Verify write prohibition for all roles
+        for user in (self.root, self.manager, self.user):
+            with self.assertRaises(
+                AccessError, msg=f"{user.name} shouldn't modify log_text"
+            ):
+                test_log.with_user(user).write({"log_text": "<p>Modified</p>"})
+
+    def test_log_text_refresh_mechanism(self):
+        """Test log_text can only be updated via refresh action"""
+        test_log = self.ServerLog.sudo().create(
+            {
+                "name": "Refresh Test Log",
+                "server_id": self.server_test_1.id,
+                "log_type": "file",
+                "access_level": "1",
+                "log_text": "<p>Initial</p>",
+            }
+        )
+
+        # 1. Direct write attempts should fail
+        with self.assertRaises(AccessError):
+            test_log.sudo().write({"log_text": "<p>Illegal Update</p>"})
+
+        # 2. Verify refresh action updates content
+        original_content = test_log.log_text
+        test_log.action_get_log_text()
+
+        self.assertNotEqual(
+            test_log.log_text,
+            original_content,
+            "action_get_log_text() should update log_text",
+        )
+
+        self.assertTrue(
+            test_log.log_text.startswith("<p>"),
+            "Refreshed content should be valid HTML",
+        )
+
+    def test_log_text_copy(self):
+        """Duplicating a log must NOT keep the log output"""
+        original = self.ServerLog.create(
+            {
+                "name": "Original Log",
+                "server_id": self.server_test_1.id,
+                "log_type": "file",
+                "access_level": "1",
+                "log_text": "<p>Original content</p>",
+            }
+        )
+
+        copied = original.copy()
+
+        # log_text must be cleared because copy=False
+        self.assertFalse(copied.log_text, "Copied log must not keep log_text")
+        self.assertNotEqual(copied.id, original.id)
+        self.assertTrue(bool(copied.name))

--- a/cetmix_tower_server/views/res_partner_view.xml
+++ b/cetmix_tower_server/views/res_partner_view.xml
@@ -22,7 +22,11 @@
       <xpath expr="//sheet/notebook" position="inside">
         <page string="Cetmix Tower" groups="cetmix_tower_server.group_user">
           <group>
-              <group name="group_secrets" string="Secrets">
+              <group
+                            name="group_secrets"
+                            string="Secrets"
+                            groups="cetmix_tower_server.group_manager"
+                        >
                 <field name="secret_ids" string="">
                   <tree editable="bottom">
                     <field


### PR DESCRIPTION
- Command logs: no-one can edit logs, even root
- Flight Plan logs: no-one can edit logs, even root
- Server Logs: log output is read-only field now
- Add a global “Creator only” access rule to all wizards to avoid data leakage
- Fix an issue with opening partner form while not being a Tower/Manager group member 

Task: 4866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened tests to enforce read-only behavior for command, plan, and server logs; ensure create/write/delete attempts raise access errors and verify log refresh and copy behaviors.

* **Security**
  * Added creator-only access rules for several wizards and limited visibility of partner "Secrets" to manager-level users.

* **Refactor**
  * Prevented direct edits to server log text; updates only via the log refresh mechanism.

* **Documentation**
  * Added a release-note fragment describing improved log access settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->