### PR TITLE
[16.0][IMP] cetmix_tower_server: inherit Auto Sync from file template

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -15,6 +15,7 @@ TEMPLATE_FILE_FIELD_MAPPING = {
     "file_type": "file_type",
     "server_dir": "server_dir",
     "keep_when_deleted": "keep_when_deleted",
+    "auto_sync": "auto_sync",
 }
 
 # to convert to 'relativedelta' object
@@ -484,7 +485,7 @@ class CxTowerFile(models.Model):
         return {
             key: values[name]
             for name, key in TEMPLATE_FILE_FIELD_MAPPING.items()
-            if values.get(name)
+            if name in values
         }
 
     @api.model

--- a/cetmix_tower_server/models/cx_tower_file_template.py
+++ b/cetmix_tower_server/models/cx_tower_file_template.py
@@ -41,6 +41,10 @@ class CxTowerFileTemplate(models.Model):
     keep_when_deleted = fields.Boolean(
         help="File will be kept on server when deleted in Tower",
     )
+    auto_sync = fields.Boolean(
+        help="If enabled, files created from this template will have "
+        "Auto Sync enabled by default. Used only with 'Tower' source.",
+    )
     file_type = fields.Selection(
         selection=lambda self: self.env["cx.tower.file"]._selection_file_type(),
         default=lambda self: self.env["cx.tower.file"]._default_file_type(),
@@ -216,6 +220,7 @@ class CxTowerFileTemplate(models.Model):
             "code": self.code,
             "file_type": self.file_type,
             "source": self.source,
+            "auto_sync": self.auto_sync,
         }
 
         new_file = file_model.with_context(is_custom_server_dir=True).create(vals)

--- a/cetmix_tower_server/readme/newsfragments/4949.feature
+++ b/cetmix_tower_server/readme/newsfragments/4949.feature
@@ -1,0 +1,1 @@
+Set 'Auto Sync' in files from file templates

--- a/cetmix_tower_server/views/cx_tower_file_template_view.xml
+++ b/cetmix_tower_server/views/cx_tower_file_template_view.xml
@@ -45,6 +45,10 @@
                                 attrs="{'invisible': [('source', '=', 'server')]}"
                             />
                             <field name="file_type" />
+                            <field
+                                name="auto_sync"
+                                attrs="{'invisible': [('source', '=', 'server')]}"
+                            />
                             <field name="note" />
                             <field
                                 name="variable_ids"
@@ -105,6 +109,7 @@
                 <field name="file_type" optional="show" />
                 <field name="file_name" optional="show" />
                 <field name="server_dir" optional="hide" />
+                <field name="auto_sync" optional="hide" />
                 <field
                     name="tag_ids"
                     widget="many2many_tags"

--- a/cetmix_tower_server_queue/tests/test_file.py
+++ b/cetmix_tower_server_queue/tests/test_file.py
@@ -25,6 +25,7 @@ class TestCxTowerFileQueue(TestTowerCommon):
                 "template_id": self.file_template.id,
                 "server_id": self.server_test_1.id,
                 "name": "upload_test_1",
+                "auto_sync": False,
             }
         )
 
@@ -34,6 +35,7 @@ class TestCxTowerFileQueue(TestTowerCommon):
                 "source": "server",
                 "server_id": self.server_test_1.id,
                 "server_dir": "/var/tmp",
+                "auto_sync": False,
             }
         )
 
@@ -66,6 +68,7 @@ class TestCxTowerFileQueue(TestTowerCommon):
                 "template_id": self.file_template.id,
                 "server_id": self.server_test_1.id,
                 "name": "download_test_1",
+                "auto_sync": False,
             }
         )
 
@@ -75,6 +78,7 @@ class TestCxTowerFileQueue(TestTowerCommon):
                 "source": "server",
                 "server_id": self.server_test_1.id,
                 "server_dir": "/var/tmp",
+                "auto_sync": False,
             }
         )
 
@@ -109,6 +113,7 @@ class TestCxTowerFileQueue(TestTowerCommon):
                 "template_id": self.file_template.id,
                 "server_id": self.server_test_1.id,
                 "name": "error_handling_test",
+                "auto_sync": False,
             }
         )
 


### PR DESCRIPTION
Avoid missing updates for files created from templates by introducing
Auto Sync on file templates and propagating it to related files.

Ensures created/updated files respect template’s intent without losing
False values during propagation.

Task: 4949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an "Auto Sync" option to file templates (visible in template forms; hidden for server-based templates) and optionally shown in lists.
  - Files created from Tower-sourced templates inherit the template's Auto Sync setting.

- Bug Fixes
  - Template-to-file propagation now preserves fields present in templates (including falsy values), ensuring Auto Sync is populated.

- Tests
  - Updated tests to include Auto Sync in created file payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->