### PR TITLE
[ADD] cetmix_tower_server: implement vault for secrets

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -4,7 +4,6 @@
     "name": "Cetmix Tower Server",
     "summary": "Manage servers and applications from Odoo",
     "version": "16.0.1.7.2",
-    "development_status": "Beta",
     "category": "Productivity",
     "website": "https://tower.cetmix.com",
     "live_test_url": "https://cetmix.com/tower",

--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -18,6 +18,7 @@
     },
     "depends": [
         "mail",
+        "rpc_helper",
     ],
     "data": [
         "security/cetmix_tower_server_groups.xml",

--- a/cetmix_tower_server/migrations/16.0.2.0.0/post-migration.py
+++ b/cetmix_tower_server/migrations/16.0.2.0.0/post-migration.py
@@ -1,0 +1,119 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """
+    Move SSH credentials, host keys, SSH keys, and secret values
+    to the vault-backed storage.
+
+    """
+
+    # 1. SSH password and host key are now stored in secrets
+    _logger.info("Moving SSH password and host key to vault.")
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # Read SSH password and host key from servers using SQL query
+    cr.execute(
+        """
+        SELECT id, ssh_password, host_key
+        FROM cx_tower_server
+        WHERE ssh_password IS NOT NULL OR host_key IS NOT NULL
+    """
+    )
+    server_records = cr.fetchall()
+    server_model = env["cx.tower.server"]
+    success = False
+    try:
+        for record in server_records:
+            _logger.info(
+                f"Moving SSH password and host key to vault for server {record[0]}"
+            )
+            server_model.browse(record[0]).write(
+                {"ssh_password": record[1], "host_key": record[2]}
+            )
+        _logger.info("Moving SSH password and host key to vault completed.")
+        success = True
+    # Clear SSH password and host key from servers
+    except Exception as e:
+        _logger.error(f"Error moving SSH password and host key to vault: {e}")
+        raise e
+    finally:
+        if success:
+            cr.execute(
+                """
+                UPDATE cx_tower_server
+                SET ssh_password = NULL, host_key = NULL
+                WHERE ssh_password IS NOT NULL OR host_key IS NOT NULL
+            """
+            )
+            _logger.info("Cleared SSH password and host key from servers.")
+
+    # 2. SSH keys are now stored in secrets
+    _logger.info("Moving SSH keys to vault.")
+    success = False
+    # Read SSH keys from keys using SQL query
+    cr.execute(
+        """
+        SELECT id, secret_value
+        FROM cx_tower_key
+        WHERE key_type = 'k'
+    """
+    )
+    ssh_key_records = cr.fetchall()
+    ssh_key_model = env["cx.tower.key"]
+    try:
+        for record in ssh_key_records:
+            _logger.info(f"Moving SSH key to vault record {record[0]}")
+            ssh_key_model.browse(record[0]).write({"secret_value": record[1]})
+        _logger.info("Moving SSH keys to vault completed.")
+        success = True
+    except Exception as e:
+        _logger.error(f"Error moving SSH keys to vault: {e}")
+        raise e
+    finally:
+        if success:
+            # Clear SSH key from keys
+            cr.execute(
+                """
+                UPDATE cx_tower_key
+                SET secret_value = NULL
+                WHERE secret_value IS NOT NULL
+            """
+            )
+            _logger.info("Cleared SSH key from keys.")
+
+    # 3. Secret values are now stored in secrets
+    _logger.info("Moving secret values to vault.")
+    success = False
+    # Read secret values from key values using SQL query
+    cr.execute(
+        """
+        SELECT id, secret_value
+        FROM cx_tower_key_value
+    """
+    )
+    secret_value_records = cr.fetchall()
+    secret_value_model = env["cx.tower.key.value"]
+    try:
+        for record in secret_value_records:
+            _logger.info(f"Moving secret value to vault record {record[0]}")
+            secret_value_model.browse(record[0]).write({"secret_value": record[1]})
+        _logger.info("Moving secret values to vault completed.")
+        success = True
+    except Exception as e:
+        _logger.error(f"Error moving secret values to vault: {e}")
+        raise e
+    finally:
+        if success:
+            # Clear secret value from key values
+            cr.execute(
+                """
+                UPDATE cx_tower_key_value
+                SET secret_value = NULL
+                WHERE secret_value IS NOT NULL
+            """
+            )
+            _logger.info("Cleared secret value from key values.")

--- a/cetmix_tower_server/models/__init__.py
+++ b/cetmix_tower_server/models/__init__.py
@@ -6,6 +6,8 @@ from . import cx_tower_access_mixin
 from . import cx_tower_access_role_mixin
 from . import cx_tower_reference_mixin
 from . import cx_tower_key_mixin
+from . import cx_tower_vault_mixin
+from . import cx_tower_vault
 from . import cx_tower_variable
 from . import cx_tower_variable_value
 from . import cx_tower_file

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -9,13 +9,16 @@ class CxTowerKey(models.Model):
 
     _name = "cx.tower.key"
     _description = "Cetmix Tower Key/Secret Storage"
-    _inherit = ["cx.tower.reference.mixin", "cx.tower.access.role.mixin"]
+    _inherit = [
+        "cx.tower.reference.mixin",
+        "cx.tower.access.role.mixin",
+        "cx.tower.vault.mixin",
+    ]
     _order = "name"
 
     KEY_PREFIX = "#!cxtower"
     KEY_TERMINATOR = "!#"
-    SECRET_VALUE_PLACEHOLDER = "*** Insert new value to replace the existing one ***"
-    SECRET_VALUE_SPOILER = "*****"
+    SECRET_FIELDS = ["secret_value"]
 
     key_type = fields.Selection(
         selection=[
@@ -71,40 +74,6 @@ class CxTowerKey(models.Model):
             else:
                 rec.reference_code = None
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        """Create a new key and set secret value if key type is secret"""
-
-        # Create records one by one to ensure that we preserve
-        # the original value list order.
-        # This is done to avoid possible errors when this list is modified
-        # by some other module that overrides this function.
-        # We also need to avoid secret values being written to the database
-        # any other way besides the _set_secret_value method.
-        records = self.browse()
-        for vals in vals_list:
-            secret_value = vals.pop("secret_value", None)
-            new_key = super().create(vals)
-            if secret_value:
-                new_key._set_secret_value(secret_value)
-            records |= new_key
-        return records
-
-    def write(self, vals):
-        """Write key values"""
-        # Remove secret value from vals and set it later
-        if "secret_value" in vals and not self.env.context.get("write_secret_value"):
-            secret_value = vals.pop("secret_value", None)
-            has_secret_value = True
-        else:
-            has_secret_value = False
-        res = super().write(vals)
-        # Set secret value
-        if has_secret_value:
-            for key in self:
-                key._set_secret_value(secret_value)
-        return res
-
     def _get_reference_pattern(self):
         """
         Override mixin method
@@ -130,19 +99,6 @@ class CxTowerKey(models.Model):
         else:
             key_prefix = None
         return key_prefix
-
-    def _read(self, fields):  # pylint: disable=missing-return # doesn't return anything
-        """Substitute fields based on api"""
-        super()._read(fields)
-        if "secret_value" in fields or fields == []:
-            # Public user used for substitution
-            for record in self:
-                try:
-                    record._cache["secret_value"] = self.SECRET_VALUE_PLACEHOLDER
-                except Exception:  # pylint: disable=except-pass
-                    # skip SpecialValue
-                    # (e.g. for missing record or access right)
-                    pass
 
     def _parse_code_and_return_key_values(self, code, pythonic_mode=False, **kwargs):
         """Replaces key placeholders in code with the corresponding values,
@@ -372,7 +328,7 @@ class CxTowerKey(models.Model):
                 key_value = filtered_key_values[0]
 
         if key_value:
-            return key_value._get_secret_value()
+            return key_value._get_secret_value("secret_value")
 
     def _replace_with_spoiler(self, code, key_values):
         """Helper function that replaces clean text keys in code with spoiler.
@@ -401,40 +357,17 @@ class CxTowerKey(models.Model):
             # If key_value contains an escaped line break replace then remove escaping
             key_value = key_value.replace("\\n", "\n")
             # Replace key including key terminator
-            code = code.replace(key_value, self.SECRET_VALUE_SPOILER)
+            code = code.replace(key_value, self.SECRET_VALUE_PLACEHOLDER)
 
         return code
 
-    def _get_secret_value(self):
-        """Get secret value.
-        Override this method in case you need
-        to implement custom key storages.
-
-        Returns:
-            str: secret value or None if no secret value is found
-        """
-
-        # Return None in case of empty recordset
-        self.ensure_one()
-        self.env.cr.execute(
-            """
-            SELECT secret_value
-            FROM cx_tower_key
-            WHERE id = %s
-            """,
-            [self.id],
-        )
-        result = self.env.cr.fetchone()
-        if result:
-            return result[0]
-
-    def _set_secret_value(self, value=None):
+    def _set_secret_values(self, vals):
         """Set secret value.
         Override this method in case you need
         to implement custom key storages.
 
         Args:
-            value (str): secret value
+            vals (dict): Dictionary of field names to secret values
         """
         self.ensure_one()
         if self.key_type == "s":
@@ -443,15 +376,11 @@ class CxTowerKey(models.Model):
                 lambda x: not x.server_id and not x.partner_id
             )
             if general_value:
-                general_value._set_secret_value(value)
+                general_value._set_secret_values(vals)
             else:
-                self.value_ids.create(
-                    {
-                        "key_id": self.id,
-                        "secret_value": value,
-                    }
-                )
+                create_vals = {"key_id": self.id}
+                create_vals.update(vals)
+                self.value_ids.create(create_vals)
 
         elif self.key_type == "k":
-            self.with_context(write_secret_value=True).write({"secret_value": value})
-            self.invalidate_recordset(["secret_value"])
+            return super()._set_secret_values(vals)

--- a/cetmix_tower_server/models/cx_tower_key_value.py
+++ b/cetmix_tower_server/models/cx_tower_key_value.py
@@ -9,8 +9,13 @@ class CxTowerKeyValue(models.Model):
     """Secret value storage"""
 
     _name = "cx.tower.key.value"
-    _inherit = "cx.tower.reference.mixin"
+    _inherit = [
+        "cx.tower.reference.mixin",
+        "cx.tower.vault.mixin",
+    ]
     _description = "Cetmix Tower Secret Value Storage"
+
+    SECRET_FIELDS = ["secret_value"]
 
     name = fields.Char(related="key_id.name", readonly=False)
     key_id = fields.Many2one(
@@ -91,85 +96,3 @@ class CxTowerKeyValue(models.Model):
                 raise ValidationError(
                     _("Only one secret value can be defined for a partner")
                 )
-
-    def _read(self, fields):  # pylint: disable=missing-return # doesn't return anything
-        """Substitute fields based on api"""
-        super()._read(fields)
-        if "secret_value" in fields or fields == []:
-            placeholder = self.env["cx.tower.key"].SECRET_VALUE_PLACEHOLDER
-            # Public user used for substitution
-            for record in self:
-                try:
-                    record._cache["secret_value"] = placeholder
-                except Exception:  # pylint: disable=except-pass
-                    # skip SpecialValue
-                    # (e.g. for missing record or access right)
-                    pass
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        """Create a new key value and set secret value"""
-
-        # Create records one by one to ensure that we preserve
-        # the original value list order.
-        # This is done to avoid possible errors when this list is modified
-        # by some other module that overrides this function.
-        # We also need to avoid secret values being written to the database
-        # any other way besides the _set_secret_value method.
-        records = self.browse()
-        for vals in vals_list:
-            secret_value = vals.pop("secret_value", None)
-            rec = super().create(vals)
-            if secret_value:
-                rec._set_secret_value(secret_value)
-            records |= rec
-        return records
-
-    def write(self, vals):
-        """Write key values"""
-        # Remove secret value from vals and set it later
-        if "secret_value" in vals and not self.env.context.get("write_secret_value"):
-            secret_value = vals.pop("secret_value", None)
-            has_secret_value = True
-        else:
-            has_secret_value = False
-        res = super().write(vals)
-        # Set secret value
-        if has_secret_value:
-            for key_value in self:
-                key_value._set_secret_value(secret_value)
-        return res
-
-    def _get_secret_value(self):
-        """Get secret value.
-        Override this method in case you need to implement custom key storages.
-
-        Returns:
-            str: secret value or None if no secret value is found
-        """
-
-        # Return None in case of empty recordset
-        self.ensure_one()
-        self.env.cr.execute(
-            """
-            SELECT secret_value
-            FROM cx_tower_key_value
-            WHERE id = %s
-            """,
-            [self.id],
-        )
-        result = self.env.cr.fetchone()
-        if result:
-            return result[0]
-
-    def _set_secret_value(self, value=None):
-        """Set secret value.
-        Override this method in case you need
-        to implement custom key storages.
-
-        Args:
-            value (str): secret value
-        """
-        self.ensure_one()
-        self.with_context(write_secret_value=True).write({"secret_value": value})
-        self.invalidate_recordset(["secret_value"])

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -83,9 +83,12 @@ class CxTowerServer(models.Model):
         "cx.tower.reference.mixin",
         "mail.thread",
         "mail.activity.mixin",
+        "cx.tower.vault.mixin",
     ]
     _description = "Cetmix Tower Server"
     _order = "name asc"
+
+    SECRET_FIELDS = ["ssh_password", "host_key"]
 
     # ---- Main
     active = fields.Boolean(default=True)
@@ -124,7 +127,8 @@ class CxTowerServer(models.Model):
         string="SSH Username", required=True, groups="cetmix_tower_server.group_manager"
     )
     ssh_password = fields.Char(
-        string="SSH Password", groups="cetmix_tower_server.group_manager"
+        string="SSH Password",
+        groups="cetmix_tower_server.group_manager",
     )
     ssh_key_id = fields.Many2one(
         comodel_name="cx.tower.key",
@@ -286,7 +290,6 @@ class CxTowerServer(models.Model):
         """Ensure SSH settings are valid.
         Set 'skip_ssh_settings_check' context key to skip the checks
         """
-
         # Skip the check if context key is set
         if self._context.get("skip_ssh_settings_check"):
             return
@@ -301,10 +304,6 @@ class CxTowerServer(models.Model):
                         srv=rec.name,
                     )
                 )
-            if rec.ssh_auth_mode == "p" and not rec.ssh_password:
-                validation_errors.append(
-                    _("Please provide SSH password for %(srv)s", srv=rec.name)
-                )
             if rec.ssh_auth_mode == "k" and not rec.ssh_key_id:
                 validation_errors.append(
                     _("Please provide SSH Key for %(srv)s", srv=rec.name)
@@ -314,13 +313,6 @@ class CxTowerServer(models.Model):
             if validation_errors:
                 validation_error = "\n".join(validation_errors)
                 raise ValidationError(validation_error)
-
-    def write(self, vals):
-        """Invalidate host_key cache"""
-        res = super().write(vals)
-        if "host_key" in vals:
-            self.invalidate_recordset(["host_key"])
-        return res
 
     def unlink(self):
         """Run post-delete flight plan"""
@@ -359,22 +351,6 @@ class CxTowerServer(models.Model):
                 server.status = "deleting"
 
         return super(CxTowerServer, servers_to_delete).unlink()
-
-    def _read(self, fields):  # pylint: disable=missing-return # doesn't return anything
-        """Replace host_key with secret value spoiler"""
-        super()._read(fields)
-        spoiler = self.env["cx.tower.key"].SECRET_VALUE_SPOILER
-        # Public user used for substitution
-        if "host_key" in fields or fields == []:
-            for record in self:
-                try:
-                    record._cache["host_key"] = (
-                        spoiler if record._cache["host_key"] else None
-                    )
-                except Exception:  # pylint: disable=except-pass
-                    # skip SpecialValue
-                    # (e.g. for missing record or access right)
-                    pass
 
     @api.returns("self", lambda value: value.id)
     def copy(self, default=None):
@@ -551,7 +527,7 @@ class CxTowerServer(models.Model):
         self.ensure_one()
         self = self.sudo()
         try:
-            host_key = self._get_host_key_value()
+            host_key = self._get_secret_value("host_key")
 
             # Check host only if IP address is present
             skip_host_key = skip_host_key or self.skip_host_key
@@ -733,7 +709,7 @@ class CxTowerServer(models.Model):
             Char: password ready to be used for connection parameters
         """
         self.ensure_one()
-        password = self.sudo().ssh_password
+        password = self._get_secret_value("ssh_password")
         return password
 
     def _get_ssh_key(self):
@@ -748,31 +724,10 @@ class CxTowerServer(models.Model):
         # regardless of access rights
         if self.sudo().ssh_key_id:
             # Use context key to read secret value
-            ssh_key = self.ssh_key_id._get_secret_value()
+            ssh_key = self.ssh_key_id._get_secret_value("secret_value")
         else:
             ssh_key = None
         return ssh_key
-
-    def _get_host_key_value(self):
-        """Get host key value
-
-        Returns:
-            Char: Host key value
-        """
-        # Return None in case of empty recordset
-        if not self:
-            return
-        self.env.cr.execute(
-            """
-            SELECT host_key
-            FROM cx_tower_server
-            WHERE id = %s
-            """,
-            [self.id],
-        )
-        result = self.env.cr.fetchone()
-        if result:
-            return result[0]
 
     @ensure_ssh_disconnect
     def _get_host_key_from_host(self, raise_on_error=True, timeout=60):
@@ -1980,3 +1935,21 @@ class CxTowerServer(models.Model):
                 "sticky": sticky,
             },
         }
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override create to validate SSH password before record creation."""
+        # Validate SSH password before creating records
+        if not self._context.get("skip_ssh_settings_check"):
+            validation_errors = []
+            for vals in vals_list:
+                if vals.get("ssh_auth_mode") == "p" and not vals.get("ssh_password"):
+                    server_name = vals["name"]
+                    validation_errors.append(
+                        _("Please provide SSH password for %(srv)s", srv=server_name)
+                    )
+
+            if validation_errors:
+                raise ValidationError("\n".join(validation_errors))
+
+        return super().create(vals_list)

--- a/cetmix_tower_server/models/cx_tower_vault.py
+++ b/cetmix_tower_server/models/cx_tower_vault.py
@@ -1,0 +1,54 @@
+from odoo import fields, models
+
+from odoo.addons.rpc_helper.decorator import disable_rpc
+
+
+@disable_rpc()
+class CxTowerVault(models.Model):
+    """Vault for storing secret data.
+
+    This model is used to store secret data for various resources.
+    The data is stored in the database and can be accessed using the
+    `_get_secret_values` method.
+
+    The data is stored in the database and can be accessed using the
+    `_get_secret_values` method.
+
+    Do not use this model directly, use the `VaultMixin` instead.
+    """
+
+    _name = "cx.tower.vault"
+    _description = "Cetmix Tower Vault"
+
+    res_model = fields.Char(
+        string="Resource Model",
+        required=True,
+        copy=False,
+        help="Model name of the resource that uses this vault",
+    )
+    res_id = fields.Many2oneReference(
+        string="Resource ID",
+        model_field="res_model",
+        help="ID of the resource that uses this vault",
+        required=True,
+        copy=False,
+    )
+    field_name = fields.Char(
+        required=True,
+        help="Name of the field that contains the secret value",
+        copy=False,
+    )
+    data = fields.Text(
+        string="Secret Data",
+        required=True,
+        copy=False,
+        help="The secret data to be stored in the vault",
+    )
+
+    _sql_constraints = [
+        (
+            "vault_unique_key",
+            "UNIQUE(res_model, res_id, field_name)",
+            "Each secret (model, record, field) must be unique in the vault.",
+        ),
+    ]

--- a/cetmix_tower_server/models/cx_tower_vault_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_vault_mixin.py
@@ -1,0 +1,408 @@
+from collections import defaultdict
+
+from odoo import api, models
+
+
+class CxTowerVaultMixin(models.AbstractModel):
+    """Mixin for vault functionality.
+
+    This mixin provides methods to securely store and retrieve sensitive data
+    in the vault. Inheriting models must define SECRET_FIELDS list with field
+    names that should be stored in the vault.
+    """
+
+    _name = "cx.tower.vault.mixin"
+    _description = "Cetmix Tower Vault Mixin"
+
+    SECRET_VALUE_PLACEHOLDER = "*****"
+    SECRET_FIELDS = []
+
+    def _read(self, fields):  # pylint: disable=missing-return # doesn't return anything
+        """Substitute fields based on api.
+
+        This method replaces values of secret fields with a placeholder value
+        when they are read from the database.
+
+        Args:
+            fields (list): List of fields to read
+        """
+        super()._read(fields)
+
+        show_all = not fields
+        secret_fields = (
+            self.SECRET_FIELDS
+            if show_all
+            else [f for f in self.SECRET_FIELDS if f in fields]
+        )
+
+        for record in self:
+            for secret_field in secret_fields:
+                try:
+                    record._cache[secret_field] = self.SECRET_VALUE_PLACEHOLDER
+                except Exception:  # pylint: disable=except-pass
+                    # skip SpecialValue
+                    # (e.g. for missing record or access right)
+                    pass
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override create to handle secret values securely.
+
+        Extracts secret fields, stores them in vault, and prevents
+        actual secret values from being saved in the main table.
+
+        Args:
+            vals_list (list): List of dictionaries containing field values
+                             for record creation
+
+        Returns:
+            recordset: Created records with secret values stored in vault
+
+        Note:
+            Secret fields are automatically processed and stored securely.
+            The main database table never contains actual secret values.
+        """
+
+        # Step 1: Extract secret fields and generate temporary IDs
+        secret_vals = self._extract_and_replace_secret_fields(vals_list)
+
+        # Step 2: Create records with batch operation
+        records = super().create(vals_list)
+
+        # Step 3: Update vault records with real IDs
+        if secret_vals:
+            self._process_secret_values_after_creation(records, secret_vals)
+
+        return records
+
+    def write(self, vals):
+        """Override write to handle secret fields.
+
+        Extracts secret field values from vals dictionary and stores them securely
+        in the vault instead of the main database table. The remaining non-secret
+        fields are processed by the standard write method.
+
+        Args:
+            vals (dict): Dictionary of field values to write to records
+
+        Returns:
+            bool: Result of the parent write operation
+
+        Note:
+            Secret fields defined in SECRET_FIELDS are automatically intercepted
+            and stored in vault. Cache is invalidated for all secret fields when
+            any secret field is modified.
+        """
+        # Extract secret fields
+        secret_values = {}
+        for secret_field in self.SECRET_FIELDS:
+            if secret_field in vals:
+                secret_values[secret_field] = vals.pop(secret_field)
+
+        res = super().write(vals)
+
+        if secret_values:
+            self._set_secret_values(secret_values)
+            # Invalidate cache for all secret fields
+            self.invalidate_recordset(self.SECRET_FIELDS)
+
+        return res
+
+    def unlink(self):
+        """Override unlink to delete vault records.
+
+        Automatically removes all associated vault records after deleting
+        the main records to prevent orphaned secret data in the vault.
+
+        Returns:
+            bool: Result of the parent unlink operation
+
+        Note:
+            Vault cleanup is performed automatically and cannot be bypassed.
+        """
+        ids = self.ids
+
+        res = super().unlink()
+
+        # Find all vault records for these records
+        vault_records = (
+            self.env["cx.tower.vault"]
+            .sudo()
+            .search([("res_model", "=", self._name), ("res_id", "in", ids)])
+        )
+
+        # Delete vault records
+        if vault_records:
+            vault_records.sudo().unlink()
+
+        return res
+
+    def _get_secret_value(self, field_name):
+        """Retrieves the actual secret value for a specific field for a single record.
+
+        This method is the only way to get the real secret field value because:
+        - Direct field access (e.g., self.secret_field)
+          returns placeholder due to _read() override
+        - The actual field in the main table is empty/NULL
+          as values are stored in vault
+
+        Args:
+            field_name (str): Name of the secret field to retrieve
+
+        Returns:
+            str or None: The actual secret value, or None if not found or field
+                        is not in SECRET_FIELDS
+
+        Note:
+            This method bypasses Odoo's ORM field access to avoid getting
+            placeholder values returned by the overridden _read() method.
+        """
+
+        self.ensure_one()
+
+        return self._get_secret_values([field_name]).get(self.id, {}).get(field_name)
+
+    def _get_secret_values(self, fields_list=None):
+        """Retrieve secret values from the vault for specified fields.
+
+        This method fetches secret values stored in the vault for all records
+        in the current recordset and specified fields (or all SECRET_FIELDS).
+
+        Args:
+            fields_list (list, optional): List of field names to retrieve.
+                                        Defaults to all SECRET_FIELDS.
+
+        Returns:
+            dict: Dictionary mapping record IDs to their secret field values.
+                  Structure: {res_id: {field_name: secret_value}}
+
+                  Example:
+                  {1: {'ssh_password': 'secret123', 'host_key': 'key456'},
+                   2: {'ssh_password': 'secret789'}}
+
+        Note:
+            This method searches vault records using standard domain filtering
+            by res_id, and field_name for reliable record matching.
+            If a record has no secret values this record is not included in the result.
+        """
+        # If no records, return empty dict
+        if not self:
+            return {}
+
+        # Prepare fields to fetch
+        fields_to_fetch = (
+            [f for f in fields_list if f in self.SECRET_FIELDS]
+            if fields_list
+            else self.SECRET_FIELDS
+        )
+        # If no fields to fetch, return empty dict
+        if not fields_to_fetch:
+            return {}
+
+        # Search vault records for all records and all secret fields
+        domain = [
+            ("res_model", "=", self._name),
+            ("res_id", "in", self.ids),
+            ("field_name", "in", fields_to_fetch),
+        ]
+        vault_records = (
+            self.env["cx.tower.vault"]
+            .sudo()
+            .search_read(
+                domain,
+                ["res_id", "field_name", "data"],
+            )
+        )
+        res = defaultdict(dict)
+        for record in vault_records:
+            res[record["res_id"]][record["field_name"]] = record["data"]
+
+        return dict(res)
+
+    def _set_secret_values(self, vals):
+        """Store secret values in the vault.
+
+        This method stores sensitive data in the vault for all records in the recordset.
+        It either updates existing vault records or creates new ones for each
+        record-field pair in the vals dictionary.
+
+        This method can be overridden to implement custom storage mechanisms
+        for secret values, such as external key management systems or
+        encryption services.
+
+        Args:
+            vals (dict): Dictionary mapping field names to their secret values
+                         to be stored in the vault for all records
+
+        Returns:
+            None
+        """
+        if not vals or not self:
+            return
+
+        # Get all existing vault records in ONE SQL query
+        domain = [
+            ("res_model", "=", self._name),
+            ("res_id", "in", self.ids),
+            ("field_name", "in", list(vals.keys())),
+        ]
+        existing_vault_records = self.env["cx.tower.vault"].sudo().search(domain)
+
+        # Prepare data for batch operations
+        vals_to_update_records = defaultdict(lambda: self.env["cx.tower.vault"])
+        records_to_unlink = self.env["cx.tower.vault"]
+        records_to_create = []
+
+        # Index existing records by (res_id, field_name) for O(1) lookups
+        existing_map = {(v.res_id, v.field_name): v for v in existing_vault_records}
+
+        # Only allow known secret fields to be set
+        allowed_fields = set(self.SECRET_FIELDS)
+
+        # Process each record and field combination
+        for record in self:
+            for field, value in vals.items():
+                if field not in allowed_fields:
+                    continue
+                # Fast lookup for existing record
+                existing_record = existing_map.get((record.id, field))
+                if existing_record:
+                    if value is False or value is None:
+                        records_to_unlink |= existing_record
+                    else:
+                        vals_to_update_records[value] |= existing_record
+
+                else:
+                    if value is False or value is None:
+                        continue
+
+                    records_to_create.append(
+                        {
+                            "res_model": self._name,
+                            "res_id": record.id,
+                            "field_name": field,
+                            "data": value,
+                        }
+                    )
+
+        # Batch operations
+        for value, records in vals_to_update_records.items():
+            records.sudo().write({"data": value})
+
+        if records_to_create:
+            self.env["cx.tower.vault"].sudo().create(records_to_create)
+        if records_to_unlink:
+            records_to_unlink.sudo().unlink()
+
+    def _extract_and_replace_secret_fields(self, vals_list):
+        """Extract secret fields and replace with temporary identifiers.
+
+        Processes value dictionaries for record creation, replacing secret field values
+        with unique temporary identifiers. The actual secret values are mapped to these
+        temporary identifiers for later secure storage in the vault system.
+
+        Args:
+            vals_list (list): List of value dictionaries for record creation.
+
+         Returns:
+           dict: Mapping of temporary identifiers to secret values.
+            Note: vals_list is modified in-place to contain temp identifiers.
+
+        Note:
+            Used during record creation as part of the secure secret storage workflow.
+        """
+        temp_id_counter = 0
+        secret_vals = {}
+
+        for vals in vals_list:
+            for secret_field in self.SECRET_FIELDS:
+                if (
+                    secret_field in vals
+                    and vals[secret_field] is not False
+                    and vals[secret_field] is not None
+                ):
+                    temp_id_counter += 1
+                    temp_identifier = str(temp_id_counter)
+                    secret_vals[temp_identifier] = vals[secret_field]
+                    vals[secret_field] = temp_identifier
+
+        return secret_vals
+
+    def _process_secret_values_after_creation(self, records, secret_vals):
+        """Process secret values after records creation.
+
+        Replaces temporary identifiers with actual secret values in the vault
+        and invalidates cache for affected fields.
+
+        Args:
+            records (recordset): Newly created records with temporary identifiers
+            secret_vals (dict): Mapping of temporary identifiers to secret values
+
+        Returns:
+            None
+
+        Note:
+            Called automatically during create() process. Should not be used directly.
+        """
+        fields_str = ", ".join(self.SECRET_FIELDS)
+        query = f"SELECT id, {fields_str} FROM {self._table} WHERE id in %s"
+        self.env.cr.execute(query, (tuple(records.ids),))
+        records_dict = self.env.cr.dictfetchall()
+
+        for record_dict in records_dict:
+            self._process_single_record_secrets(record_dict, secret_vals)
+
+        records._clear_temp_values()
+        records.invalidate_recordset(self.SECRET_FIELDS)
+
+    def _process_single_record_secrets(self, record_dict, secret_vals):
+        """Process secrets for a single record.
+
+        Replaces temporary identifiers with actual secret values for one record,
+        clears temporary values from main table and stores secrets in vault.
+
+        Args:
+            record_dict (dict): Dictionary with record data
+            including temporary identifiers
+            secret_vals (dict): Mapping of temporary identifiers to actual secret values
+
+        Returns:
+            None
+
+        Note:
+            Internal method used by _process_secret_values_after_creation.
+        """
+        record_id = record_dict.get("id")
+        vault_vals = {}
+        field_temp_id_pairs = (
+            (field_name, record_dict[field_name]) for field_name in self.SECRET_FIELDS
+        )
+
+        # Collect secret values and fields to clear
+        for field_name, temp_identifier in field_temp_id_pairs:
+            secret_value = secret_vals.get(temp_identifier)
+            if secret_value:
+                vault_vals[field_name] = secret_value
+
+        # Update database and vault if needed
+        if vault_vals:
+            record = self.browse(record_id)
+            record._set_secret_values(vault_vals)
+
+    def _clear_temp_values(self):
+        """Clear temporary values from main table.
+
+        Sets all SECRET_FIELDS to NULL in the database to remove temporary
+        identifiers after secret values have been stored in vault.
+        Works with multiple records in the recordset.
+
+        Returns:
+            None
+
+        Note:
+            Internal method used during secret processing workflow.
+            Clears all SECRET_FIELDS for all records in the current recordset.
+        """
+        set_clause = ", ".join(f"{field} = NULL" for field in self.SECRET_FIELDS)
+        query = f"UPDATE {self._table} SET {set_clause} WHERE id in %s"
+        self.env.cr.execute(query, (tuple(self.ids),))

--- a/cetmix_tower_server/readme/newsfragments/4824.feature
+++ b/cetmix_tower_server/readme/newsfragments/4824.feature
@@ -1,0 +1,1 @@
+'Cetmix Tower Vault' - new way of centralized password/key management

--- a/cetmix_tower_server/security/ir.model.access.csv
+++ b/cetmix_tower_server/security/ir.model.access.csv
@@ -54,6 +54,7 @@ access_create_server_from_template_manager,Create Server From Template->Manager,
 access_create_server_from_template_line_manager,Create Server From Template Line->Manager,model_cx_tower_server_template_create_wizard_line,group_manager,1,1,1,1
 access_cx_tower_variable_option_user,Variable Option->User,model_cx_tower_variable_option,group_user,1,0,0,0
 access_cx_tower_variable_option_manager,Variable Option->Manager,model_cx_tower_variable_option,group_manager,1,1,1,1
+access_cx_tower_vault_no_access,cx.tower.vault no access,model_cx_tower_vault,group_user,0,0,0,0
 access_cx_tower_server_host_key_wizard_manager,Show Host Key->Manager,model_cx_tower_server_host_key_wizard,group_manager,1,1,1,1
 access_cx_tower_server_host_key_wizard_root,Show Host Key->Root,model_cx_tower_server_host_key_wizard,group_root,1,1,1,1
 access_cetmix_tower_user,Cetmix Tower->User,model_cetmix_tower,group_user,1,1,0,0

--- a/cetmix_tower_server/tests/__init__.py
+++ b/cetmix_tower_server/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_tag
 from . import test_shortcut
 from . import test_tools
 from . import test_partner_server_btn
+from . import test_vault_mixin

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -1011,12 +1011,13 @@ result = re.sub(pattern, replacement, value)
     def test_parse_ssh_command_result(self):
         """Test ssh command result parsing"""
 
+        placeholder = self.Key.SECRET_VALUE_PLACEHOLDER
         # -------------------------------------------------------
         # Case 1: regular command execution result with no error
         # We are testing secret value placeholder here
         # -------------------------------------------------------
         status = 0
-        response = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
+        response = ["Such much", f"Doge like SSH {placeholder}"]
         error = []
 
         ssh_command_result = self.Server._parse_command_results(
@@ -1035,7 +1036,7 @@ result = re.sub(pattern, replacement, value)
         )
         self.assertEqual(
             result_response,
-            f"Such muchDoge like SSH {self.Key.SECRET_VALUE_SPOILER}",
+            f"Such muchDoge like SSH {placeholder}",
             "Response in result doesn't match expected",
         )
         self.assertIsNone(result_error, "Error in response must be set to None")
@@ -1114,7 +1115,7 @@ result = re.sub(pattern, replacement, value)
         # For example this happens in 'docker build'.
         # -------------------------------------------------------
         status = 0
-        error = ["Such much", f"Doge like SSH {self.Key.SECRET_VALUE_SPOILER}"]
+        error = ["Such much", f"Doge like SSH {placeholder}"]
         response = []
 
         ssh_command_result = self.Server._parse_command_results(
@@ -1133,7 +1134,7 @@ result = re.sub(pattern, replacement, value)
         )
         self.assertEqual(
             result_error,
-            f"Such muchDoge like SSH {self.Key.SECRET_VALUE_SPOILER}",
+            f"Such muchDoge like SSH {placeholder}",
             "Response in result doesn't match expected",
         )
         self.assertIsNone(result_response, "Error in response must be set to None")
@@ -1558,6 +1559,8 @@ else:
         This test ensures that a command is rendered and executed correctly,
         and that the secret value is correctly handled and replaced in the output.
         """
+
+        placeholder = self.Key.SECRET_VALUE_PLACEHOLDER
         # Case 1
         # Render the command using server_test_1
         rendered_command = self.server_test_1._render_command(
@@ -1577,7 +1580,7 @@ else:
         # Assert that the response contains the secret spoiler text
         self.assertEqual(
             command_result["response"],
-            self.Key.SECRET_VALUE_SPOILER,
+            placeholder,
             "The response must correctly include the secret value placeholder",
         )
 
@@ -1606,7 +1609,7 @@ else:
         # Assert that the response contains the secret spoiler text
         self.assertEqual(
             command_result["response"],
-            f'We use "{self.Key.SECRET_VALUE_SPOILER}"',
+            f'We use "{placeholder}"',
             "The response must correctly include the secret value placeholder",
         )
 
@@ -1635,7 +1638,7 @@ else:
         # Assert that the response contains the secret spoiler text
         self.assertEqual(
             command_result["response"],
-            self.Key.SECRET_VALUE_SPOILER,
+            placeholder,
             "The response must correctly include the secret value placeholder",
         )
 
@@ -1665,7 +1668,7 @@ else:
         # Assert that the response contains the secret spoiler text
         self.assertEqual(
             command_result["response"],
-            self.Key.SECRET_VALUE_SPOILER,
+            placeholder,
             "The response must correctly include the secret value placeholder",
         )
 

--- a/cetmix_tower_server/tests/test_key.py
+++ b/cetmix_tower_server/tests/test_key.py
@@ -425,9 +425,10 @@ class TestTowerKey(TestTowerCommon):
             "They make #!memes together. Check #!cxtower.secret.MEME_KEY&#!"
             "cxtower.secret.DOGE_KEY"
         )
+        placeholder = self.Key.SECRET_VALUE_PLACEHOLDER
         expected_code = (
-            f"Hey {self.Key.SECRET_VALUE_SPOILER} & Doge {self.Key.SECRET_VALUE_SPOILER} so "  # noqa
-            f"like {self.Key.SECRET_VALUE_SPOILER}!\n"
+            f"Hey {placeholder} & Doge {placeholder} so "
+            f"like {placeholder}!\n"
             "They make #!memes together. Check #!cxtower.secret.MEME_KEY&#!"
             "cxtower.secret.DOGE_KEY"
         )
@@ -734,14 +735,18 @@ class TestTowerKey(TestTowerCommon):
         manager_key_value.browse(global_value.id).write(
             {"secret_value": "updated global"}
         )
-        self.assertEqual(global_value._get_secret_value(), "updated global")
+        self.assertEqual(
+            global_value._get_secret_value("secret_value"), "updated global"
+        )
 
         # Add as server manager - should write to server value
         self.server_1.write({"manager_ids": [(4, self.manager.id)]})
         manager_key_value.browse(server_value.id).write(
             {"secret_value": "updated server"}
         )
-        self.assertEqual(server_value._get_secret_value(), "updated server")
+        self.assertEqual(
+            server_value._get_secret_value("secret_value"), "updated server"
+        )
 
         # Test create access
         for_bob = manager_key_value.create(
@@ -825,12 +830,13 @@ class TestTowerKey(TestTowerCommon):
 
         # Read
         self.assertEqual(
-            root_key_value.browse(value.id)._get_secret_value(), "root value"
+            root_key_value.browse(value.id)._get_secret_value("secret_value"),
+            "root value",
         )
 
         # Write
         root_key_value.browse(value.id).write({"secret_value": "updated value"})
-        self.assertEqual(value._get_secret_value(), "updated value")
+        self.assertEqual(value._get_secret_value("secret_value"), "updated value")
 
         # Delete
         value.unlink()

--- a/cetmix_tower_server/tests/test_server_template.py
+++ b/cetmix_tower_server/tests/test_server_template.py
@@ -103,7 +103,7 @@ class TestTowerServerTemplate(TestTowerCommon):
             new_server.ssh_username, "admin", "Server SSH Username must be 'admin'"
         )
         self.assertEqual(
-            new_server.ssh_password,
+            new_server._get_secret_value("ssh_password"),
             "password",
             "Server SSH Password must be 'password'",
         )

--- a/cetmix_tower_server/tests/test_vault_mixin.py
+++ b/cetmix_tower_server/tests/test_vault_mixin.py
@@ -1,0 +1,506 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from .common import TestTowerCommon
+
+
+class TestVaultMixin(TestTowerCommon):
+    """Test vault mixin functionality."""
+
+    def test_vault_mixin_secret_fields(self):
+        """Test vault mixin functionality for secret fields
+        (host_key and ssh_password)"""
+        # Create a server with initial secret values
+        initial_password = "initial_password"
+        initial_host_key = "initial_host_key"
+
+        server = self.Server.create(
+            {
+                "name": "Vault Test Server",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": initial_password,
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "host_key": initial_host_key,
+                "skip_host_key": False,
+            }
+        )
+
+        # Test 1: Verify initial values are stored in vault and accessible
+        # Read values using common way - should return placeholder
+        self.assertEqual(
+            server.ssh_password,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "ssh_password should return placeholder value when read normally",
+        )
+        self.assertEqual(
+            server.host_key,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "host_key should return placeholder value when read normally",
+        )
+
+        # Read using _get_secret_values() - should return actual initial values
+        secret_values = server._get_secret_values()
+        self.assertIsNotNone(secret_values, "secret_values should not be None")
+        self.assertIn(server.id, secret_values, "Server ID should be in secret values")
+
+        server_secrets = secret_values[server.id]
+        self.assertIn(
+            "ssh_password", server_secrets, "ssh_password should be in secret values"
+        )
+        self.assertIn("host_key", server_secrets, "host_key should be in secret values")
+
+        self.assertEqual(
+            server_secrets["ssh_password"],
+            initial_password,
+            "ssh_password should return initial value from vault",
+        )
+        self.assertEqual(
+            server_secrets["host_key"],
+            initial_host_key,
+            "host_key should return initial value from vault",
+        )
+
+        # Read individual fields using _get_secret_value()
+        # should return initial values
+        retrieved_password = server._get_secret_value("ssh_password")
+        retrieved_host_key = server._get_secret_value("host_key")
+
+        self.assertEqual(
+            retrieved_password,
+            initial_password,
+            "_get_secret_value should return correct initial ssh_password",
+        )
+        self.assertEqual(
+            retrieved_host_key,
+            initial_host_key,
+            "_get_secret_value should return correct initial host_key",
+        )
+
+        # Test 2: Save new values to secret fields
+        new_password = "new_secure_password_123"
+        new_host_key = "new_host_key_456"
+
+        server.write(
+            {
+                "ssh_password": new_password,
+                "host_key": new_host_key,
+            }
+        )
+
+        # Test 3: Read values using common way after update - should return placeholder
+        # Note: In Odoo, we need to re-read the record to see updated values
+        server = self.Server.browse(server.id)
+        self.assertEqual(
+            server.ssh_password,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "ssh_password should return placeholder value when read normally "
+            "after update",
+        )
+        self.assertEqual(
+            server.host_key,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "host_key should return placeholder value when read normally "
+            "after update",
+        )
+
+        # Test 4: Read using _get_secret_values() after update
+        # should return new values
+        secret_values = server._get_secret_values()
+        self.assertIsNotNone(
+            secret_values, "secret_values should not be None after update"
+        )
+        self.assertIn(
+            server.id,
+            secret_values,
+            "Server ID should be in secret values after update",
+        )
+
+        server_secrets = secret_values[server.id]
+        self.assertIn(
+            "ssh_password",
+            server_secrets,
+            "ssh_password should be in secret values after update",
+        )
+        self.assertIn(
+            "host_key",
+            server_secrets,
+            "host_key should be in secret values after update",
+        )
+
+        self.assertEqual(
+            server_secrets["ssh_password"],
+            new_password,
+            "ssh_password should return new value from vault after update",
+        )
+        self.assertEqual(
+            server_secrets["host_key"],
+            new_host_key,
+            "host_key should return new value from vault after update",
+        )
+
+        # Test 5: Read individual fields using _get_secret_value() after update
+        # Get both values in one call using _get_secret_values()
+        secret_values = server._get_secret_values()
+        self.assertIsNotNone(
+            secret_values, "secret_values should not be None for individual field test"
+        )
+        self.assertIn(
+            server.id,
+            secret_values,
+            "Server ID should be in secret values for individual field test",
+        )
+
+        server_secrets = secret_values[server.id]
+        retrieved_password = server_secrets["ssh_password"]
+        retrieved_host_key = server_secrets["host_key"]
+
+        self.assertEqual(
+            retrieved_password,
+            new_password,
+            "_get_secret_values should return correct new ssh_password after update",
+        )
+        self.assertEqual(
+            retrieved_host_key,
+            new_host_key,
+            "_get_secret_values should return correct new host_key after update",
+        )
+
+        # Test 6: Verify that non-secret fields are not affected
+        self.assertEqual(
+            server.name,
+            "Vault Test Server",
+            "Non-secret field should not be affected by vault mixin",
+        )
+        self.assertEqual(
+            server.ssh_username,
+            "admin",
+            "Non-secret field should not be affected by vault mixin",
+        )
+
+    def test_vault_mixin_create_with_secret_fields(self):
+        """Test vault mixin functionality when creating records with secret fields"""
+        # Create a server with secret fields
+        server = self.Server.create(
+            {
+                "name": "Create Test Server",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": "create_password",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "host_key": "create_host_key",
+                "skip_host_key": False,
+            }
+        )
+
+        # Verify secret fields are stored in vault and not in main table
+        self.assertEqual(
+            server.ssh_password,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "ssh_password should return placeholder after creation",
+        )
+        self.assertEqual(
+            server.host_key,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "host_key should return placeholder after creation",
+        )
+
+        # Verify actual values are accessible via vault methods
+        secret_values = server._get_secret_values()
+        self.assertIn(
+            server.id,
+            secret_values,
+            "Server ID should be in secret values after creation",
+        )
+
+        server_secrets = secret_values[server.id]
+        self.assertEqual(
+            server_secrets["ssh_password"],
+            "create_password",
+            "ssh_password should be stored in vault after creation",
+        )
+        self.assertEqual(
+            server_secrets["host_key"],
+            "create_host_key",
+            "host_key should be stored in vault after creation",
+        )
+
+    def test_vault_mixin_delete_secret_fields(self):
+        """Test vault mixin functionality when deleting secret field values"""
+        # Create a server with secret fields
+        server = self.Server.create(
+            {
+                "name": "Delete Test Server",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": "delete_password",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "host_key": "delete_host_key",
+                "skip_host_key": False,
+            }
+        )
+
+        # Verify initial values exist
+        secret_values = server._get_secret_values()
+        self.assertIn(
+            "ssh_password",
+            secret_values[server.id],
+            "ssh_password should exist initially",
+        )
+        self.assertIn(
+            "host_key", secret_values[server.id], "host_key should exist initially"
+        )
+
+        # Delete secret field values
+        server.write(
+            {
+                "ssh_password": False,
+                "host_key": False,
+            }
+        )
+
+        # Verify values are removed from vault
+        secret_values = server._get_secret_values()
+        server_secrets = secret_values.get(server.id, {})
+
+        self.assertNotIn(
+            "ssh_password", server_secrets, "ssh_password should be removed from vault"
+        )
+        self.assertNotIn(
+            "host_key", server_secrets, "host_key should be removed from vault"
+        )
+
+        # Verify normal field access still returns placeholders
+        server = self.Server.browse(server.id)
+        self.assertEqual(
+            server.ssh_password,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "ssh_password should return placeholder after deletion",
+        )
+        self.assertEqual(
+            server.host_key,
+            self.Server.SECRET_VALUE_PLACEHOLDER,
+            "host_key should return placeholder after deletion",
+        )
+
+    def test_vault_mixin_bulk_create_with_secret_fields(self):
+        """Test vault mixin functionality when creating multiple servers with different
+        secret field configurations"""
+        placeholder = self.Server.SECRET_VALUE_PLACEHOLDER
+        # Create 3 servers with different secret field configurations
+        servers_data = [
+            {
+                "name": "Server 1 - Both Fields",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": "password1",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "host_key": "host_key1",
+                "skip_host_key": False,
+            },
+            {
+                "name": "Server 2 - Host Key Only",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_auth_mode": "k",
+                "os_id": self.os_debian_10.id,
+                "host_key": "host_key2",
+                "skip_host_key": False,
+                "ssh_key_id": self.key_1.id,
+            },
+            {
+                "name": "Server 3 - SSH Password Only",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": "password3",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "skip_host_key": True,
+            },
+        ]
+
+        # Create all servers in one call
+        servers = self.Server.create(servers_data)
+
+        # Verify we have 3 servers
+        self.assertEqual(len(servers), 3, "Should have created 3 servers")
+
+        # Test 1: Get values for all 3 servers regular way - should return placeholders
+        for server in servers:
+            self.assertEqual(
+                server.ssh_password,
+                placeholder,
+                f"Server {server.name} ssh_password should return placeholder "
+                f"when read normally",
+            )
+
+            self.assertEqual(
+                server.host_key,
+                placeholder,
+                f"Server {server.name} host_key should return placeholder "
+                f"when read normally",
+            )
+
+        # Test 2: Get values for all 3 servers at once using _get_secret_values()
+        all_secret_values = servers._get_secret_values()
+        self.assertIsNotNone(all_secret_values, "all_secret_values should not be None")
+
+        # Verify Server 1 (both fields)
+        server1 = servers[0]
+        self.assertIn(
+            server1.id, all_secret_values, "Server 1 should be in secret values"
+        )
+        server1_secrets = all_secret_values[server1.id]
+
+        self.assertEqual(
+            server1_secrets.get("ssh_password"),
+            "password1",
+            "Server 1 ssh_password should be preserved correctly in vault",
+        )
+        self.assertEqual(
+            server1_secrets.get("host_key"),
+            "host_key1",
+            "Server 1 host_key should be preserved correctly in vault",
+        )
+
+        # Verify Server 2 (host key only)
+        server2 = servers[1]
+        self.assertIn(
+            server2.id, all_secret_values, "Server 2 should be in secret values"
+        )
+        server2_secrets = all_secret_values[server2.id]
+
+        self.assertIsNone(
+            server2_secrets.get("ssh_password"),
+            "Server 2 should not have ssh_password in vault",
+        )
+        self.assertEqual(
+            server2_secrets.get("host_key"),
+            "host_key2",
+            "Server 2 host_key should be preserved correctly in vault",
+        )
+
+        # Verify Server 3 (ssh password only)
+        server3 = servers[2]
+        self.assertIn(
+            server3.id, all_secret_values, "Server 3 should be in secret values"
+        )
+        server3_secrets = all_secret_values[server3.id]
+
+        self.assertEqual(
+            server3_secrets.get("ssh_password"),
+            "password3",
+            "Server 3 ssh_password should be preserved correctly in vault",
+        )
+        self.assertIsNone(
+            server3_secrets.get("host_key"),
+            "Server 3 should not have host_key in vault",
+        )
+
+        # Test 3: Verify that non-secret fields are not affected
+        for server in servers:
+            self.assertIsNotNone(
+                server.name,
+                f"Server {server.id} name should not be affected by vault mixin",
+            )
+            self.assertIsNotNone(
+                server.ssh_username,
+                f"Server {server.id} ssh_username should not be affected "
+                f"by vault mixin",
+            )
+            self.assertIsNotNone(
+                server.ip_v4_address,
+                f"Server {server.id} ip_v4_address should not be affected "
+                f"by vault mixin",
+            )
+
+        # Test 4: Modify secret fields and verify changes are handled correctly
+        # Change the ssh password and remove the host key from Server 1
+        server1 = servers.filtered(lambda s: s.name == "Server 1 - Both Fields")
+        server1.write(
+            {
+                "ssh_password": "updated_password1",
+                "host_key": False,
+            }
+        )
+
+        # Remove host key and add an ssh password in Server 2
+        server2 = servers.filtered(lambda s: s.name == "Server 2 - Host Key Only")
+        server2.write(
+            {
+                "host_key": False,
+                "ssh_password": "new_password2",
+            }
+        )
+
+        # Remove ssh password from Server 3
+        server3 = servers.filtered(lambda s: s.name == "Server 3 - SSH Password Only")
+        server3.write(
+            {
+                "ssh_password": False,
+            }
+        )
+
+        # Test 5: Get values for all 3 servers regular way after modifications
+        # Ensure that all values are replaced with placeholders
+        for server in servers:
+            self.assertEqual(
+                server.ssh_password,
+                placeholder,
+                f"Server {server.id} ssh_password should return placeholder "
+                f"after modifications",
+            )
+            self.assertEqual(
+                server.host_key,
+                placeholder,
+                f"Server {server.id} host_key should return placeholder "
+                f"after modifications",
+            )
+
+        # Test 6: Get values for all 3 servers at once using _get_secret_values()
+        # Ensure that all values are preserved correctly after modifications
+        all_secret_values = servers._get_secret_values()
+        self.assertIsNotNone(
+            all_secret_values,
+            "all_secret_values should not be None after modifications",
+        )
+
+        # Verify Server 1 (updated password, no host key)
+        server1 = servers[0]
+        server1_secrets = all_secret_values[server1.id]
+
+        self.assertEqual(
+            server1_secrets.get("ssh_password"),
+            "updated_password1",
+            "Server 1 ssh_password should be updated correctly in vault",
+        )
+        self.assertIsNone(
+            server1_secrets.get("host_key"),
+            "Server 1 host_key should be removed from vault",
+        )
+
+        # Verify Server 2 (new password, no host key)
+        server2_secrets = all_secret_values[server2.id]
+
+        self.assertEqual(
+            server2_secrets.get("ssh_password"),
+            "new_password2",
+            "Server 2 ssh_password should be added correctly in vault",
+        )
+        self.assertIsNone(
+            server2_secrets.get("host_key"),
+            "Server 2 host_key should be removed from vault",
+        )
+
+        # Verify Server 3 (no ssh password, no host key)
+        # Server 3 should not be in the result since it has no secret values
+        self.assertNotIn(
+            server3.id,
+            all_secret_values,
+            "Server 3 should not be in secret values since it has no secret fields",
+        )

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -627,7 +627,10 @@ records:
 
         srv = self.env["cx.tower.server"].get_by_reference("srv_nopass")
         self.assertTrue(srv, "Server was not created")
-        self.assertFalse(srv.ssh_password, "ssh_password must stay empty after import")
+        self.assertFalse(
+            srv._get_secret_value("ssh_password"),
+            "ssh_password must stay empty after import",
+        )
 
     def test_orm_create_server_requires_password(self):
         """Creating a server via ORM/UI must fail when ssh_password is missing."""


### PR DESCRIPTION
Implement a new approach for storing confidential data in a centralized way to avoid code duplication and improve maintainability.

The solution introduces a centralized secret storage mechanism through an abstract mixin and dedicated vault model. This approach eliminates code duplication across cx.tower.key, cx.tower.key.value, and cx.tower.server models by moving shared secret handling logic to a reusable component.

This implementation provides a foundation that can be easily extended to use external key management systems by overriding the mixin functions, improving both security and scalability.

Task: 4824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized vault for secrets: secrets (SSH passwords, host keys, key values) are stored in a vault; UI shows placeholders while secrets remain retrievable via secret accessors. Server creation now enforces SSH password when required.

- **Tests**
  - Added and updated tests for vault masking, retrieval, updates, deletions, and bulk creation; tests use the placeholder.

- **Chores**
  - Migration to vault storage added; package dependency updated and development status removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->