### PR TITLE
[16.0][FIX] cetmix_tower_yaml: important updates

### DIFF
--- a/cetmix_tower_yaml/__manifest__.py
+++ b/cetmix_tower_yaml/__manifest__.py
@@ -14,6 +14,7 @@
     "external_dependencies": {"python": ["pyyaml"]},
     "data": [
         "security/cetmix_tower_yaml_groups.xml",
+        "security/cx_tower_yaml_wizard_access_rules.xml",
         "security/ir.model.access.csv",
         "views/cx_tower_command_view.xml",
         "views/cx_tower_file_template_view.xml",

--- a/cetmix_tower_yaml/migrations/16.0.1.4.1/post-migration.py
+++ b/cetmix_tower_yaml/migrations/16.0.1.4.1/post-migration.py
@@ -1,0 +1,19 @@
+def migrate(cr, version):
+    """
+    Normalize existing license values to lowercase.
+    Runs only on upgrade (version != False).
+    """
+    if not version:
+        return
+    # Skip rows already lowercase for efficiency
+    cr.execute(
+        """
+        UPDATE cx_tower_yaml_manifest_tmpl
+           SET license = LOWER(TRIM(license))
+         WHERE license IS NOT NULL
+           AND (
+                license <> LOWER(license)
+             OR license <> TRIM(license)
+           )
+    """
+    )

--- a/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
@@ -46,31 +46,36 @@ class CxTowerYamlManifestTemplate(models.Model):
         default="1.0.0",
     )
 
+    file_prefix = fields.Char(
+        string="File prefix",
+        help="Add prefix to the exported YAML file name when this template is selected",
+    )
+
     @api.model
     def _selection_license(self):
         """Return available license options for manifest."""
         return [
-            ("AGPL-3", "AGPL-3"),
-            ("LGPL-3", "LGPL-3"),
-            ("MIT", "MIT"),
-            ("Custom", "Custom"),
+            ("agpl-3", "AGPL-3"),
+            ("lgpl-3", "LGPL-3"),
+            ("mit", "MIT"),
+            ("custom", _("Custom")),
         ]
 
     @api.model
     def _selection_currency(self):
         """Return available currency options for manifest pricing."""
         return [
-            ("EUR", "Euro"),
-            ("USD", "US Dollar"),
+            ("EUR", _("Euro")),
+            ("USD", _("US Dollar")),
         ]
 
     @api.constrains("license", "license_text")
     def _check_license_text_for_custom(self):
-        """Ensure that custom license text is provided when license is 'Custom'."""
+        """Ensure that custom license text is provided when license is 'custom'."""
         for rec in self:
-            if rec.license == "Custom" and not rec.license_text:
+            if rec.license == "custom" and not (rec.license_text or "").strip():
                 raise ValidationError(
-                    _("Provide Custom License Text when License is set to “Custom”.")
+                    _("Provide Custom License Text when License is set to 'Custom'.")
                 )
 
     @api.constrains("version")

--- a/cetmix_tower_yaml/readme/newsfragments/4896.bugfix
+++ b/cetmix_tower_yaml/readme/newsfragments/4896.bugfix
@@ -1,0 +1,1 @@
+Make selection values lowercase to simplify their management.

--- a/cetmix_tower_yaml/security/cx_tower_yaml_wizard_access_rules.xml
+++ b/cetmix_tower_yaml/security/cx_tower_yaml_wizard_access_rules.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+
+        <!-- cx.tower.yaml.export.wiz -->
+        <record id="rule_cx_tower_yaml_export_wiz_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_yaml_export_wiz" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+         <!-- cx.tower.yaml.export.wiz.download -->
+
+        <record
+        id="rule_cx_tower_yaml_export_wiz_download_creator_only"
+        model="ir.rule"
+    >
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_yaml_export_wiz_download" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+        <!-- cx.tower.yaml.import.wiz -->
+        <record id="rule_cx_tower_yaml_import_wiz_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_yaml_import_wiz" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+        <!-- cx.tower.yaml.import.wiz.upload -->
+        <record id="rule_cx_tower_yaml_import_wiz_upload_creator_only" model="ir.rule">
+            <field name="name">Creator only</field>
+            <field name="model_id" ref="model_cx_tower_yaml_import_wiz_upload" />
+            <field name="global" eval="True" />
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+        </record>
+
+</odoo>

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -323,3 +323,53 @@ records:
         act = wiz.action_generate_yaml_file()
         download = self.env["cx.tower.yaml.export.wiz.download"].browse(act["res_id"])
         self.assertTrue(download.yaml_file_name.endswith(".yaml"))
+
+    def test_custom_requires_text(self):
+        """Creating a template with license 'custom' but no text must fail"""
+        with self.assertRaises(ValidationError):
+            self.env["cx.tower.yaml.manifest.tmpl"].create(
+                {
+                    "name": "Bad Manifest",
+                    "license": "custom",
+                }
+            )
+
+        tmpl_ok = self.env["cx.tower.yaml.manifest.tmpl"].create(
+            {
+                "name": "Good Manifest",
+                "license": "custom",
+                "license_text": "Custom license terms",
+            }
+        )
+        self.assertEqual(tmpl_ok.license, "custom")
+        self.assertEqual(tmpl_ok.license_text, "Custom license terms")
+
+        with self.assertRaises(ValidationError):
+            self.env["cx.tower.yaml.manifest.tmpl"].create(
+                {
+                    "name": "Bad Manifest 2",
+                    "license": "custom",
+                    "license_text": "    ",
+                }
+            )
+
+    def test_wizard_resets_price_on_license_change(self):
+        """Wizard must reset price/currency when license changes away from 'custom'"""
+        wiz = self.YamlExportWizard.new(
+            {
+                "manifest_license": "custom",
+                "manifest_price": 42.0,
+                "manifest_currency": "EUR",
+            }
+        )
+        wiz.manifest_license = "agpl-3"
+        wiz._onchange_manifest_license()
+        self.assertEqual(wiz.manifest_price, 0.0)
+        self.assertFalse(wiz.manifest_currency)
+
+        wiz.manifest_price = 7.5
+        wiz.manifest_currency = "USD"
+        wiz.manifest_license = "custom"
+        wiz._onchange_manifest_license()
+        self.assertEqual(wiz.manifest_price, 7.5)
+        self.assertEqual(wiz.manifest_currency, "USD")

--- a/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
+++ b/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
@@ -5,6 +5,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="file_prefix" />
                 <field name="author_ids" widget="many2many_tags" />
                 <field name="version" />
                 <field name="website" />
@@ -21,17 +22,18 @@
                 <sheet>
                     <group>
                         <field name="name" />
+                        <field name="file_prefix" />
                         <field name="author_ids" widget="many2many_tags" />
                         <field name="version" />
                         <field name="website" />
                         <field name="license" />
                         <field
                             name="license_text"
-                            attrs="{'invisible': [('license', '!=', 'Custom')]}"
+                            attrs="{'invisible': [('license', '!=', 'custom')]}"
                         />
                         <field
                             name="currency"
-                            attrs="{'invisible': [('license', '!=', 'Custom')]}"
+                            attrs="{'invisible': [('license', '!=', 'custom')]}"
                         />
                     </group>
                 </sheet>

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -145,7 +145,6 @@ class CxTowerYamlExportWiz(models.TransientModel):
     @api.depends("manifest_template_id")
     def _compute_manifest(self):
         mapping = {
-            "manifest_name": "name",
             "manifest_author_ids": "author_ids",
             "manifest_website": "website",
             "manifest_license": "license",
@@ -161,15 +160,33 @@ class CxTowerYamlExportWiz(models.TransientModel):
                 if not rec[wiz_field]:
                     rec[wiz_field] = tmpl[tmpl_field]
 
+            # prepend template's file prefix to YAML file name
+            prefix = (tmpl.file_prefix or "").strip()
+            if prefix:
+                # sanitize prefix without defaulting to a placeholder like "snippet"
+                raw = prefix.lower()
+                sanitized_prefix = re.sub(r"_+", "_", CLEAN_STR.sub("_", raw)).strip(
+                    "_"
+                )
+                if sanitized_prefix:
+                    # use current or default base name, then clean it
+                    current = rec.yaml_file_name or rec._default_yaml_file_name()
+                    base = rec._clean_yaml_basename(current)
+                    # avoid double-prefixing
+                    if not base.startswith(f"{sanitized_prefix}_"):
+                        rec.yaml_file_name = rec._clean_yaml_basename(
+                            f"{sanitized_prefix}_{base}"
+                        )
+
     @api.onchange("manifest_license")
     def _onchange_manifest_license(self):
-        """Drop price and currency when user switches off the 'Custom' license.
+        """Drop price and currency when user switches off the 'custom' license.
 
-        If manifest_license != 'Custom', reset manifest_price to 0.0 and
+        If manifest_license != 'custom', reset manifest_price to 0.0 and
         manifest_currency to False so they won’t appear in the generated YAML.
         """
         for rec in self:
-            if rec.manifest_license != "Custom":
+            if rec.manifest_license != "custom":
                 rec.manifest_price = 0.0
                 rec.manifest_currency = False
 
@@ -220,6 +237,8 @@ class CxTowerYamlExportWiz(models.TransientModel):
         if not self.manifest_name:
             manifest = {}
         else:
+            lic = (self.manifest_license or "").lower()
+
             fields_order = [
                 ("name", self.manifest_name),
                 ("summary", self.manifest_summary),
@@ -230,16 +249,14 @@ class CxTowerYamlExportWiz(models.TransientModel):
                 ("license", self.manifest_license),
                 (
                     "license_text",
-                    self.manifest_license_text
-                    if self.manifest_license == "Custom"
+                    (self.manifest_license_text or "").strip()
+                    if lic == "custom"
                     else None,
                 ),
                 ("price", self.manifest_price),
                 (
                     "currency",
-                    self.manifest_currency
-                    if self.manifest_license == "Custom"
-                    else None,
+                    self.manifest_currency if lic == "custom" else None,
                 ),
             ]
             manifest = {k: v for k, v in fields_order if v not in (False, None, "", [])}
@@ -283,7 +300,9 @@ class CxTowerYamlExportWiz(models.TransientModel):
         """Logical cross-checks before saving YAML."""
         if self.manifest_price and not self.manifest_currency:
             raise ValidationError(_("Currency is required when price is specified"))
-        if self.manifest_license == "Custom" and not self.manifest_license_text:
+        if (self.manifest_license or "").lower() == "custom" and not (
+            self.manifest_license_text or ""
+        ).strip():
             raise ValidationError(_("License text is required for a custom license"))
 
     def write(self, vals):

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.xml
@@ -59,7 +59,7 @@
                         />
                         <field
                             name="manifest_price"
-                            attrs="{'invisible': [('manifest_license', '!=', 'Custom')]}"
+                            attrs="{'invisible': [('manifest_license', '!=', 'custom')]}"
                         />
                         <field
                             name="manifest_currency"
@@ -85,7 +85,7 @@
 
                     <page
                         string="License text"
-                        attrs="{'invisible': [('manifest_license', '!=', 'Custom')]}"
+                        attrs="{'invisible': [('manifest_license', '!=', 'custom')]}"
                     >
                         <field
                             name="manifest_license_text"
@@ -93,7 +93,7 @@
                             nolabel="1"
                             colspan="4"
                             placeholder="License text"
-                            attrs="{'required': [('manifest_license', '=', 'Custom')]}"
+                            attrs="{'required': [('manifest_license', '=', 'custom')]}"
                         />
                     </page>
 


### PR DESCRIPTION
- Added creator-only access rules for all wizards
- Ensured users can only access their own wizard instances
- Normalized all license values to lowercase
- Maintained backward compatibility for existing data

Task: 4896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Add file prefix on manifest templates to prefix exported YAML filenames.
  * Enforce version format (Major.Minor.Patch) with validation.
* Bug Fixes
  * Standardize license values to lowercase; UI visibility behaves correctly.
  * Require license text for “custom”; reset price/currency when switching away from “custom”.
* Chores
  * Limit YAML import/export wizard records to their creators for privacy.
  * Migrate existing license values to lowercase.
* Documentation
  * Add note explaining lowercase selection values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->