### PR TITLE
[16.0][IMP][FIX] cetmix_tower_server Vault and UI/UX updates

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -58,6 +58,7 @@
         "views/cx_tower_command_view.xml",
         "views/cx_tower_plan_view.xml",
         "views/cx_tower_plan_line_view.xml",
+        "views/cx_tower_plan_line_view_action_view.xml",
         "views/cx_tower_command_log_view.xml",
         "views/cx_tower_plan_log_view.xml",
         "views/cx_tower_key_view.xml",

--- a/cetmix_tower_server/data/neutralize.sql
+++ b/cetmix_tower_server/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- deactivate scheduled tasks
+UPDATE cx_tower_scheduled_task
+   SET active = false;

--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -144,6 +144,7 @@ class CxTowerCommand(models.Model):
         column1="command_id",
         column2="plan_id",
         store=True,
+        copy=False,
     )
     flight_plan_used_ids_count = fields.Integer(
         compute="_compute_flight_plan_used_ids_count",

--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -74,6 +74,30 @@ class CxTowerKey(models.Model):
             else:
                 rec.reference_code = None
 
+    @api.returns("self", lambda value: value.id)
+    def copy(self, default=None):
+        """Copy key. Ensure secret value is copied.
+
+        Args:
+            default (dict, optional): Default values. Defaults to None.
+
+        Returns:
+            self: Copied key
+        """
+        default = default or {}
+        default["secret_value"] = self._get_secret_value("secret_value")
+        result = super().copy(default=default)
+
+        # Copy key values
+        for value in self.value_ids:
+            value.copy(
+                {
+                    "key_id": result.id,
+                }
+            )
+
+        return result
+
     def _get_reference_pattern(self):
         """
         Override mixin method

--- a/cetmix_tower_server/models/cx_tower_key_value.py
+++ b/cetmix_tower_server/models/cx_tower_key_value.py
@@ -96,3 +96,17 @@ class CxTowerKeyValue(models.Model):
                 raise ValidationError(
                     _("Only one secret value can be defined for a partner")
                 )
+
+    @api.returns("self", lambda value: value.id)
+    def copy(self, default=None):
+        """Copy key value. Ensure secret value is copied.
+
+        Args:
+            default (dict, optional): Default values. Defaults to None.
+
+        Returns:
+            self: Copied key value
+        """
+        default = default or {}
+        default["secret_value"] = self._get_secret_value("secret_value")
+        return super().copy(default=default)

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -312,6 +312,24 @@ class CxTowerServer(models.Model):
                 validation_error = "\n".join(validation_errors)
                 raise ValidationError(validation_error)
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override create to validate SSH password before record creation."""
+        # Validate SSH password before creating records
+        if not self._context.get("skip_ssh_settings_check"):
+            validation_errors = []
+            for vals in vals_list:
+                if vals.get("ssh_auth_mode") == "p" and not vals.get("ssh_password"):
+                    server_name = vals["name"]
+                    validation_errors.append(
+                        _("Please provide SSH password for %(srv)s", srv=server_name)
+                    )
+
+            if validation_errors:
+                raise ValidationError("\n".join(validation_errors))
+
+        return super().create(vals_list)
+
     def unlink(self):
         """Run post-delete flight plan"""
         servers_to_delete = self.env["cx.tower.server"]
@@ -1937,21 +1955,3 @@ class CxTowerServer(models.Model):
                 "sticky": sticky,
             },
         }
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        """Override create to validate SSH password before record creation."""
-        # Validate SSH password before creating records
-        if not self._context.get("skip_ssh_settings_check"):
-            validation_errors = []
-            for vals in vals_list:
-                if vals.get("ssh_auth_mode") == "p" and not vals.get("ssh_password"):
-                    server_name = vals["name"]
-                    validation_errors.append(
-                        _("Please provide SSH password for %(srv)s", srv=server_name)
-                    )
-
-            if validation_errors:
-                raise ValidationError("\n".join(validation_errors))
-
-        return super().create(vals_list)

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -109,12 +109,10 @@ class CxTowerServer(models.Model):
     )
     skip_host_key = fields.Boolean(
         default=False,
-        copy=False,
         help="Enable to skip host key verification",
     )
     host_key = fields.Char(
         groups="cetmix_tower_server.group_manager",
-        copy=False,
         help="Host key to verify the server",
     )
     ssh_port = fields.Integer(
@@ -367,8 +365,12 @@ class CxTowerServer(models.Model):
             )
         default["file_ids"] = file_ids.ids
 
+        # Copy SSH password and host key
+        default["ssh_password"] = self._get_secret_value("ssh_password")
+        default["host_key"] = self._get_secret_value("host_key")
         result = super().copy(default=default)
 
+        # Copy server secrets
         for secret in self.secret_ids:
             secret.sudo().copy({"server_id": result.id})
 

--- a/cetmix_tower_server/models/cx_tower_template_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_template_mixin.py
@@ -21,6 +21,7 @@ class CxTowerTemplateMixin(models.AbstractModel):
         comodel_name="cx.tower.variable",
         compute="_compute_variable_ids",
         store=True,
+        copy=False,
     )
 
     @classmethod

--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -43,7 +43,7 @@ class TowerVariable(models.Model):
         inverse_name="variable_id",
     )
     value_ids_count = fields.Integer(
-        string="Value Count", compute="_compute_value_ids_count"
+        string="Value Count", compute="_compute_variable_counters"
     )
     option_ids = fields.One2many(
         comodel_name="cx.tower.variable.option",
@@ -92,7 +92,7 @@ class TowerVariable(models.Model):
         copy=False,
     )
     command_ids_count = fields.Integer(
-        string="Command Count", compute="_compute_command_ids_count"
+        string="Command Count", compute="_compute_variable_counters"
     )
     plan_line_ids = fields.Many2many(
         comodel_name="cx.tower.plan.line",
@@ -102,7 +102,7 @@ class TowerVariable(models.Model):
         copy=False,
     )
     plan_line_ids_count = fields.Integer(
-        string="Plan Line Count", compute="_compute_plan_line_ids_count"
+        string="Plan Line Count", compute="_compute_variable_counters"
     )
     file_ids = fields.Many2many(
         comodel_name="cx.tower.file",
@@ -112,7 +112,7 @@ class TowerVariable(models.Model):
         copy=False,
     )
     file_ids_count = fields.Integer(
-        string="File Count", compute="_compute_file_ids_count"
+        string="File Count", compute="_compute_variable_counters"
     )
     file_template_ids = fields.Many2many(
         comodel_name="cx.tower.file.template",
@@ -122,7 +122,7 @@ class TowerVariable(models.Model):
         copy=False,
     )
     file_template_ids_count = fields.Integer(
-        string="File Template Count", compute="_compute_file_template_ids_count"
+        string="File Template Count", compute="_compute_variable_counters"
     )
     variable_value_ids = fields.Many2many(
         comodel_name="cx.tower.variable.value",
@@ -132,46 +132,24 @@ class TowerVariable(models.Model):
         copy=False,
     )
     variable_value_ids_count = fields.Integer(
-        string="Variable Value Count", compute="_compute_variable_value_ids_count"
+        string="Variable Value Count", compute="_compute_variable_counters"
     )
 
     _sql_constraints = [("name_uniq", "unique (name)", "Variable names must be unique")]
 
-    @api.depends("command_ids")
-    def _compute_command_ids_count(self):
-        """Count number of commands for the variable"""
-        for rec in self:
-            rec.command_ids_count = len(rec.command_ids)
-
-    @api.depends("plan_line_ids")
-    def _compute_plan_line_ids_count(self):
-        """Count number of plan lines for the variable"""
-        for rec in self:
-            rec.plan_line_ids_count = len(rec.plan_line_ids)
-
-    @api.depends("file_ids")
-    def _compute_file_ids_count(self):
-        """Count number of files for the variable"""
-        for rec in self:
-            rec.file_ids_count = len(rec.file_ids)
-
-    @api.depends("file_template_ids")
-    def _compute_file_template_ids_count(self):
-        """Count number of file templates for the variable"""
-        for rec in self:
-            rec.file_template_ids_count = len(rec.file_template_ids)
-
-    @api.depends("variable_value_ids")
-    def _compute_variable_value_ids_count(self):
+    def _compute_variable_counters(self):
         """Count number of variable values for the variable"""
         for rec in self:
-            rec.variable_value_ids_count = len(rec.variable_value_ids)
-
-    @api.depends("value_ids", "value_ids.variable_id")
-    def _compute_value_ids_count(self):
-        """Count number of values for the variable"""
-        for rec in self:
-            rec.value_ids_count = len(rec.value_ids)
+            rec.update(
+                {
+                    "variable_value_ids_count": len(rec.variable_value_ids),
+                    "command_ids_count": len(rec.command_ids),
+                    "plan_line_ids_count": len(rec.plan_line_ids),
+                    "file_ids_count": len(rec.file_ids),
+                    "file_template_ids_count": len(rec.file_template_ids),
+                    "value_ids_count": len(rec.value_ids),
+                }
+            )
 
     def action_open_values(self):
         self.ensure_one()

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -89,6 +89,7 @@ class TowerVariableValue(models.Model):
         string="Variables",
         compute="_compute_variable_ids",
         store=True,
+        copy=False,
     )
     required = fields.Boolean()
 

--- a/cetmix_tower_server/models/cx_tower_vault.py
+++ b/cetmix_tower_server/models/cx_tower_vault.py
@@ -8,8 +8,6 @@ class CxTowerVault(models.Model):
     """Vault for storing secret data.
 
     This model is used to store secret data for various resources.
-    The data is stored in the database and can be accessed using the
-    `_get_secret_values` method.
 
     The data is stored in the database and can be accessed using the
     `_get_secret_values` method.

--- a/cetmix_tower_server/readme/newsfragments/4996.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/4996.bugfix
@@ -1,0 +1,1 @@
+Handle secret values when a record is duplicated using copy()

--- a/cetmix_tower_server/readme/newsfragments/4996.feature
+++ b/cetmix_tower_server/readme/newsfragments/4996.feature
@@ -1,0 +1,1 @@
+UI/UX improvements

--- a/cetmix_tower_server/views/cx_tower_plan_line_view_action_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view_action_view.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="cx_tower_plan_line_view_action_form" model="ir.ui.view">
+        <field name="name">cx.tower.plan.line.view.action.form</field>
+        <field name="model">cx.tower.plan.line.action</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="sequence" />
+                        <label for="condition" string="If exit code" />
+                        <div class="o_row">
+                            <field name="condition" />
+                            <field name="value_char" />
+                        </div>
+                        <label for="action" string="Then" />
+                        <div class="o_row">
+                            <field name="action" />
+                            <field
+                                name="custom_exit_code"
+                                attrs="{'invisible': [('action', '!=', 'ec')], 'required': [('action', '=', 'ec')]}"
+                            />
+                        </div>
+                    </group>
+                    <p><b>AND</b></p>
+                    <group>
+                        <field
+                            name="variable_value_ids"
+                            order="variable_reference"
+                            string="Set Variable Values"
+                        >
+                            <tree editable="bottom">
+                                <field name="sequence" widget="handle" />
+                                <field name="reference" optional="hide" />
+                                <field name="variable_reference" optional="hide" />
+                                <field name="variable_id" />
+                                <field name="variable_type" invisible="1" />
+                                <field
+                                    name="value_char"
+                                    attrs="{'readonly': [('variable_type', '=', 'o')]}"
+                                />
+                                <field
+                                    name="option_id"
+                                    options="{'no_create': True, 'no_create_edit': True}"
+                                    attrs="{'readonly': [('variable_type', '=', 's')]}"
+                                />
+                                <field name="access_level" optional="show" />
+                            </tree>
+                            <form>
+                                <group>
+                                    <field name="variable_id" />
+                                    <field name="value_char" />
+                                    <field name="access_level" />
+                                </group>
+                                <field
+                                    name="note"
+                                    placeholder="Put your notes here..."
+                                />
+                            </form>
+                        </field>
+                    </group>
+
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/cetmix_tower_server/views/cx_tower_server_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_view.xml
@@ -318,7 +318,6 @@
                                     <field
                                         name="ssh_password"
                                         attrs="{'required': [('ssh_auth_mode', '=', 'p')]}"
-                                        password="True"
                                     />
                                     <field
                                         name="ssh_key_id"

--- a/cetmix_tower_server/views/cx_tower_variable_view.xml
+++ b/cetmix_tower_server/views/cx_tower_variable_view.xml
@@ -231,7 +231,10 @@
         <field name="model">cx.tower.variable</field>
         <field name="arch" type="xml">
             <search string="Search Values">
-                <field name="name" />
+                <field
+                    name="name"
+                    filter_domain="['|',('name', 'ilike', self), ('reference', 'ilike', self)]"
+                />
                 <field name="reference" />
             </search>
         </field>


### PR DESCRIPTION
## Commit 1

Fix the way secret values are copied.
Before this commit placeholder would be copied instead of the actual value.
After this commit the actual value is copied.

## Commit 2

- Search variables by name and reference in the list view.
  One field instead of two.
- Commands: do not copy "Used in plans"
- Variables: do not copy "Used in". Set "copy=False" in the variable mixing
  otherwise variables are copied automatically. Use a single compute method
  for all counters.
- Disable scheduled tasks when db is neutralised
- Form view for plan line actions opened from the variable value list view
- Relocate the "create" method in the 'cx.tower.server' model in accordance with the OCA Coding guidelines

Task: 4996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a dedicated form to configure plan line actions, including conditional exit codes and variable value settings.
  - Improved search: find variables by name or reference in one query.

- Bug Fixes
  - Duplicating records now preserves secret values and related secrets/files where appropriate.
  - Server password field rendering adjusted for clearer input behavior.

- Documentation
  - Added release notes covering secret-handling and UI/UX improvements.

- Chores
  - Registered the new plan-line action view and deactivated existing scheduled tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->