### PR TITLE
[17.0][FIX] cetmix_tower_yaml File upload

### DIFF
--- a/cetmix_tower_yaml/readme/newsfragments/4899.bugfix
+++ b/cetmix_tower_yaml/readme/newsfragments/4899.bugfix
@@ -1,0 +1,1 @@
+Error when uploading a YAML file while not being an Odoo "Access Rights" group member

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
@@ -104,7 +104,7 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
             raise ValidationError(_("YAML file doesn't contain any records"))
 
         # Collect and validate all record models
-        ir_model_obj = self.env["ir.model"]
+        ir_model_obj = self.env["ir.model"].sudo()
         unique_models = {}
 
         # First pass: check all records have models and collect unique models


### PR DESCRIPTION
Before this fix when a user that was not an Odoo "Access Rights" group member tried to upload a YAML file, the import wizard would fail with error: "You are not allowed to access 'Models' (ir.model) records.".

This fix allows the import wizard to be used by any user, even if they are not an Odoo "Access Rights" group member.

Task: 4899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error that occurred when uploading a YAML file without the necessary access rights, ensuring smoother uploads regardless of group membership.

* **Documentation**
  * Added a news entry describing the resolved permission issue during YAML file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->