### PR TITLE
[16.0][IMP] cetmix_tower_webhook Variables and secrets

### DIFF
--- a/cetmix_tower_webhook/__init__.py
+++ b/cetmix_tower_webhook/__init__.py
@@ -1,3 +1,2 @@
 from . import controllers
 from . import models
-from . import wizards

--- a/cetmix_tower_webhook/__manifest__.py
+++ b/cetmix_tower_webhook/__manifest__.py
@@ -16,6 +16,7 @@
         "views/cx_tower_webhook_authenticator_views.xml",
         "views/cx_tower_webhook_log_views.xml",
         "views/cx_tower_webhook_views.xml",
+        "views/cx_tower_variable_views.xml",
         "views/res_config_settings_views.xml",
         "views/menuitems.xml",
     ],

--- a/cetmix_tower_webhook/models/__init__.py
+++ b/cetmix_tower_webhook/models/__init__.py
@@ -5,4 +5,5 @@ from . import cx_tower_webhook_eval_mixin
 from . import cx_tower_webhook_authenticator
 from . import cx_tower_webhook_log
 from . import cx_tower_webhook
+from . import cx_tower_variable
 from . import res_config_settings

--- a/cetmix_tower_webhook/models/cx_tower_variable.py
+++ b/cetmix_tower_webhook/models/cx_tower_variable.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class CxTowerVariable(models.Model):
+    _inherit = "cx.tower.variable"
+
+    # --- Link to records where the variable is used
+    webhook_ids = fields.Many2many(
+        comodel_name="cx.tower.webhook",
+        relation="cx_tower_webhook_variable_rel",
+        column1="variable_id",
+        column2="webhook_id",
+        copy=False,
+    )
+    webhook_ids_count = fields.Integer(
+        string="Webhook Count", compute="_compute_webhook_ids_count"
+    )
+    webhook_authenticator_ids = fields.Many2many(
+        comodel_name="cx.tower.webhook.authenticator",
+        relation="cx_tower_webhook_authenticator_variable_rel",
+        column1="variable_id",
+        column2="webhook_authenticator_id",
+        copy=False,
+    )
+    webhook_authenticator_ids_count = fields.Integer(
+        string="Webhook Authenticator Count", compute="_compute_webhook_ids_count"
+    )
+
+    def _compute_webhook_ids_count(self):
+        """
+        Count number of webhooks and webhook authenticators for the variable
+        """
+        for rec in self:
+            rec.update(
+                {
+                    "webhook_ids_count": len(rec.webhook_ids),
+                    "webhook_authenticator_ids_count": len(
+                        rec.webhook_authenticator_ids
+                    ),
+                }
+            )
+
+    def action_open_webhooks(self):
+        """Open the webhooks where the variable is used"""
+
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_webhook.cx_tower_webhook_action"
+        )
+        action.update(
+            {
+                "domain": [("variable_ids", "in", self.ids)],
+            }
+        )
+        return action
+
+    def action_open_webhook_authenticators(self):
+        """Open the webhook authenticators where the variable is used"""
+
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "cetmix_tower_webhook.cx_tower_webhook_authenticator_action"
+        )
+        action.update(
+            {
+                "domain": [("variable_ids", "in", self.ids)],
+            }
+        )
+        return action
+
+    def _get_propagation_field_mapping(self):
+        """
+        Override to add webhook and webhook authenticator
+        to the propagation field mapping.
+        """
+        res = super()._get_propagation_field_mapping()
+        res.update(
+            {
+                "cx.tower.webhook": ["code"],
+                "cx.tower.webhook.authenticator": ["code"],
+            }
+        )
+        return res

--- a/cetmix_tower_webhook/models/cx_tower_webhook.py
+++ b/cetmix_tower_webhook/models/cx_tower_webhook.py
@@ -12,9 +12,7 @@ from .constants import DEFAULT_WEBHOOK_CODE, DEFAULT_WEBHOOK_CODE_HELP
 class CxTowerWebhook(models.Model):
     _name = "cx.tower.webhook"
     _inherit = [
-        "cx.tower.reference.mixin",
         "cx.tower.webhook.eval.mixin",
-        "cx.tower.yaml.mixin",
     ]
     _description = "Webhook"
 
@@ -70,6 +68,12 @@ class CxTowerWebhook(models.Model):
     )
     log_count = fields.Integer(
         compute="_compute_log_count",
+    )
+    variable_ids = fields.Many2many(
+        comodel_name="cx.tower.variable",
+        relation="cx_tower_webhook_variable_rel",
+        column1="webhook_id",
+        column2="variable_id",
     )
 
     _sql_constraints = [
@@ -159,6 +163,8 @@ class CxTowerWebhook(models.Model):
             "method",
             "code",
             "content_type",
+            "variable_ids",
+            "secret_ids",
         ]
         return res
 

--- a/cetmix_tower_webhook/models/cx_tower_webhook_authenticator.py
+++ b/cetmix_tower_webhook/models/cx_tower_webhook_authenticator.py
@@ -19,9 +19,7 @@ _logger = logging.getLogger(__name__)
 class CxTowerWebhookAuthenticator(models.Model):
     _name = "cx.tower.webhook.authenticator"
     _inherit = [
-        "cx.tower.reference.mixin",
         "cx.tower.webhook.eval.mixin",
-        "cx.tower.yaml.mixin",
     ]
     _description = "Webhook Authenticator"
 
@@ -39,6 +37,12 @@ class CxTowerWebhookAuthenticator(models.Model):
         help="Comma-separated list of trusted proxy IP addresses or CIDR ranges "
         "(e.g., 10.0.0.1,192.168.1.0/24). "
         "Only these proxies can set X-Forwarded-For headers.",
+    )
+    variable_ids = fields.Many2many(
+        comodel_name="cx.tower.variable",
+        relation="cx_tower_webhook_authenticator_variable_rel",
+        column1="webhook_authenticator_id",
+        column2="variable_id",
     )
 
     @api.constrains("trusted_proxy_ips")
@@ -135,7 +139,14 @@ class CxTowerWebhookAuthenticator(models.Model):
             list[str]: List of field names.
         """
         res = super()._get_fields_for_yaml()
-        res += ["name", "code", "allowed_ip_addresses", "trusted_proxy_ips"]
+        res += [
+            "name",
+            "code",
+            "allowed_ip_addresses",
+            "trusted_proxy_ips",
+            "variable_ids",
+            "secret_ids",
+        ]
         return res
 
     def authenticate(self, raise_on_error=True, **kwargs):

--- a/cetmix_tower_webhook/models/cx_tower_webhook_eval_mixin.py
+++ b/cetmix_tower_webhook/models/cx_tower_webhook_eval_mixin.py
@@ -8,6 +8,12 @@ from odoo.tools.safe_eval import safe_eval
 
 class CxTowerWebhookEvalMixin(models.AbstractModel):
     _name = "cx.tower.webhook.eval.mixin"
+    _inherit = [
+        "cx.tower.template.mixin",
+        "cx.tower.key.mixin",
+        "cx.tower.yaml.mixin",
+        "cx.tower.reference.mixin",
+    ]
     _description = "Eval context/code helper for Cetmix Tower Webhook"
 
     code_help = fields.Html(
@@ -19,6 +25,11 @@ class CxTowerWebhookEvalMixin(models.AbstractModel):
         default=lambda self: self._default_eval_code(),
         required=True,
     )
+
+    @classmethod
+    def _get_depends_fields(cls):
+        """Add code to the depends fields."""
+        return ["code"]
 
     def _compute_code_help(self):
         """

--- a/cetmix_tower_webhook/readme/newsfragments/4980.bugfix
+++ b/cetmix_tower_webhook/readme/newsfragments/4980.bugfix
@@ -1,0 +1,1 @@
+Export related variables and secrets

--- a/cetmix_tower_webhook/views/cx_tower_variable_views.xml
+++ b/cetmix_tower_webhook/views/cx_tower_variable_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id="cx_tower_variable_view_form" model="ir.ui.view">
+        <field name="name">cx.tower.variable.view.form</field>
+        <field name="model">cx.tower.variable</field>
+        <field
+            name="inherit_id"
+            ref="cetmix_tower_server.cx_tower_variable_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_open_webhooks"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-link"
+                    attrs="{'invisible': [('webhook_ids_count', '=', 0)]}"
+                >
+                    <field
+                        name="webhook_ids_count"
+                        widget="statinfo"
+                        string="Webhooks"
+                    />
+                </button>
+                <button
+                    name="action_open_webhook_authenticators"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-key"
+                    attrs="{'invisible': [('webhook_authenticator_ids_count', '=', 0)]}"
+                >
+                    <field
+                        name="webhook_authenticator_ids_count"
+                        widget="statinfo"
+                        string="Webhook Authenticators"
+                    />
+                </button>
+
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/cetmix_tower_webhook/views/cx_tower_webhook_authenticator_views.xml
+++ b/cetmix_tower_webhook/views/cx_tower_webhook_authenticator_views.xml
@@ -23,6 +23,19 @@
                         <group>
                             <field name="name" />
                             <field name="reference" />
+                            <field
+                                name="variable_ids"
+                                widget="many2many_tags"
+                                readonly="1"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('variable_ids', '=', [])]}"
+                            />
+                            <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('secret_ids', '=', [])]}"
+                            />
                         </group>
                         <group>
                             <field

--- a/cetmix_tower_webhook/views/cx_tower_webhook_views.xml
+++ b/cetmix_tower_webhook/views/cx_tower_webhook_views.xml
@@ -31,6 +31,19 @@
                             <field name="reference" />
                             <field name="active" />
                             <field name="authenticator_id" />
+                            <field
+                                name="variable_ids"
+                                widget="many2many_tags"
+                                readonly="1"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('variable_ids', '=', [])]}"
+                            />
+                            <field
+                                name="secret_ids"
+                                widget="many2many_tags"
+                                groups="cetmix_tower_server.group_manager,cetmix_tower_server.group_root"
+                                attrs="{'invisible': [('secret_ids', '=', [])]}"
+                            />
                         </group>
                         <group>
                             <field name="endpoint" />

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -108,6 +108,7 @@ class CxTowerYamlMixin(models.AbstractModel):
         ):
             raise AccessError(_("You are not allowed to create records from YAML"))
 
+    @api.model_create_multi
     def create(self, vals_list):
         # Handle validation error when field values are not valid
         try:

--- a/cetmix_tower_yaml/readme/newsfragments/4980.bugfix
+++ b/cetmix_tower_yaml/readme/newsfragments/4980.bugfix
@@ -1,0 +1,1 @@
+Add the missing 'create' function decorator


### PR DESCRIPTION
- Export related variables and secrets in YAML.
- Show related variables and secrets in the variable form.

Task: 4980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Related Variables and Secrets shown on Webhook and Webhook Authenticator forms (read-only tags, visible to manager/root).
  - Stat buttons on Variable form to open related Webhooks and Authenticators with live counters and navigation.
- Bug Fixes
  - Exports now include related Variables and Secrets for Webhooks and Authenticators.
- Documentation
  - Added release note entry about exporting related Variables and Secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->