### PR TITLE
[16.0][IMP] cetmix_tower_server/yaml UI/UX updates and code improvements

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -371,7 +371,7 @@ class CxTowerPlan(models.Model):
             command_log (cx.tower.command.log()): Command log record
         """
         self.ensure_one()
-        action, exit_code, plan_line_id = self._get_next_action_values(command_log)
+        action, exit_code, plan_line = self._get_next_action_values(command_log)
         plan_log = command_log.plan_log_id
 
         # Update log message
@@ -380,14 +380,14 @@ class CxTowerPlan(models.Model):
             exit_code = 0
 
         # Run next line
-        if action == "n" and plan_line_id:
+        if action == "n" and plan_line:
             server = command_log.server_id
-            if plan_line_id._is_executable_line(server):
-                plan_line_id._run(
+            if plan_line._is_executable_line(server):
+                plan_line._run(
                     server, plan_log, variable_values=plan_log.variable_values
                 )
             else:
-                plan_line_id._skip(server, plan_log)
+                plan_line._skip(server, plan_log)
 
         # Exit
         if action in ["e", "ec"]:

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -443,7 +443,7 @@ class CxTowerServer(models.Model):
         """Update selected log from its source."""
         for server in self:
             if server.server_log_ids:
-                server.server_log_ids.action_get_log_text()
+                server.server_log_ids.action_update_log()
 
     def action_open_command_logs(self):
         """

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, fields, models
 from odoo.exceptions import AccessError
-from odoo.tools import plaintext2html
 
 
 class CxTowerServerLog(models.Model):
@@ -44,7 +43,7 @@ class CxTowerServerLog(models.Model):
         groups="cetmix_tower_server.group_root,cetmix_tower_server.group_manager",
         help="File that will be executed to get the log data",
     )
-    log_text = fields.Html(readonly=True, copy=False)
+    log_text = fields.Text(readonly=True, copy=False)
 
     # --- Server template related
     server_template_id = fields.Many2one("cx.tower.server.template", ondelete="cascade")
@@ -77,7 +76,7 @@ class CxTowerServerLog(models.Model):
         Open log record in current window
         """
         self.ensure_one()
-        self.action_get_log_text()
+        self.action_update_log()
         return {
             "type": "ir.actions.act_window",
             "name": self.name,
@@ -95,52 +94,67 @@ class CxTowerServerLog(models.Model):
             raise AccessError(_("You are not allowed to modify the server log output."))
         return super().write(vals)
 
-    def action_get_log_text(self):
+    def action_update_log(self):
         """Update log text from source"""
 
         # We are using `sudo` to override command/file access limitations
         for rec in self.sudo().with_context(cx_allow_log_text_update=True):
-            if rec.log_type == "file" and rec.file_id:
-                log_text = rec._get_log_from_file()
-            elif rec.log_type == "command" and rec.command_id:
-                log_text = rec._get_log_from_command()
-            else:
-                log_text = self.NO_LOG_FETCHED_MESSAGE
-            rec.log_text = self._format_log_text(log_text)
+            rec.log_text = rec._get_formatted_log_text()
 
-    def _get_copied_name(self, force_name=None):
-        # Original name is preserved when log is duplicated
-        return force_name or self.name
-
-    def _format_log_text(self, log_text):
-        """Formats log text to prior to display it.
-        Override this function to implement custom log formatting.
-
-        Args:
-            log_text (Text): source log text
+    def _get_log_text(self):
+        """
+        Get log text from source
+        Use this function to get pure log text from source.
 
         Returns:
-            Html: formatted log text
+            Text: log text
         """
-        return plaintext2html(log_text)
+        self.ensure_one()
+        if self.log_type == "file" and self.file_id:
+            return self._get_log_from_file()
+        elif self.log_type == "command" and self.command_id:
+            return self._get_log_from_command()
+
+    def _get_formatted_log_text(self):
+        """
+        Get formatted log text.
+        Use this function to get formatted log text.
+
+        Returns:
+            Text: formatted log text
+        """
+        log_text = self._get_log_text()
+        if log_text:
+            return self._format_log_text(log_text)
+        return self.NO_LOG_FETCHED_MESSAGE
+
+    def _format_log_text(self, log_text):
+        """
+        Format log text.
+        Use this function to format log text.
+
+        Returns:
+            Text: formatted log text
+        """
+        return log_text
 
     def _get_log_from_file(self):
         """Get log from a file.
         Override this function to implement custom log handler
 
         Returns:
-            Text: log text. Supports HTML formatting
+            Text: log text
         """
         self.ensure_one()
         if self.file_id.source == "server":
-            return self.file_id.code or self.NO_LOG_FETCHED_MESSAGE
+            return self.file_id.code
         if self.file_id.source == "tower":
-            return self.file_id.code_on_server or self.NO_LOG_FETCHED_MESSAGE
+            return self.file_id.code_on_server
 
     def _get_log_from_command(self):
         """Get log from a command.
         Returns:
-            Text: log text. Supports HTML formatting
+            Text: log text
         """
         self.ensure_one()
 
@@ -157,3 +171,7 @@ class CxTowerServerLog(models.Model):
             elif error:
                 log_text = error
         return log_text
+
+    def _get_copied_name(self, force_name=None):
+        # Original name is preserved when log is duplicated
+        return force_name or self.name

--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -89,6 +89,7 @@ class TowerVariable(models.Model):
         relation="cx_tower_command_variable_rel",
         column1="variable_id",
         column2="command_id",
+        copy=False,
     )
     command_ids_count = fields.Integer(
         string="Command Count", compute="_compute_command_ids_count"
@@ -98,6 +99,7 @@ class TowerVariable(models.Model):
         relation="cx_tower_plan_line_variable_rel",
         column1="variable_id",
         column2="plan_line_id",
+        copy=False,
     )
     plan_line_ids_count = fields.Integer(
         string="Plan Line Count", compute="_compute_plan_line_ids_count"
@@ -107,6 +109,7 @@ class TowerVariable(models.Model):
         relation="cx_tower_file_variable_rel",
         column1="variable_id",
         column2="file_id",
+        copy=False,
     )
     file_ids_count = fields.Integer(
         string="File Count", compute="_compute_file_ids_count"
@@ -116,6 +119,7 @@ class TowerVariable(models.Model):
         relation="cx_tower_file_template_variable_rel",
         column1="variable_id",
         column2="file_template_id",
+        copy=False,
     )
     file_template_ids_count = fields.Integer(
         string="File Template Count", compute="_compute_file_template_ids_count"
@@ -125,6 +129,7 @@ class TowerVariable(models.Model):
         relation="cx_tower_variable_value_variable_rel",
         column1="variable_id",
         column2="variable_value_id",
+        copy=False,
     )
     variable_value_ids_count = fields.Integer(
         string="Variable Value Count", compute="_compute_variable_value_ids_count"

--- a/cetmix_tower_server/tests/test_server_log.py
+++ b/cetmix_tower_server/tests/test_server_log.py
@@ -282,17 +282,12 @@ class TestTowerServerLog(TestTowerCommon):
 
         # 2. Verify refresh action updates content
         original_content = test_log.log_text
-        test_log.action_get_log_text()
+        test_log.action_update_log()
 
         self.assertNotEqual(
             test_log.log_text,
             original_content,
-            "action_get_log_text() should update log_text",
-        )
-
-        self.assertTrue(
-            test_log.log_text.startswith("<p>"),
-            "Refreshed content should be valid HTML",
+            "action_update_log() should update log_text",
         )
 
     def test_log_text_copy(self):

--- a/cetmix_tower_server/views/cx_tower_server_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_log_view.xml
@@ -8,7 +8,7 @@
             <form>
                 <header>
                     <button
-                        name="action_get_log_text"
+                        name="action_update_log"
                         type="object"
                         class="oe_highlight"
                         string="Refresh"

--- a/cetmix_tower_server/views/menuitems.xml
+++ b/cetmix_tower_server/views/menuitems.xml
@@ -7,7 +7,7 @@
         groups="group_user"
         web_icon="cetmix_tower_server,static/description/icon.png"
     />
-    <!-- Servers -->
+    <!-- ========================= Servers ========================= -->
     <menuitem
         id="menu_cx_tower_server_root"
         name="Servers"
@@ -40,124 +40,58 @@
         sequence="15"
     />
 
-    <!-- Commands -->
+    <!-- ========================= Logs ========================= -->
+    <menuitem
+        id="menu_cx_tower_log_root"
+        name="Logs"
+        parent="menu_root"
+        sequence="20"
+    />
+    <menuitem
+        id="menu_cx_tower_command_log"
+        name="Command Log"
+        action="action_cx_tower_command_log"
+        parent="menu_cx_tower_log_root"
+        sequence="1"
+    />
+    <menuitem
+        id="menu_cx_tower_plan_log"
+        name="Flight Plan Log"
+        action="action_cx_tower_plan_log"
+        parent="menu_cx_tower_log_root"
+        sequence="2"
+    />
+
+    <!-- ========================= Commands ========================= -->
     <menuitem
         id="menu_cx_tower_command_root"
         name="Commands"
         parent="menu_root"
         groups="group_user"
-        sequence="3"
+        sequence="30"
     />
     <menuitem
         id="menu_cx_tower_command"
         name="Commands"
         action="action_cx_tower_command"
         parent="menu_cx_tower_command_root"
-        sequence="3"
+        sequence="10"
     />
     <menuitem
         id="menu_cx_tower_plan"
         name="Flight Plans"
         action="action_cx_tower_plan"
         parent="menu_cx_tower_command_root"
-        sequence="7"
-    />
-    <menuitem
-        id="menu_cx_tower_command_log"
-        name="Command Log"
-        action="action_cx_tower_command_log"
-        parent="menu_cx_tower_command_root"
-        sequence="70"
-    />
-    <menuitem
-        id="menu_cx_tower_plan_log"
-        name="Flight Plan Log"
-        action="action_cx_tower_plan_log"
-        parent="menu_cx_tower_command_root"
-        sequence="72"
-    />
-    <!-- Tools -->
-    <menuitem
-        id="menu_tools"
-        name="Tools"
-        parent="menu_root"
-        sequence="120"
-        groups="group_user"
-    />
-    <menuitem
-        id="menu_cx_tower_scheduled_task"
-        name="Scheduled Tasks"
-        action="action_cx_tower_scheduled_task"
-        parent="menu_tools"
-        sequence="1"
-        groups="group_manager"
+        sequence="20"
     />
 
-    <!-- Settings -->
-    <menuitem
-        id="menu_settings"
-        name="Settings"
-        parent="menu_root"
-        sequence="999"
-        groups="group_manager"
-    />
-    <menuitem
-        id="menu_cetmix_tower_general_settings"
-        name="General Settings"
-        parent="menu_settings"
-        sequence="0"
-        action="action_cetmix_tower_config_settings"
-        groups="group_manager"
-    />
-    <menuitem
-        id="menu_cx_tower_variable"
-        name="Variables"
-        action="action_cx_tower_variable"
-        parent="menu_settings"
-        sequence="3"
-    />
-    <menuitem
-        id="menu_cx_tower_variable_value"
-        name="Variable Values"
-        action="action_cx_tower_variable_value"
-        parent="menu_settings"
-        sequence="5"
-    />
-    <menuitem
-        id="menu_cx_tower_key"
-        name="Keys and Secrets"
-        action="action_cx_tower_key"
-        parent="menu_settings"
-        sequence="8"
-    />
-    <menuitem
-        id="menu_cx_tower_shortcut"
-        name="Shortcuts"
-        action="action_cx_tower_shortcut"
-        parent="menu_settings"
-        sequence="10"
-    />
-    <menuitem
-        id="menu_cx_tower_os"
-        name="OSs"
-        action="action_cx_tower_os"
-        parent="menu_settings"
-        sequence="100"
-    />
-    <menuitem
-        id="menu_cx_tower_tag"
-        name="Tags"
-        action="action_cx_tower_tag"
-        parent="menu_settings"
-        sequence="13"
-    />
-
+    <!-- ========================= Files ========================= -->
     <menuitem
         id="menu_cx_tower_file_root"
         name="Files"
-        parent="cetmix_tower_server.menu_root"
+        parent="menu_root"
         groups="cetmix_tower_server.group_user"
-        sequence="4"
+        sequence="40"
     />
     <menuitem
         id="menu_cx_tower_file"
@@ -173,5 +107,113 @@
         parent="menu_cx_tower_file_root"
         sequence="2"
     />
+
+    <!-- ========================= Tools ========================= -->
+    <menuitem
+        id="menu_tools"
+        name="Tools"
+        parent="menu_root"
+        sequence="40"
+        groups="group_user"
+    />
+
+
+    <!-- ========================= Settings ========================= -->
+    <menuitem
+        id="menu_settings"
+        name="Settings"
+        parent="menu_root"
+        sequence="50"
+        groups="group_manager"
+    />
+    <menuitem
+        id="menu_cetmix_tower_general_settings"
+        name="General Settings"
+        parent="menu_settings"
+        sequence="0"
+        action="action_cetmix_tower_config_settings"
+        groups="group_manager"
+    />
+    <!-- Variables -->
+    <menuitem
+        id="menu_cx_tower_variable_root"
+        name="Variables"
+        parent="menu_settings"
+        sequence="10"
+        groups="group_manager"
+    />
+    <menuitem
+        id="menu_cx_tower_variable"
+        name="Variables"
+        parent="menu_cx_tower_variable_root"
+        action="action_cx_tower_variable"
+        sequence="1"
+    />
+    <menuitem
+        id="menu_cx_tower_variable_value"
+        name="Variable Values"
+        action="action_cx_tower_variable_value"
+        parent="menu_cx_tower_variable_root"
+        sequence="2"
+    />
+
+    <!-- Keys and Secrets -->
+    <menuitem
+        id="menu_cx_tower_key_root"
+        name="Keys and Secrets"
+        parent="menu_settings"
+        sequence="20"
+    />
+    <menuitem
+        id="menu_cx_tower_key"
+        name="Keys and Secrets"
+        action="action_cx_tower_key"
+        parent="menu_cx_tower_key_root"
+        sequence="1"
+    />
+    <!-- Automation -->
+    <menuitem
+        id="menu_cx_tower_automation_root"
+        name="Automation"
+        parent="menu_settings"
+        sequence="30"
+    />
+    <menuitem
+        id="menu_cx_tower_scheduled_task"
+        name="Scheduled Tasks"
+        action="action_cx_tower_scheduled_task"
+        parent="menu_cx_tower_automation_root"
+        sequence="1"
+        groups="group_manager"
+    />
+    <menuitem
+        id="menu_cx_tower_shortcut"
+        name="Shortcuts"
+        action="action_cx_tower_shortcut"
+        parent="menu_cx_tower_automation_root"
+        sequence="2"
+    />
+    <!-- Properties -->
+    <menuitem
+        id="menu_cx_tower_property_root"
+        name="Properties"
+        parent="menu_settings"
+        sequence="500"
+    />
+    <menuitem
+        id="menu_cx_tower_os"
+        name="Operating Systems"
+        action="action_cx_tower_os"
+        parent="menu_cx_tower_property_root"
+        sequence="100"
+    />
+    <menuitem
+        id="menu_cx_tower_tag"
+        name="Tags"
+        action="action_cx_tower_tag"
+        parent="menu_cx_tower_property_root"
+        sequence="13"
+    />
+
 
 </odoo>

--- a/cetmix_tower_yaml/views/cx_tower_yaml_manifest_author_views.xml
+++ b/cetmix_tower_yaml/views/cx_tower_yaml_manifest_author_views.xml
@@ -29,11 +29,5 @@
         <field name="view_mode">tree,form</field>
         <field name="target">current</field>
     </record>
-    <menuitem
-        id="menu_yaml_manifest_author_action"
-        name="YAML Manifest Authors"
-        parent="cetmix_tower_server.menu_settings"
-        action="action_yaml_manifest_author"
-        sequence="17"
-    />
+
 </odoo>

--- a/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
+++ b/cetmix_tower_yaml/views/cx_tower_yaml_manifest_template_views.xml
@@ -46,11 +46,4 @@
         <field name="view_id" ref="view_yaml_manifest_template_tree" />
         <field name="target">current</field>
     </record>
-    <menuitem
-        id="menu_yaml_manifest_template"
-        name="YAML Manifest Templates"
-        parent="cetmix_tower_server.menu_settings"
-        action="action_yaml_manifest_template"
-        sequence="15"
-    />
 </odoo>

--- a/cetmix_tower_yaml/views/menuitems.xml
+++ b/cetmix_tower_yaml/views/menuitems.xml
@@ -1,4 +1,5 @@
 <odoo>
+    <!-- Import YAML -> Tools -->
     <menuitem
         id="menu_cetmix_tower_yaml_import"
         name="Import YAML"
@@ -6,5 +7,27 @@
         sequence="10"
         groups="group_import"
         action="action_cx_tower_yaml_import_wiz_upload"
+    />
+
+    <!-- YAML Manifest Settings -> Settings -->
+    <menuitem
+        id="menu_yaml_settings_root"
+        name="YAML Export/Import"
+        parent="cetmix_tower_server.menu_settings"
+        sequence="60"
+    />
+    <menuitem
+        id="menu_yaml_manifest_author_action"
+        name="Manifest Authors"
+        parent="menu_yaml_settings_root"
+        action="action_yaml_manifest_author"
+        sequence="1"
+    />
+    <menuitem
+        id="menu_yaml_manifest_template"
+        name="Manifest Templates"
+        parent="menu_yaml_settings_root"
+        action="action_yaml_manifest_template"
+        sequence="2"
     />
 </odoo>


### PR DESCRIPTION
- Re-arrange menu items to improve the usability and make adding new items easier.
- Rename the 'plan_line_id' variable into 'plan_line' in cx.tower.plan function def _run_next_action to match the OCA coding style.
- Server logs: 
  - Use text field instead of html field for log text. Because:
    - Quicker to render
    - Easier to extend later in customizations
  - Add helper functions to get log text and format it. This also allows to get log text from source without saving it to the database. This can be useful for the cases when log should be displayed and refreshed without saving it to the database.
- Variable: Don't copy m2m relations to related records when duplicating variable. Otherwise when you duplicate a variable all the related records of the original variable are linked.

Task 4909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Reorganized navigation: added top-level Logs and Files; Settings split into Automation, Properties, Variables, and Keys and Secrets.
  - YAML settings grouped under a new “YAML Export/Import” section.
- Refactor
  - Server logs now display as plain text with a unified Refresh action; the Refresh button was updated accordingly.
  - Server-triggered log updates now refresh associated logs.
  - Duplicating variables no longer copies related commands, files, plans, templates, or values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->