### PR TITLE
[16.0][IMP] cetmix_tower_server reference mixin improvements

### DIFF
--- a/cetmix_tower_git/tests/test_server.py
+++ b/cetmix_tower_git/tests/test_server.py
@@ -1,4 +1,7 @@
-from odoo.addons.queue_job.tests.common import trap_jobs
+try:
+    from odoo.addons.queue_job.tests.common import trap_jobs
+except ImportError:
+    trap_jobs = None
 
 from .common import CommonTest
 
@@ -77,16 +80,22 @@ class TestServer(CommonTest):
             )
         )
 
-        with trap_jobs() as trap:
+        # If cetmix_tower_server_queue module is installed, test async processing
+        if self.env["ir.module.module"].search_count(
+            [("name", "=", "cetmix_tower_server_queue"), ("state", "=", "installed")]
+        ):
+            with trap_jobs() as trap:
+                wizard.action_confirm()
+
+                # Verify that jobs were created
+                self.assertGreater(
+                    len(trap.enqueued_jobs), 0, "Jobs should have been enqueued"
+                )
+
+                # Execute all trapped jobs to simulate async processing
+                trap.perform_enqueued_jobs()
+        else:
             wizard.action_confirm()
-
-            # Verify that jobs were created
-            self.assertGreater(
-                len(trap.enqueued_jobs), 0, "Jobs should have been enqueued"
-            )
-
-            # Execute all trapped jobs to simulate async processing
-            trap.perform_enqueued_jobs()
 
         # Now search for the created records after jobs have been executed
         server = self.Server.search(

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -48,6 +48,7 @@ class CxTowerPlan(models.Model):
         comodel_name="cx.tower.plan.line",
         inverse_name="plan_id",
         auto_join=True,
+        copy=True,
     )
     command_ids = fields.Many2many(
         string="Commands",
@@ -118,35 +119,6 @@ class CxTowerPlan(models.Model):
         for plan in self:
             plan.command_ids = [(6, 0, plan.line_ids.mapped("command_id").ids)]
 
-    def copy(self, default=None):
-        # Call the super method to handle basic duplication
-        default = dict(default or {})
-        new_plan = super().copy(default=default)
-
-        # Duplicate the lines from the original plan
-        for line in self.line_ids:
-            new_line = line.copy(
-                {
-                    # assign the new plan to the duplicated line
-                    "plan_id": new_plan.id,
-                }
-            )
-
-            # Duplicate actions linked to the line
-            for action in line.action_ids:
-                new_action = action.with_context(reference_mixin_skip_copy=True).copy(
-                    # link new actions to the new line
-                    {"line_id": new_line.id, "name": line.name}
-                )
-
-                # Duplicate variable values linked to the action
-                for variable_value in action.variable_value_ids:
-                    variable_value.with_context(reference_mixin_skip_self=True).copy(
-                        {"plan_line_action_id": new_action.id}
-                    )
-
-        return new_plan
-
     def action_open_plan_logs(self):
         """
         Open current flight plan log records
@@ -156,6 +128,11 @@ class CxTowerPlan(models.Model):
         )
         action["domain"] = [("plan_id", "=", self.id)]
         return action
+
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["line_ids"]
 
     def _is_plan_incompatible_with_server(self, server):
         """

--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -27,12 +27,6 @@ class CxTowerPlanLine(models.Model):
         auto_join=True,
         ondelete="cascade",
     )
-    plan_line_ids = fields.One2many(
-        comodel_name="cx.tower.plan.line",
-        related="command_id.flight_plan_id.line_ids",
-        string="Flight Plan Lines",
-        readonly=True,
-    )
     action = fields.Selection(
         selection=lambda self: self.command_id._selection_action(),
         compute="_compute_action",
@@ -60,7 +54,7 @@ class CxTowerPlanLine(models.Model):
         comodel_name="cx.tower.plan.line.action",
         inverse_name="line_id",
         auto_join=True,
-        copy=False,
+        copy=True,
         help="Actions trigger based on command result."
         " If empty next command will be executed",
     )
@@ -93,6 +87,12 @@ class CxTowerPlanLine(models.Model):
         related="command_id.flight_plan_id",
         readonly=True,
         string="Run Flight Plan",
+    )
+    plan_run_line_ids = fields.One2many(
+        comodel_name="cx.tower.plan.line",
+        related="command_id.flight_plan_id.line_ids",
+        string="Flight Plan Lines",
+        readonly=True,
     )
     file_template_id = fields.Many2one(
         comodel_name="cx.tower.file.template",
@@ -272,8 +272,13 @@ class CxTowerPlanLine(models.Model):
             **log_vals,
         )
 
-    # Check cx.tower.reference.mixin for the function documentation
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["action_ids"]
+
     def _get_pre_populated_model_data(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
         res = super()._get_pre_populated_model_data()
         res.update({"cx.tower.plan.line": ["cx.tower.plan", "plan_id"]})
         return res

--- a/cetmix_tower_server/models/cx_tower_plan_line_action.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line_action.py
@@ -55,7 +55,7 @@ class CxTowerPlanLineAction(models.Model):
     variable_value_ids = fields.One2many(
         # Other field properties are defined in mixin
         inverse_name="plan_line_action_id",
-        copy=False,
+        copy=True,
     )
 
     @api.depends("condition", "action", "value_char")
@@ -89,8 +89,13 @@ class CxTowerPlanLineAction(models.Model):
             else:
                 rec.name = _("Wrong action")
 
-    # Check cx.tower.reference.mixin for the function documentation
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["variable_value_ids"]
+
     def _get_pre_populated_model_data(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
         res = super()._get_pre_populated_model_data()
         res.update({"cx.tower.plan.line.action": ["cx.tower.plan.line", "line_id"]})
         return res

--- a/cetmix_tower_server/models/cx_tower_reference_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_reference_mixin.py
@@ -123,11 +123,14 @@ class CxTowerReferenceMixin(models.AbstractModel):
                 reference = self._generate_or_fix_reference(reference)
             vals.update({"reference": reference})
 
-        # Clear cache for this method
-        if "reference" in vals:
-            self.clear_caches()
+        res = super().write(vals)
 
-        return super().write(vals)
+        # Update references of dependent models
+        if "reference" in vals:
+            self._update_dependent_model_references()
+            # Clear caches
+            self.clear_caches()
+        return res
 
     def unlink(self):
         """
@@ -183,6 +186,66 @@ class CxTowerReferenceMixin(models.AbstractModel):
             {model_name: [parent_model, relation_field]}
         """
         return {}
+
+    def _get_extra_vals_fields(self):
+        """Returns list of extra fields that are needed for reference generation.
+        This method if used to make custom reference generation logic more flexible.
+        Eg for 'cx.tower.variable.value':
+            'server_id', 'server_template_id', 'plan_line_action_id'.
+        So for common models like 'cx.tower.server' this method is not needed.
+
+        Returns:
+            list: List of fields:
+            [field_name1, field_name2, ...]
+        """
+        return []
+
+    def _get_dependent_model_relation_fields(self):
+        """Returns list of fields that reference dependent models.
+
+        Eg flight plan lines references are generated based on the flight plan one.
+
+        Returns:
+            list: List of fields:
+            [field_name1, field_name2, ...]
+        """
+        return []
+
+    def _update_dependent_model_references(self):
+        """Update references of dependent models"""
+        dependent_model_relation_fields = self._get_dependent_model_relation_fields()
+        if dependent_model_relation_fields:
+            for field in dependent_model_relation_fields:
+                related_model_name = self[field]._name
+
+                # Check if the related model has auto-generate settings
+                auto_generate_settings = (
+                    self[field]._get_pre_populated_model_data().get(related_model_name)
+                )
+                if auto_generate_settings:
+                    parent_model, relation_field = auto_generate_settings
+                else:
+                    continue
+
+                # Parse the field for all records
+                for record in self:
+                    related_records = record[field]
+                    # Get vals list
+                    rec_vals_list = related_records.read(
+                        [relation_field] + related_records._get_extra_vals_fields()
+                    )
+                    # Transform Many2one tuples to IDs
+                    for rv in rec_vals_list:
+                        for k, v in rv.items():
+                            # Transform m2o fields from (id, name) to id
+                            if isinstance(v, tuple):
+                                rv[k] = v[0]
+                    related_records._pre_populate_references(
+                        parent_model, relation_field, rec_vals_list
+                    )
+                    ref_by_id = {rv["id"]: rv["reference"] for rv in rec_vals_list}
+                    for related_record in related_records:
+                        related_record.reference = ref_by_id[related_record.id]
 
     def _generate_or_fix_reference(self, reference_source):
         """

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1960,3 +1960,8 @@ class CxTowerServer(models.Model):
                 "sticky": sticky,
             },
         }
+
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["variable_value_ids", "file_ids"]

--- a/cetmix_tower_server/models/cx_tower_server_template.py
+++ b/cetmix_tower_server/models/cx_tower_server_template.py
@@ -647,3 +647,8 @@ class CxTowerServerTemplate(models.Model):
             )
 
         raise ValidationError("\n".join(error_parts))
+
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["variable_value_ids"]

--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -330,6 +330,11 @@ class TowerVariable(models.Model):
             "cx.tower.plan.line": ["condition"],
         }
 
+    def _get_dependent_model_relation_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+        res = super()._get_dependent_model_relation_fields()
+        return res + ["value_ids"]
+
     def _validate_value(self, value_char=None):
         """
         Validate the variable value

--- a/cetmix_tower_server/models/cx_tower_variable_value.py
+++ b/cetmix_tower_server/models/cx_tower_variable_value.py
@@ -461,6 +461,12 @@ class TowerVariableValue(models.Model):
                 break
         return is_global
 
+    def _get_extra_vals_fields(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
+
+        # Use _used_in_models as a source of truth
+        return [fld_val[0] for fld_val in self._used_in_models().values()]
+
     def _pre_populate_references(self, model_name, field_name, vals_list):
         """
         Generate model-scoped references for variable values.
@@ -528,8 +534,8 @@ class TowerVariableValue(models.Model):
 
         return vals_list
 
-    # Check cx.tower.reference.mixin for the function documentation
     def _get_pre_populated_model_data(self):
+        """Check cx.tower.reference.mixin for the function documentation"""
         res = super()._get_pre_populated_model_data()
         res.update({"cx.tower.variable.value": ["cx.tower.variable", "variable_id"]})
         return res

--- a/cetmix_tower_server/readme/newsfragments/5005.feature
+++ b/cetmix_tower_server/readme/newsfragments/5005.feature
@@ -1,0 +1,1 @@
+Auto update references for related records

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -2109,3 +2109,75 @@ custom_values['random_var_reference'] = 'another_random_var_value'
             1,
             "There should be maximum one command in the log",
         )
+
+    def test_flight_plan_reference_update(self):
+        """Test flight plan reference update cascades to dependent models"""
+        # 1. Add a variable value to plan_line_1_action_2
+        variable_value = self.VariableValue.create(
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "Ubuntu 20.04",
+                "plan_line_action_id": self.plan_line_1_action_2.id,
+            }
+        )
+
+        # Store original references for comparison
+        original_plan_reference = self.plan_1.reference
+        original_plan_line_1_reference = self.plan_line_1.reference
+        original_plan_line_2_reference = self.plan_line_2.reference
+        original_plan_line_1_action_1_reference = self.plan_line_1_action_1.reference
+        original_plan_line_1_action_2_reference = self.plan_line_1_action_2.reference
+        original_plan_line_2_action_1_reference = self.plan_line_2_action_1.reference
+        original_plan_line_2_action_2_reference = self.plan_line_2_action_2.reference
+        original_variable_value_reference = variable_value.reference
+
+        # 2. Change the reference for plan_1 to "nice_new_plan"
+        self.plan_1.write({"reference": "nice_new_plan"})
+
+        # 3. Verify that references are updated for plan lines
+        # Invalidate models to refresh all references
+        self.env["cx.tower.plan"].invalidate_model(["reference"])
+        self.env["cx.tower.plan.line"].invalidate_model(["reference"])
+        self.env["cx.tower.plan.line.action"].invalidate_model(["reference"])
+        self.env["cx.tower.variable.value"].invalidate_model(["reference"])
+
+        # Check that plan reference was updated
+        self.assertEqual(self.plan_1.reference, "nice_new_plan")
+        self.assertNotEqual(self.plan_1.reference, original_plan_reference)
+
+        # Check that plan line references were updated to include the new plan reference
+        self.assertIn("nice_new_plan", self.plan_line_1.reference)
+        self.assertIn("nice_new_plan", self.plan_line_2.reference)
+        self.assertNotEqual(self.plan_line_1.reference, original_plan_line_1_reference)
+        self.assertNotEqual(self.plan_line_2.reference, original_plan_line_2_reference)
+
+        # Check that plan line action references were updated
+        self.assertIn("nice_new_plan", self.plan_line_1_action_1.reference)
+        self.assertIn("nice_new_plan", self.plan_line_1_action_2.reference)
+        self.assertIn("nice_new_plan", self.plan_line_2_action_1.reference)
+        self.assertIn("nice_new_plan", self.plan_line_2_action_2.reference)
+        self.assertNotEqual(
+            self.plan_line_1_action_1.reference, original_plan_line_1_action_1_reference
+        )
+        self.assertNotEqual(
+            self.plan_line_1_action_2.reference, original_plan_line_1_action_2_reference
+        )
+        self.assertNotEqual(
+            self.plan_line_2_action_1.reference, original_plan_line_2_action_1_reference
+        )
+        self.assertNotEqual(
+            self.plan_line_2_action_2.reference, original_plan_line_2_action_2_reference
+        )
+
+        # Check that variable value reference was updated
+        #  to include the new plan reference
+        self.assertIn("nice_new_plan", variable_value.reference)
+        self.assertNotEqual(variable_value.reference, original_variable_value_reference)
+
+        # Verify the reference pattern for variable value follows the expected format:
+        # <variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>  # noqa: E501
+        expected_pattern = (
+            f"{self.variable_os.reference}_variable_value_plan_line_action_"
+            f"{self.plan_line_1_action_2.reference}"
+        )
+        self.assertEqual(variable_value.reference, expected_pattern)

--- a/cetmix_tower_server/tests/test_server.py
+++ b/cetmix_tower_server/tests/test_server.py
@@ -827,3 +827,64 @@ result = {
         # Test with skip_host_key
         server.skip_host_key = True
         server.test_ssh_connection()
+
+    def test_server_reference_update(self):
+        """Test server reference update cascades to dependent models"""
+        # 1. Add a variable value to server_test_1
+        variable_value = self.VariableValue.create(
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "Ubuntu 20.04",
+                "server_id": self.server_test_1.id,
+            }
+        )
+
+        # 2. Add a file to server_test_1
+        server_file = self.File.create(
+            {
+                "name": "test_file.txt",
+                "server_id": self.server_test_1.id,
+                "source": "tower",
+                "code": "Test file content",
+            }
+        )
+
+        # Store original references for comparison
+        original_server_reference = self.server_test_1.reference
+        original_variable_value_reference = variable_value.reference
+        original_file_reference = server_file.reference
+
+        # 3. Change the reference for server_test_1 to "awesome_server"
+        self.server_test_1.write({"reference": "awesome_server"})
+
+        # 4. Verify that references are updated for dependent models
+        # Invalidate models to refresh all references
+        self.env["cx.tower.server"].invalidate_model(["reference"])
+        self.env["cx.tower.variable.value"].invalidate_model(["reference"])
+        self.env["cx.tower.file"].invalidate_model(["reference"])
+
+        # Check that server reference was updated
+        self.assertEqual(self.server_test_1.reference, "awesome_server")
+        self.assertNotEqual(self.server_test_1.reference, original_server_reference)
+
+        # Check that variable value reference was updated
+        # to include the new server reference
+        self.assertIn("awesome_server", variable_value.reference)
+        self.assertNotEqual(variable_value.reference, original_variable_value_reference)
+
+        # Check that file reference was updated to include the new server reference
+        self.assertIn("awesome_server", server_file.reference)
+        self.assertNotEqual(server_file.reference, original_file_reference)
+
+        # Verify the reference pattern for variable value follows the expected format:
+        # <variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>  # noqa: E501
+        expected_variable_pattern = (
+            f"{self.variable_os.reference}_variable_value_server_"
+            f"{self.server_test_1.reference}"
+        )
+        self.assertEqual(variable_value.reference, expected_variable_pattern)
+
+        # Verify the reference pattern for file follows the expected format:
+        # <parent_reference>_<model_generic_reference>_<index>
+        expected_file_pattern = f"{self.server_test_1.reference}_file_1"
+        self.assertEqual(server_file.reference, expected_file_pattern)

--- a/cetmix_tower_server/tests/test_server_template.py
+++ b/cetmix_tower_server/tests/test_server_template.py
@@ -1029,3 +1029,45 @@ class TestTowerServerTemplate(TestTowerCommon):
         # Manager1 should not be able to delete their record after being removed
         with self.assertRaises(AccessError):
             record3.with_user(self.manager1).unlink()
+
+    def test_server_template_reference_update(self):
+        """Test server template reference update cascades to dependent models"""
+        # 1. Add a variable value to server_template_sample
+        variable_value = self.VariableValue.create(
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "Ubuntu 20.04",
+                "server_template_id": self.server_template_sample.id,
+            }
+        )
+
+        # Store original references for comparison
+        original_template_reference = self.server_template_sample.reference
+        original_variable_value_reference = variable_value.reference
+
+        # 2. Change the reference for server_template_sample to "super_template"
+        self.server_template_sample.write({"reference": "super_template"})
+
+        # 3. Verify that references are updated for dependent models
+        # Invalidate models to refresh all references
+        self.env["cx.tower.server.template"].invalidate_model(["reference"])
+        self.env["cx.tower.variable.value"].invalidate_model(["reference"])
+
+        # Check that server template reference was updated
+        self.assertEqual(self.server_template_sample.reference, "super_template")
+        self.assertNotEqual(
+            self.server_template_sample.reference, original_template_reference
+        )
+
+        # Check that variable value reference was updated
+        # to include the new template reference
+        self.assertIn("super_template", variable_value.reference)
+        self.assertNotEqual(variable_value.reference, original_variable_value_reference)
+
+        # Verify the reference pattern for variable value follows the expected format:
+        # <variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>  # noqa: E501
+        expected_variable_pattern = (
+            f"{self.variable_os.reference}_variable_value_server_template_"
+            f"{self.server_template_sample.reference}"
+        )
+        self.assertEqual(variable_value.reference, expected_variable_pattern)

--- a/cetmix_tower_server/tests/test_variable.py
+++ b/cetmix_tower_server/tests/test_variable.py
@@ -1088,3 +1088,43 @@ class TestVariableReferenceRename(TestTowerCommon):
             self.assertEqual(val.value_char, expected_val)
             expected_cond = f"if {{{{ {actual_ref} }}}} then"
             self.assertEqual(pl.condition, expected_cond)
+
+    def test_variable_reference_update(self):
+        """Test variable reference update cascades to dependent models"""
+        # 1. Add a variable value to variable_os
+        variable_value = self.VariableValue.create(
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "Ubuntu 20.04",
+                "server_id": self.server_test_1.id,
+            }
+        )
+
+        # Store original references for comparison
+        original_variable_reference = self.variable_os.reference
+        original_variable_value_reference = variable_value.reference
+
+        # 2. Change the reference for variable_os to "awesome_variable"
+        self.variable_os.write({"reference": "awesome_variable"})
+
+        # 3. Verify that references are updated for dependent models
+        # Invalidate models to refresh all references
+        self.env["cx.tower.variable"].invalidate_model(["reference"])
+        self.env["cx.tower.variable.value"].invalidate_model(["reference"])
+
+        # Check that variable reference was updated
+        self.assertEqual(self.variable_os.reference, "awesome_variable")
+        self.assertNotEqual(self.variable_os.reference, original_variable_reference)
+
+        # Check that variable value reference was updated
+        # to include the new variable reference
+        self.assertIn("awesome_variable", variable_value.reference)
+        self.assertNotEqual(variable_value.reference, original_variable_value_reference)
+
+        # Verify the reference pattern for variable value follows the expected format:
+        # <variable_reference>_<model_generic_reference>_<linked_model_generic_reference>_<linked_record_reference>  # noqa: E501
+        expected_variable_pattern = (
+            f"{self.variable_os.reference}_variable_value_server_"
+            f"{self.server_test_1.reference}"
+        )
+        self.assertEqual(variable_value.reference, expected_variable_pattern)

--- a/cetmix_tower_server/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view.xml
@@ -61,7 +61,7 @@
                                 attrs="{'invisible': [('action', '!=', 'file_using_template')]}"
                             />
                             <field
-                                name="plan_line_ids"
+                                name="plan_run_line_ids"
                                 string="Flight Plan Lines"
                                 attrs="{'invisible': [('action', '!=', 'plan')]}"
                             >


### PR DESCRIPTION
## Commit 1
**cetmix_tower_server**

Add feature to update related record references when record reference is updated.
This is needed to ensure references are unique and consistent.

Following models are modified:
- Server -> Variable Values, Files
- Server Template -> Variable Values
- Flight Plan -> Lines -> Line Actions -> Variable Values

## Commit 2

**cetmix_tower_git**

Run trap_jobs from test_server.py only if cetmix_tower_server_queue module is installed.

Task 5005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplicating a flight plan now preserves its lines, actions, and variable values.
  - Flight Plan Lines view updated to show related run lines for clearer linkage.
  - Added feature to auto-update references for related records when a reference changes.

- **Bug Fixes**
  - Reference changes now propagate automatically to dependent records (plans, lines, actions, variables, servers, templates, files).

- **Tests**
  - Added tests for cascading reference updates.
  - Server tests now tolerate optional job-queue presence and only check queue behavior when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->