### PR TITLE
[16.0][FIX] cetmix_tower_server: Fix validation error

### DIFF
--- a/cetmix_tower_webhook/models/cx_tower_webhook.py
+++ b/cetmix_tower_webhook/models/cx_tower_webhook.py
@@ -152,6 +152,7 @@ class CxTowerWebhook(models.Model):
         """Override to add fields to YAML export."""
         res = super()._get_fields_for_yaml()
         res += [
+            "name",
             "active",
             "authenticator_id",
             "endpoint",


### PR DESCRIPTION
**Steps to reproduce**

- Export existing webhook in YAML (attached to the task)
- Import it on another server

**Expected result**

- Webhook is created
- Webhook authenticator is created

**Current result**
- Validation Error
<img width="684" height="186" alt="image" src="https://github.com/user-attachments/assets/88b251ad-bee6-4cfd-a81f-8cca883308c8" />

**After this commit**

- YAML exports for Tower webhooks now include the “Name” field, making exported configurations easier to identify and review without validation error.

Task: 4972