### PR TITLE
[16.0][FIX] cetmix_tower_server: Fix references for variable values

### DIFF
--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import re
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -458,6 +459,73 @@ class TowerVariableValue(models.Model):
                 is_global = False
                 break
         return is_global
+
+    def _pre_populate_references(self, model_name, field_name, vals_list):
+        """
+        Generate model-scoped references for variable values.
+
+        Overrides the mixin method to implement a model-dependent reference pattern.
+
+        Pattern:
+            <variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>
+        Global:
+            <variable_reference>_<model_generic_reference>_global
+        """
+        # Collect parent variable references
+        parent_record_refs = self._prepare_references(model_name, field_name, vals_list)
+        model_reference = self._get_model_generic_reference()
+
+        # Prepare mappings for linked models defined in _used_in_models
+        used_models = self._used_in_models() or {}
+        # Map m2o field -> model name
+        m2o_to_model = {info[0]: model for model, info in used_models.items()}
+        # Precompute linked model generic refs and record refs
+        linked_generic_by_field = {}
+        linked_refs_by_field = {}
+        for model, (m2o_field, _desc) in used_models.items():
+            linked_generic_by_field[m2o_field] = self.env[
+                model
+            ]._get_model_generic_reference()
+            linked_refs_by_field[m2o_field] = self._prepare_references(
+                model, m2o_field, vals_list
+            )
+
+        for vals in vals_list:
+            # Respect explicitly provided references with at least one valid symbol
+            existing_reference = vals.get("reference")
+            if existing_reference and bool(
+                re.search(self.REFERENCE_PRELIMINARY_PATTERN, existing_reference)
+            ):
+                continue
+
+            variable_id = vals.get(field_name)
+            variable_reference = parent_record_refs.get(variable_id)
+            if not variable_reference:
+                # Fallback to generic variable reference if parent reference missing
+                variable_reference = self.env[model_name]._get_model_generic_reference()
+
+            # Determine which related model the value is linked to
+            linked_m2o_field = next(
+                (f for f in m2o_to_model.keys() if vals.get(f)), None
+            )
+
+            if linked_m2o_field:
+                linked_model_generic = linked_generic_by_field.get(linked_m2o_field)
+                linked_record_id = vals.get(linked_m2o_field)
+                linked_record_reference = linked_refs_by_field.get(
+                    linked_m2o_field, {}
+                ).get(linked_record_id)
+                vals["reference"] = (
+                    f"{variable_reference}_"
+                    f"{model_reference}_"
+                    f"{linked_model_generic}_"
+                    f"{linked_record_reference}"
+                )
+            else:
+                # Global value (not linked to any record)
+                vals["reference"] = f"{variable_reference}_{model_reference}_global"
+
+        return vals_list
 
     # Check cx.tower.reference.mixin for the function documentation
     def _get_pre_populated_model_data(self):

--- a/cetmix_tower_server/readme/newsfragments/4961.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4961.bugfix
@@ -1,0 +1,1 @@
+Improve variable value references uniqueness

--- a/cetmix_tower_server/tests/test_variable_value.py
+++ b/cetmix_tower_server/tests/test_variable_value.py
@@ -532,3 +532,33 @@ class TestTowerVariableValue(common.TestTowerCommon):
             [("plan_line_action_id", "=", self.test_plan_line_action.id)]
         )
         self.assertIn(plan_action_value.id, manager_plan_values.ids)
+
+    def test_reference_pattern_global_server_template_action(self):
+        """Ensure model-scoped references follow the required pattern."""
+        # Global
+        model_ref = self.VariableValue._get_model_generic_reference()
+        self.assertTrue(self.global_value_1.reference.endswith(f"_{model_ref}_global"))
+
+        # Server
+        srv_model_ref = self.Server._get_model_generic_reference()
+        self.assertTrue(
+            self.server_value_1.reference.startswith(
+                f"{self.variable_level_1.reference}_{model_ref}_{srv_model_ref}_"
+            )
+        )
+
+        # Server Template
+        tmpl_model_ref = self.ServerTemplate._get_model_generic_reference()
+        self.assertTrue(
+            self.template_value_1.reference.startswith(
+                f"{self.variable_level_1.reference}_{model_ref}_{tmpl_model_ref}_"
+            )
+        )
+
+        # Plan Line Action
+        action_model_ref = self.plan_line_action._get_model_generic_reference()
+        self.assertTrue(
+            self.plan_value_1.reference.startswith(
+                f"{self.variable_level_1.reference}_{model_ref}_{action_model_ref}_"
+            )
+        )


### PR DESCRIPTION
Previously, variable values used a generic reference pattern like `instance_url_variable_value_1_6`. This caused conflicts because the same reference key could appear in different models and Tower instances. As a result, YAML imports could unintentionally override unrelated records and raise errors.

Now variable references are model-dependent. The new naming convention follows the pattern:

```
<related_variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>
```

For global values, the record-specific part is replaced with the `_global` suffix.

Examples:
- Server: instance_url_variable_value_server_my_new_server
- Server template: instance_url_variable_value_server_template_woocommerce
- Global: instance_url_variable_value_global

This ensures references are unique across models and instances.

Task: 4961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent variable reference collisions by generating model-scoped references and preserving explicitly provided references.
  * Ensure consistent patterns for global and linked-record values to improve pre-population reliability.

* **Tests**
  * Added tests validating reference patterns for global, server, server-template, and plan-line-action scopes and cross-model uniqueness.

* **Chores**
  * Added release note fragment documenting the bug fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->