### PR TITLE
[17.0][IMP] cetmix_tower_server_notify_backend Button

### DIFF
--- a/cetmix_tower_server_notify_backend/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_notify_backend/models/cx_tower_command_log.py
@@ -9,9 +9,26 @@ class CxTowerCommandLog(models.Model):
 
     def _command_finished(self):
         res = super()._command_finished()
+
+        # Use context timestamp to avoid timezone issues
         context_timestamp = fields.Datetime.context_timestamp(
             self, fields.Datetime.now()
         )
+
+        # Action for button
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_server.action_cx_tower_command_log"
+        )
+        action.update(
+            {
+                "views": [(False, "form")],
+            }
+        )
+        context = self.env.context.copy()
+        params = dict(context.get("params") or {})
+        params["button_name"] = _("View Log")
+        context["params"] = params
+        action["context"] = context
 
         for rec in self:
             # Record might be deleted before we get here.
@@ -21,6 +38,15 @@ class CxTowerCommandLog(models.Model):
             # from a Flight Plan.
             if not rec.exists() or rec.plan_log_id:  # type: ignore
                 continue
+
+            # Add record id to the action
+            action.update(
+                {
+                    "res_id": rec.id,
+                }
+            )
+
+            # Send notification
             if rec.command_status == 0:
                 rec.create_uid.notify_success(
                     message=_(
@@ -30,6 +56,7 @@ class CxTowerCommandLog(models.Model):
                     ),
                     title=rec.server_id.name,
                     sticky=True,
+                    action=action,
                 )
             else:
                 rec.create_uid.notify_danger(
@@ -43,6 +70,7 @@ class CxTowerCommandLog(models.Model):
                     ),
                     title=rec.server_id.name,
                     sticky=True,
+                    action=action,
                 )
 
         return res

--- a/cetmix_tower_server_notify_backend/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server_notify_backend/models/cx_tower_plan_log.py
@@ -10,14 +10,39 @@ class CxTowerPlanLog(models.Model):
     def _plan_finished(self):
         res = super()._plan_finished()
 
+        # Use context timestamp to avoid timezone issues
         context_timestamp = fields.Datetime.context_timestamp(
             self, fields.Datetime.now()
         )
+
+        # Action for button
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_server.action_cx_tower_plan_log"
+        )
+        action.update(
+            {
+                "views": [(False, "form")],
+            }
+        )
+        context = self.env.context.copy()
+        params = dict(context.get("params") or {})
+        params["button_name"] = _("View Log")
+        context["params"] = params
+        action["context"] = context
+
         for log in self:
-            # don't notify if a plan that was runned from another plan has been executed
+            # don't notify if a plan that was run from another plan has been executed
             if log.parent_flight_plan_log_id:
                 continue
 
+            # Add record id to the action
+            action.update(
+                {
+                    "res_id": log.id,
+                }
+            )
+
+            # Send notification
             if log.plan_status == 0:
                 log.create_uid.notify_success(
                     message=_(
@@ -28,6 +53,7 @@ class CxTowerPlanLog(models.Model):
                     ),
                     title=log.server_id.name,
                     sticky=True,
+                    action=action,
                 )
             else:
                 log.create_uid.notify_danger(
@@ -41,6 +67,7 @@ class CxTowerPlanLog(models.Model):
                     ),
                     title=log.server_id.name,
                     sticky=True,
+                    action=action,
                 )
 
         return res

--- a/cetmix_tower_server_notify_backend/readme/newsfragments/4910.feature
+++ b/cetmix_tower_server_notify_backend/readme/newsfragments/4910.feature
@@ -1,0 +1,1 @@
+Show "View Log" button in notifications.


### PR DESCRIPTION
Show "View Log" button in notifications.
This allows to open the log record directly from the notification.

Forward port of https://github.com/cetmix/cetmix-tower/pull/382

Task 4918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notifications for command and plan logs now include a per-log “View Log” button that opens the specific log.
  - Notification messages display consistent, timezone-aware timestamps for clearer context.
- **Documentation**
  - Added a news fragment announcing the new “View Log” button in notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->