### PR TITLE
[17.0][MIG] cetmix_tower_server: forward port from 16.0

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -297,7 +297,12 @@ class CxTowerPlan(models.Model):
         server_variable_values = server.variable_value_ids
 
         # Check line condition
-        if not current_line._is_executable_line(server):
+        variable_values = (
+            command_log.variable_values or command_log.plan_log_id.variable_values
+        )
+        if not current_line._is_executable_line(
+            server, variable_values=variable_values
+        ):
             # Immediately return to the next line if condition fails
             return self._get_next_action_state(
                 "n", PLAN_LINE_CONDITION_CHECK_FAILED, current_line
@@ -382,10 +387,9 @@ class CxTowerPlan(models.Model):
         # Run next line
         if action == "n" and plan_line:
             server = command_log.server_id
-            if plan_line._is_executable_line(server):
-                plan_line._run(
-                    server, plan_log, variable_values=plan_log.variable_values
-                )
+            variable_values = command_log.variable_values or plan_log.variable_values
+            if plan_line._is_executable_line(server, variable_values=variable_values):
+                plan_line._run(server, plan_log, variable_values=variable_values)
             else:
                 plan_line._skip(server, plan_log)
 

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -204,12 +204,15 @@ class CxTowerPlanLine(models.Model):
         path = self.path or command_as_root.path
         server.run_command(command_as_root, path, sudo=use_sudo, **kwargs)
 
-    def _is_executable_line(self, server):
+    def _is_executable_line(self, server, variable_values=None):
         """
         Check if this line can be executed based on its condition.
 
         Args:
             server (cx.tower.server()): The server on which conditions are checked.
+            variable_values (dict, optional): Custom values provided when running the
+                flight plan. These values are merged with server variables when
+                rendering the condition.
 
         Returns:
             bool: True if the line can be executed, otherwise False.
@@ -217,14 +220,22 @@ class CxTowerPlanLine(models.Model):
         self.ensure_one()
         condition = self.condition
         if condition:
+            # Collect variable references used in the condition
             variables = self.command_id.get_variables_from_code(condition)
+
+            # Values from server variables referenced in the condition
+            server_values = {}
             if variables:
-                variable_values_dict = (
-                    server.get_variable_values(variables) if variables else {}
-                )
-                variable_values = variable_values_dict.get(server.id, {})
+                variable_values_dict = server.get_variable_values(variables)
+                server_values = variable_values_dict.get(server.id, {}) or {}
+
+            # Merge with custom values passed to the flight plan (if any)
+            merged_values = {**server_values, **(variable_values or {})}
+
+            # Render condition with all available values (in pythonic mode)
+            if merged_values:
                 condition = self.command_id.render_code_custom(
-                    condition, pythonic_mode=True, **variable_values
+                    condition, pythonic_mode=True, **merged_values
                 )
 
             # For evaluate a string that contains an expression that mostly uses

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -150,12 +150,15 @@ class CxTowerPlanLog(models.Model):
             cx.tower.plan.log(): New flightplan log record.
         """
 
-        def get_executable_line(plan, server):
+        def get_executable_line(plan, server, variable_values=None):
             """
             Generator to get each line and check if it's executable.
             """
             for line in plan.line_ids:
-                yield line, line._is_executable_line(server)
+                yield (
+                    line,
+                    line._is_executable_line(server, variable_values=variable_values),
+                )
 
         vals = {
             "server_id": server.id,
@@ -177,7 +180,9 @@ class CxTowerPlanLog(models.Model):
         plan_log = self.sudo().create(vals)
 
         # Process each line until the first executable one is found
-        for line, is_executable in get_executable_line(plan, server):
+        for line, is_executable in get_executable_line(
+            plan, server, variable_values=variable_values
+        ):
             if is_executable:
                 line._run(server, plan_log, **kwargs)
                 break

--- a/cetmix_tower_server/readme/newsfragments/4922.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4922.bugfix
@@ -1,0 +1,1 @@
+Check custom values in flight plan line condition

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -1998,3 +1998,66 @@ custom_values['random_var_reference'] = 'another_random_var_value'
             plan_log.variable_values[self.variable_url.reference],
             "https://www.cetmix.com",
         )
+
+    def test_plan_with_custom_values_in_condition(self):
+        """
+        Ensure that plan line conditions see updated custom_values
+        produced by previous commands.
+
+        1) python sets test_path_ = '/test_path'
+        2) create_dir with condition "{{ test_path_ }} == '/test_path'" -> executes
+        3) python updates test_path_ = '/another_test_path'
+        4) create_dir with condition "{{ test_path_ }} == '/another_test_path'"
+           -> executes
+        Then invert conditions and check both lines are skipped appropriately.
+        """
+        command_python_1_id = self.command_python_custom_variable_values_1.id
+        command_python_2_id = self.command_python_custom_variable_values_2.id
+
+        plan = self._create_plan(
+            **{
+                "name": "Plan with custom_values in condition",
+                "line_ids": [
+                    (0, 0, {"command_id": command_python_1_id, "sequence": 1}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": self.command_create_dir.id,
+                            "sequence": 2,
+                            "condition": "{{ test_path_ }} == '/test_path'",
+                        },
+                    ),
+                    (0, 0, {"command_id": command_python_2_id, "sequence": 3}),
+                    (
+                        0,
+                        0,
+                        {
+                            "command_id": self.command_create_dir.id,
+                            "sequence": 4,
+                            "condition": "{{ test_path_ }} == '/another_test_path'",
+                        },
+                    ),
+                ],
+            }
+        )
+
+        plan_log = self.server_test_1.run_flight_plan(plan)
+
+        logs = plan_log.command_log_ids
+        self.assertEqual(len(logs), 4, "Should be 4 command logs")
+
+        create_dir_logs = logs.filtered(
+            lambda line: line.command_id == self.command_create_dir
+        )
+        self.assertEqual(len(create_dir_logs), 2, "Should be 2 create_dir logs")
+
+        self.assertFalse(
+            create_dir_logs[0].is_skipped, "First create_dir must be executed"
+        )
+        self.assertFalse(
+            create_dir_logs[1].is_skipped, "Second create_dir must be executed"
+        )
+
+        self.assertIn("/test_path", create_dir_logs[0].code)
+        self.assertIn("/another_test_path", create_dir_logs[1].code)

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -37,8 +37,9 @@
                         <field name="note" readonly="1" invisible="not note" />
                     </group>
                     <group>
-                    <field name="condition" widget="ace" options="{'mode': 'python'}" />
-            </group>
+                        <label for="condition" string="Condition" />
+                        <field name="condition" widget="ace_tower" />
+                    </group>
                     <notebook>
                         <page name="preview" string="Preview">
                             <field
@@ -75,8 +76,7 @@
                                     <field name="path" optional="show" />
                                     <field
                                         name="condition"
-                                        widget="ace"
-                                        options="{'mode': 'python'}"
+                                        widget="ace_tower"
                                         optional="show"
                                     />
                                 </tree>


### PR DESCRIPTION
Forward port the following PR:

[[FIX] cetmix_tower_server: Custom values in fp line condition](https://github.com/cetmix/cetmix-tower/pull/392)

Task: 4934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Plan line conditions now correctly honor custom variable values during execution, ensuring the right steps run or skip as expected.
- Style
  - Updated the “Condition” field to use the ace_tower editor and added a visible label for clearer editing in forms and lists.
- Documentation
  - Added a changelog entry noting the fix for checking custom values in plan line conditions.
- Tests
  - Added tests to verify conditions react to updated custom values across sequential plan lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->