### PR TITLE
[17.0][i18n] update italian

### DIFF
--- a/cetmix_tower_server/i18n/it.po
+++ b/cetmix_tower_server/i18n/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2025-08-18 13:53+0100\n"
+"PO-Revision-Date: 2025-09-04 16:30+0100\n"
 "Last-Translator: \n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/tower-server-14-0-dev/cetmix_tower_server/it/>\n"
 "MIME-Version: 1.0\n"
@@ -380,6 +380,13 @@ msgid "Access level is not defined for '%(variable)s'"
 msgstr "Il livello di accesso non è definito per '%(variable)s'"
 
 #. module: cetmix_tower_server
+#. odoo-javascript
+#: code:addons/cetmix_tower_server/static/src/components/ace_variables/ace_variables.esm.js:0
+#, python-format
+msgid "Ace Tower Editor"
+msgstr "Editor Ace Tower"
+
+#. module: cetmix_tower_server
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command__action
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command_log__command_action
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command_run_wizard__action
@@ -562,6 +569,11 @@ msgstr "Intervallo sincronizzazione automatica"
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_scheduled_task_cv__value_char
 msgid "Automatically populated from selected option. Manual edits will be overwritten when option changes."
 msgstr "Compilato auitomaticamente dall'opzione selezionata. Le modifiche manuali verranno sovrascritte quando si modifica l'opzione."
+
+#. module: cetmix_tower_server
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_automation_root
+msgid "Automation"
+msgstr "Automazione"
 
 #. module: cetmix_tower_server
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_file_template_view_search
@@ -859,7 +871,10 @@ msgid "Child plans"
 msgstr "Piani figli"
 
 #. module: cetmix_tower_server
+#. odoo-javascript
+#: code:addons/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.xml:0
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.view_cx_tower_server_host_key_wizard_form
+#, python-format
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2192,6 +2207,7 @@ msgstr "Riferimento chiave per utilizzo inline"
 
 #. module: cetmix_tower_server
 #: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_key
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_key_root
 msgid "Keys and Secrets"
 msgstr "Chiavi e segreti"
 
@@ -2328,6 +2344,7 @@ msgid "Log Type"
 msgstr "Tipo registro"
 
 #. module: cetmix_tower_server
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_log_root
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_command_view_form
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_plan_view_form
 msgid "Logs"
@@ -2421,6 +2438,13 @@ msgstr "Variabili richieste mancanti"
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_server_template_create_wizard__missing_required_variables_message
 msgid "Missing Required Variables Message"
 msgstr "Messaggio variabili richieste mancanti"
+
+#. module: cetmix_tower_server
+#. odoo-javascript
+#: code:addons/cetmix_tower_server/static/src/components/ace_variables/ace_variables.esm.js:0
+#, python-format
+msgid "Mode"
+msgstr "Modalità"
 
 #. module: cetmix_tower_server
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_file_view_form
@@ -2549,11 +2573,25 @@ msgid "No runner found for command action '%(cmd_action)s'"
 msgstr "Nessuna esecuzione trovata per l'azione comando '%(cmd_action)s'"
 
 #. module: cetmix_tower_server
+#. odoo-javascript
+#: code:addons/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.xml:0
+#, python-format
+msgid "No secrets found"
+msgstr "Nessun segreto trovato"
+
+#. module: cetmix_tower_server
 #. odoo-python
 #: code:addons/cetmix_tower_server/models/cetmix_tower.py:0
 #, python-format
 msgid "No server found for the provided reference."
 msgstr "Nessun server trovato per il riferimento fornito."
+
+#. module: cetmix_tower_server
+#. odoo-javascript
+#: code:addons/cetmix_tower_server/static/src/components/ace_variables/autocomplete_popup.xml:0
+#, python-format
+msgid "No variables found"
+msgstr "Nessuna variabile trovata"
 
 #. module: cetmix_tower_server
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_server_template_create_wizard_view_form
@@ -2633,11 +2671,6 @@ msgstr "SO %(os)s usato dal server '%(srv)s' non è presente nella lista compati
 #. module: cetmix_tower_server
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command__os_ids
 msgid "OSes"
-msgstr "SO"
-
-#. module: cetmix_tower_server
-#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_os
-msgid "OSs"
 msgstr "SO"
 
 #. module: cetmix_tower_server
@@ -2721,6 +2754,11 @@ msgstr "Apri maschera completa"
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_server_template_create_wizard__os_id
 msgid "Operating System"
 msgstr "Sistema operativo"
+
+#. module: cetmix_tower_server
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_os
+msgid "Operating Systems"
+msgstr "Sistemi operativi"
 
 #. module: cetmix_tower_server
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_command_run_wizard_variable_value__option_id
@@ -2917,6 +2955,11 @@ msgstr "Versione anteprima"
 #: model:ir.model.fields,help:cetmix_tower_server.field_cx_tower_scheduled_task__last_call
 msgid "Previous time the task ran successfully."
 msgstr "Orario precedente in cui il lavoro è stato eseguito con successo."
+
+#. module: cetmix_tower_server
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_property_root
+msgid "Properties"
+msgstr "Proprietà"
 
 #. module: cetmix_tower_server
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.res_config_settings_view_form
@@ -4457,6 +4500,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_template_mixin__variable_ids
 #: model:ir.model.fields,field_description:cetmix_tower_server.field_cx_tower_variable_value__variable_ids
 #: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_variable
+#: model:ir.ui.menu,name:cetmix_tower_server.menu_cx_tower_variable_root
 msgid "Variables"
 msgstr "Variabili"
 
@@ -4683,6 +4727,9 @@ msgstr "value: valore della variabile"
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_server.cx_tower_plan_run_wizard_view_form
 msgid "with tags"
 msgstr "quali etichette"
+
+#~ msgid "OSs"
+#~ msgstr "SO"
 
 #~ msgid ""
 #~ "\n"

--- a/cetmix_tower_server_notify_backend/i18n/it.po
+++ b/cetmix_tower_server_notify_backend/i18n/it.po
@@ -55,6 +55,14 @@ msgstr "Registro comandi Cetmix Tower"
 msgid "Cetmix Tower Flight Plan Log"
 msgstr "Registro piani di volo Cetmix Tower"
 
+#. module: cetmix_tower_server_notify_backend
+#. odoo-python
+#: code:addons/cetmix_tower_server_notify_backend/models/cx_tower_command_log.py:0
+#: code:addons/cetmix_tower_server_notify_backend/models/cx_tower_plan_log.py:0
+#, python-format
+msgid "View Log"
+msgstr "Visualizza registro"
+
 #~ msgid "Display Name"
 #~ msgstr "Nome visualizzato"
 

--- a/cetmix_tower_yaml/i18n/it.po
+++ b/cetmix_tower_yaml/i18n/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2025-08-19 10:51+0100\n"
+"PO-Revision-Date: 2025-09-04 16:34+0100\n"
 "Last-Translator: \n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/tower-server-14-0-dev/cetmix_tower_yaml/it/>\n"
 "MIME-Version: 1.0\n"
@@ -67,6 +67,11 @@ msgstr "Aggiungi manifest"
 #: model:ir.model.fields,help:cetmix_tower_yaml.field_cx_tower_yaml_export_wiz__explode_child_records
 msgid "Add entire child record definitions to the exported YAML file. Otherwise only references to child records will be added."
 msgstr "Aggiungere le definizioni di tutti i record figli allo YAML esportato. Altrimenti solo i riferimenti ai record figli verranno aggiunti."
+
+#. module: cetmix_tower_yaml
+#: model:ir.model.fields,help:cetmix_tower_yaml.field_cx_tower_yaml_manifest_tmpl__file_prefix
+msgid "Add prefix to the exported YAML file name when this template is selected"
+msgstr "Aggiungere un prefisso al nome del file YAML esportato quando è selezionato questo modello"
 
 #. module: cetmix_tower_yaml
 #. odoo-python
@@ -267,6 +272,13 @@ msgid "Currency is required when price is specified"
 msgstr "La valuta è richiesta quando è indicato il prezzo"
 
 #. module: cetmix_tower_yaml
+#. odoo-python
+#: code:addons/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py:0
+#, python-format
+msgid "Custom"
+msgstr "Personalizzata"
+
+#. module: cetmix_tower_yaml
 #: model:ir.model.fields,help:cetmix_tower_yaml.field_cx_tower_yaml_manifest_tmpl__license_text
 msgid "Custom license text when license type is Custom."
 msgstr "Testo licenza personalizzato quando il tipo licenza è personalizzato."
@@ -307,6 +319,13 @@ msgstr "Errore durante la creazione del record '%(reference)s' nel modello '%(mo
 #, python-format
 msgid "Error updating record %(reference)s: %(error)s"
 msgstr "Errore durante l'aggiornamento del record %(reference)s: %(error)s"
+
+#. module: cetmix_tower_yaml
+#. odoo-python
+#: code:addons/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py:0
+#, python-format
+msgid "Euro"
+msgstr "Euro"
 
 #. module: cetmix_tower_yaml
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_yaml_import_wiz_view_form
@@ -371,6 +390,11 @@ msgstr "Nome file"
 #, python-format
 msgid "File contains non-unicode characters or is empty"
 msgstr "Il file contiene caratteri non unicode o è vuoto"
+
+#. module: cetmix_tower_yaml
+#: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_yaml_manifest_tmpl__file_prefix
+msgid "File prefix"
+msgstr "Prefisso file"
 
 #. module: cetmix_tower_yaml
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_yaml_export_wiz_view_form
@@ -508,9 +532,19 @@ msgid "Manifest"
 msgstr "Manifest"
 
 #. module: cetmix_tower_yaml
+#: model:ir.ui.menu,name:cetmix_tower_yaml.menu_yaml_manifest_author_action
+msgid "Manifest Authors"
+msgstr "Autori manifest"
+
+#. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_yaml_export_wiz__manifest_template_id
 msgid "Manifest Template"
 msgstr "Modello manifest"
+
+#. module: cetmix_tower_yaml
+#: model:ir.ui.menu,name:cetmix_tower_yaml.menu_yaml_manifest_template
+msgid "Manifest Templates"
+msgstr "Modelli manifest"
 
 #. module: cetmix_tower_yaml
 #. odoo-python
@@ -610,8 +644,8 @@ msgstr "Processo"
 #. odoo-python
 #: code:addons/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py:0
 #, python-format
-msgid "Provide Custom License Text when License is set to “Custom”."
-msgstr "Fornire un testo licenza personalizzato quando la licenza è impostata su \"Personalizzata\"."
+msgid "Provide Custom License Text when License is set to 'Custom'."
+msgstr "Fornire il testo della licenza quando la licenza è impostata su \"Personalizzata\"."
 
 #. module: cetmix_tower_yaml
 #. odoo-python
@@ -722,6 +756,13 @@ msgid "To create new entities instead of updating existing ones, remove or modif
 msgstr "Per creare nuovi record anziché aggiornare quelli esistenti, rimuovere o modificare il campo <code>reference</code> nel codice YAML per tali record."
 
 #. module: cetmix_tower_yaml
+#. odoo-python
+#: code:addons/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py:0
+#, python-format
+msgid "US Dollar"
+msgstr "Dollaro USA"
+
+#. module: cetmix_tower_yaml
 #: model:ir.model.fields.selection,name:cetmix_tower_yaml.selection__cx_tower_yaml_import_wiz__if_record_exists__update
 msgid "Update existing record"
 msgstr "Aggiorna record esistente"
@@ -820,6 +861,11 @@ msgid "YAML Export"
 msgstr "Esporta YAML"
 
 #. module: cetmix_tower_yaml
+#: model:ir.ui.menu,name:cetmix_tower_yaml.menu_yaml_settings_root
+msgid "YAML Export/Import"
+msgstr "Esporta/Importa YAML"
+
+#. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_yaml_export_wiz__yaml_file_name
 msgid "YAML File Name"
 msgstr "Nome file YAML"
@@ -836,7 +882,6 @@ msgstr "Autore manifest YAML"
 
 #. module: cetmix_tower_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_yaml_manifest_author
-#: model:ir.ui.menu,name:cetmix_tower_yaml.menu_yaml_manifest_author_action
 msgid "YAML Manifest Authors"
 msgstr "Autori manifest YAML"
 
@@ -847,7 +892,6 @@ msgstr "Modello manifest YAML"
 
 #. module: cetmix_tower_yaml
 #: model:ir.actions.act_window,name:cetmix_tower_yaml.action_yaml_manifest_template
-#: model:ir.ui.menu,name:cetmix_tower_yaml.menu_yaml_manifest_template
 msgid "YAML Manifest Templates"
 msgstr "Modelli manifest YAML"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Expanded Italian translations across the app, including Ace Tower Editor UI (labels, autocomplete, mode).
  * New Italian menu labels: Automation, Operating Systems, Logs, Keys and Secrets, Variables.
  * Added Italian strings for YAML Export/Import: file prefix, generate YAML, manifest Authors/Templates, currencies (Euro, US Dollar), and related menus.
  * Added “View Log” translation in notifications backend.
* Chores
  * Removed/updated outdated OS-related terms and deprecated help strings; alignment and consistency improvements in Italian UI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->