### PR TITLE
[17.0][MIG] cetmix_tower_git File connection

### DIFF
--- a/cetmix_tower_git/__manifest__.py
+++ b/cetmix_tower_git/__manifest__.py
@@ -24,6 +24,7 @@
         "views/cx_tower_file_views.xml",
         "views/cx_tower_file_template_views.xml",
         "views/cx_tower_server_view.xml",
+        "views/cx_tower_plan_line_view.xml",
     ],
     "demo": [
         "demo/demo_data.xml",

--- a/cetmix_tower_git/models/__init__.py
+++ b/cetmix_tower_git/models/__init__.py
@@ -8,3 +8,4 @@ from . import cx_tower_git_project
 from . import cx_tower_git_remote
 from . import cx_tower_git_source
 from . import cx_tower_server
+from . import cetmix_tower

--- a/cetmix_tower_git/models/__init__.py
+++ b/cetmix_tower_git/models/__init__.py
@@ -9,3 +9,4 @@ from . import cx_tower_git_remote
 from . import cx_tower_git_source
 from . import cx_tower_server
 from . import cetmix_tower
+from . import cx_tower_plan_line

--- a/cetmix_tower_git/models/cetmix_tower.py
+++ b/cetmix_tower_git/models/cetmix_tower.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class CetmixTower(models.AbstractModel):
+    _inherit = "cetmix.tower"
+
+    @api.model
+    def server_get_by_git_ref(self, repository_url, head=None, head_type=None):
+        """
+        Return servers linked to a given Git repository reference.
+
+        This is a thin shortcut that delegates to
+        :meth:`cx.tower.server.get_servers_by_git_ref`.
+
+        Parameters
+        ----------
+        repository_url : str
+            Pre-normalized canonical Git URL
+            (e.g. ``https://host/owner/repo.git``).
+        head : str, optional
+            Branch name, commit SHA, or PR identifier.
+        head_type : {'branch', 'commit', 'pr'}, optional
+            Type of the ``head`` argument.
+
+        Returns
+        -------
+        recordset of cx.tower.server
+            Matching servers. Empty recordset if no matches.
+        """
+        return self.env["cx.tower.server"].get_servers_by_git_ref(
+            repository_url, head, head_type
+        )

--- a/cetmix_tower_git/models/cx_tower_plan_line.py
+++ b/cetmix_tower_git/models/cx_tower_plan_line.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class CxTowerPlanLine(models.Model):
+    """Flight Plan Line"""
+
+    _inherit = "cx.tower.plan.line"
+
+    git_project_id = fields.Many2one(
+        comodel_name="cx.tower.git.project",
+        string="Git Project",
+        help="Select a git project to be linked to the file and server.",
+    )
+    is_make_copy = fields.Boolean(
+        string="Make a Copy",
+        help="Create a copy of the Git Project instead of linking "
+        "the file to the existing one.",
+    )
+
+    # ------------------------------
+    # YAML mixin methods
+    # ------------------------------
+    def _get_fields_for_yaml(self):
+        res = super()._get_fields_for_yaml()
+        res += [
+            "git_project_id",
+            "is_make_copy",
+        ]
+        return res

--- a/cetmix_tower_git/models/cx_tower_server.py
+++ b/cetmix_tower_git/models/cx_tower_server.py
@@ -97,3 +97,41 @@ class CxTowerServer(models.Model):
 
         servers = matching.mapped("git_project_id.git_project_rel_ids.server_id")
         return servers
+
+    def _command_runner_file_using_template_create_file(
+        self,
+        file_template_id,
+        server_dir,
+        plan_line,
+        if_file_exists,
+        **kwargs,
+    ):
+        """Override to create git project relation
+        when creating a file using a template.
+        """
+        file = super()._command_runner_file_using_template_create_file(
+            file_template_id, server_dir, plan_line, if_file_exists, **kwargs
+        )
+        if file and plan_line:
+            git_project = plan_line.git_project_id
+            if not git_project:
+                return file
+
+            if plan_line.is_make_copy:
+                # Remove default_server_ids from context, because this relation
+                # will be created through git_project_rel_ids.
+                # default_server_ids will interfere at the moment when
+                # pairs of values are created through SQL query
+                # in the method write_real and it does not take into account
+                # that in this case we are creating a copy of the git project
+                git_project = git_project.with_context(default_server_ids=False).copy()
+
+            self.env["cx.tower.git.project.rel"].create(
+                {
+                    "git_project_id": git_project.id,
+                    "server_id": self.id,
+                    "file_id": file.id,
+                    "project_format": git_project._default_project_format(),
+                }
+            )
+        return file

--- a/cetmix_tower_git/models/cx_tower_server.py
+++ b/cetmix_tower_git/models/cx_tower_server.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CxTowerServer(models.Model):
@@ -59,3 +59,41 @@ class CxTowerServer(models.Model):
         return super()._update_or_create_related_record(
             model, reference, values, create_immediately=create_immediately
         )
+
+    @api.model
+    def get_servers_by_git_ref(self, repository_url, head=None, head_type=None):
+        """
+        Return servers linked to a given Git repository reference.
+
+        Parameters
+        ----------
+        repository_url : str
+            Pre-normalized canonical Git URL
+            (e.g. ``https://host/owner/repo.git``).
+        head : str, optional
+            Branch name, commit SHA, or PR identifier.
+        head_type : {'branch', 'commit', 'pr'}, optional
+            Type of the ``head`` argument.
+            If only ``head`` is provided, it will match across all head types.
+            If only ``head_type`` is provided, it will filter by type regardless of head
+
+        Returns
+        -------
+        recordset of cx.tower.server
+            Matching servers. Empty recordset if no matches.
+        """
+        # URL MUST be already canonical.
+        if not repository_url:
+            return self.env["cx.tower.server"].browse()
+
+        Remote = self.env["cx.tower.git.remote"]
+        domain = [("url", "=", repository_url)]
+        if head:
+            domain.append(("head", "=", head))
+        if head_type:
+            domain.append(("head_type", "=", head_type))
+
+        matching = Remote.search(domain)
+
+        servers = matching.mapped("git_project_id.git_project_rel_ids.server_id")
+        return servers

--- a/cetmix_tower_git/readme/newsfragments/4759.feature
+++ b/cetmix_tower_git/readme/newsfragments/4759.feature
@@ -1,0 +1,1 @@
+Link or copy a git project when uploading the linked file using command

--- a/cetmix_tower_git/readme/newsfragments/4838.feature
+++ b/cetmix_tower_git/readme/newsfragments/4838.feature
@@ -1,0 +1,1 @@
+Search servers by git reference

--- a/cetmix_tower_git/tests/__init__.py
+++ b/cetmix_tower_git/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_file_rel
 from . import test_file_template_rel
 from . import test_tower_git_ref
 from . import test_cetmix_tower
+from . import test_server

--- a/cetmix_tower_git/tests/__init__.py
+++ b/cetmix_tower_git/tests/__init__.py
@@ -3,3 +3,5 @@ from . import test_source
 from . import test_project
 from . import test_file_rel
 from . import test_file_template_rel
+from . import test_tower_git_ref
+from . import test_cetmix_tower

--- a/cetmix_tower_git/tests/test_cetmix_tower.py
+++ b/cetmix_tower_git/tests/test_cetmix_tower.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from .common import CommonTest
+
+
+class TestTowerGitShortcut(CommonTest):
+    """Ensure the cetmix.tower shortcut delegates correctly."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Link the Git project to Server 1 so the lookup can find it
+        cls.GitProjectRel.create(
+            {
+                "git_project_id": cls.git_project_1.id,
+                "server_id": cls.server_test_1.id,
+                "file_id": cls.server_1_file_1.id,
+            }
+        )
+
+    def test_shortcut_returns_same_servers(self):
+        """Shortcut must return exactly the same servers as the model API."""
+        url = self.remote_github_https.url
+        head = self.remote_github_https.head
+        head_type = self.remote_github_https.head_type
+
+        servers_model = self.env["cx.tower.server"].get_servers_by_git_ref(
+            url, head, head_type
+        )
+        servers_shortcut = self.env["cetmix.tower"].server_get_by_git_ref(
+            url, head, head_type
+        )
+        self.assertCountEqual(servers_model.ids, servers_shortcut.ids)

--- a/cetmix_tower_git/tests/test_server.py
+++ b/cetmix_tower_git/tests/test_server.py
@@ -1,0 +1,135 @@
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import CommonTest
+
+
+class TestServer(CommonTest):
+    """Test setting git project to server from plan line."""
+
+    def test_server_creation_running_flight_plan(self):
+        """Test that server is created with git project from plan line."""
+        git_project = self.GitProject.create(
+            {
+                "name": "Test Git Project",
+                "manager_ids": [(4, self.manager.id)],
+            }
+        )
+
+        file_template = self.FileTemplate.create(
+            {
+                "name": "Git Config Template",
+                "file_name": "repos.yaml",
+                "server_dir": "/var/test",
+                "code": "repositories:\n  test_repo:\n    "
+                "url: https://github.com/test/repo.git\n    target: main",
+            }
+        )
+
+        command = self.Command.create(
+            {
+                "name": "Create Git Config File",
+                "action": "file_using_template",
+                "file_template_id": file_template.id,
+            }
+        )
+
+        flight_plan = self.Plan.create(
+            {
+                "name": "Git Project Setup Plan",
+                "note": "Sets up a git project on the server",
+            }
+        )
+
+        self.plan_line.create(
+            {
+                "plan_id": flight_plan.id,
+                "command_id": command.id,
+                "sequence": 10,
+                "git_project_id": git_project.id,
+            }
+        )
+
+        server_template = self.ServerTemplate.create(
+            {
+                "name": "Git Server Template",
+                "ssh_port": 22,
+                "ssh_username": "admin",
+                "ssh_password": "password",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "flight_plan_id": flight_plan.id,
+                "manager_ids": [(4, self.manager.id)],
+            }
+        )
+
+        action = server_template.action_create_server()
+
+        # Open the wizard and fill in the data
+        wizard = (
+            self.env["cx.tower.server.template.create.wizard"]
+            .with_context(**action["context"])
+            .create(
+                {
+                    "name": "Git Server",
+                    "ip_v4_address": "192.168.1.10",
+                    "server_template_id": server_template.id,
+                }
+            )
+        )
+
+        with trap_jobs() as trap:
+            wizard.action_confirm()
+
+            # Verify that jobs were created
+            self.assertGreater(
+                len(trap.enqueued_jobs), 0, "Jobs should have been enqueued"
+            )
+
+            # Execute all trapped jobs to simulate async processing
+            trap.perform_enqueued_jobs()
+
+        # Now search for the created records after jobs have been executed
+        server = self.Server.search(
+            [
+                ("name", "=", "Git Server"),
+                ("server_template_id", "=", server_template.id),
+            ]
+        )
+        self.assertEqual(len(server), 1, "Exactly one server should have been created")
+
+        # Verify the file was created
+        file = self.File.search(
+            [("server_id", "=", server.id), ("name", "=", "repos.yaml")]
+        )
+
+        self.assertEqual(
+            len(file), 1, "Exactly one git config file should have been created"
+        )
+
+        # Verify the git project relation exists
+        git_project_rel = self.GitProjectRel.search(
+            [
+                ("server_id", "=", server.id),
+                ("git_project_id", "=", git_project.id),
+                ("file_id", "=", file.id),
+            ]
+        )
+
+        self.assertEqual(
+            len(git_project_rel), 1, "Exactly one git project relation should exist"
+        )
+        self.assertEqual(
+            git_project_rel.file_id,
+            file,
+            "The related file should be the git config file",
+        )
+        self.assertEqual(
+            git_project_rel.git_project_id,
+            git_project,
+            "The related git project should match the one in the flight plan",
+        )
+        self.assertEqual(
+            git_project_rel.project_format,
+            git_project._default_project_format(),
+            "Project format should match the default format",
+        )

--- a/cetmix_tower_git/tests/test_tower_git_ref.py
+++ b/cetmix_tower_git/tests/test_tower_git_ref.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2022 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from .common import CommonTest
+
+
+class TestGetServersByGitRef(CommonTest):
+    """Unit tests for cx.tower.server.get_servers_by_git_ref()."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # canonical repo URL used in the tests
+        cls.repo_slug = "testorg/test_repo_123"
+        cls.canonical = f"https://github.com/{cls.repo_slug}.git"
+
+        # Git objects
+        GitProject = cls.GitProject
+        GitSource = cls.GitSource
+        GitRemote = cls.GitRemote
+        GitProjRel = cls.GitProjectRel
+        File = cls.File
+
+        cls.project = GitProject.create({"name": "Demo"})
+        cls.src = GitSource.create(
+            {
+                "name": "Local",
+                "git_project_id": cls.project.id,
+            }
+        )
+
+        GitRemote.create(
+            {
+                "git_project_id": cls.project.id,
+                "source_id": cls.src.id,
+                "url": cls.canonical,
+                "head": "main",
+                "head_type": "branch",
+            }
+        )
+
+        file = File.create(
+            {
+                "server_id": cls.server_test_1.id,
+                "source": "tower",
+                "file_type": "text",
+                "name": "dummy.txt",
+            }
+        )
+        GitProjRel.create(
+            {
+                "git_project_id": cls.project.id,
+                "server_id": cls.server_test_1.id,
+                "file_id": file.id,
+            }
+        )
+
+    # Positive
+    def test_success(self):
+        """Canonical URL must return the linked server."""
+        servers = self.Server.get_servers_by_git_ref(self.canonical, "main", "branch")
+        self.assertEqual(servers, self.server_test_1)
+
+    # Negative
+    def test_no_match(self):
+        """Foreign repo URL must return an empty recordset."""
+        other = "https://github.com/another/repo.git"
+        servers = self.Server.get_servers_by_git_ref(other, "main", "branch")
+        self.assertFalse(servers)

--- a/cetmix_tower_git/views/cx_tower_plan_line_view.xml
+++ b/cetmix_tower_git/views/cx_tower_plan_line_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="cx_tower_plan_line_view_form" model="ir.ui.view">
+        <field name="name">cx.tower.plan.line.view.form</field>
+        <field name="model">cx.tower.plan.line</field>
+        <field
+            name="inherit_id"
+            ref="cetmix_tower_server.cx_tower_plan_line_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='condition']" position="before">
+                <group invisible="action != 'file_using_template'">
+                    <field name="git_project_id" />
+                    <field name="is_make_copy" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1187,6 +1187,33 @@ class CxTowerServer(models.Model):
         else:
             raise ValidationError(error_message)
 
+    def _command_runner_file_using_template_create_file(
+        self, file_template_id, server_dir, plan_line, if_file_exists, **kwargs
+    ):
+        """
+        Creates a file on the server using the specified file template.
+
+        This method is intended to allow overriding the file creation logic
+        and provides access to the created file object.
+        Args:
+            file_template_id (recordset): The file template to use for creating
+                the new file.
+            server_dir (str): The directory on the server where the file should be
+                created.
+            plan_line (recordset): The plan line to use for creating
+                the new file.
+            if_file_exists (str): The action to take if the file already exists.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            record: The created file record.
+        """
+        return file_template_id.create_file(
+            server=self,
+            server_dir=server_dir,
+            if_file_exists=if_file_exists,
+        )
+
     def _command_runner_file_using_template(
         self,
         log_record,
@@ -1219,10 +1246,13 @@ class CxTowerServer(models.Model):
         """
         try:
             # Attempt to create a new file using the template for the current server
-            file = log_record.command_id.file_template_id.create_file(
-                server=self,
+            plan_line = log_record.plan_log_id.plan_line_executed_id
+            file_template_id = log_record.command_id.file_template_id
+            file = self._command_runner_file_using_template_create_file(
+                file_template_id=file_template_id,
                 if_file_exists=log_record.command_id.if_file_exists,
                 server_dir=server_dir,
+                plan_line=plan_line,
             )
 
             # If file creation failed, log the failure and exit

--- a/cetmix_tower_server/readme/newsfragments/4759.feature
+++ b/cetmix_tower_server/readme/newsfragments/4759.feature
@@ -1,0 +1,1 @@
+Improve the extendability of the file upload command.


### PR DESCRIPTION
Forward port the following features from 16.0:

- https://github.com/cetmix/cetmix-tower/pull/356
  - Search file by git reference
- https://github.com/cetmix/cetmix-tower/pull/377
  - Allow to link a git projects to files created with the "File upload" command

Task: 5024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Link or copy Git projects when uploading files using command templates
  * Search servers by Git repository reference
  * New Git project selection and copy options in plan line configuration form

<!-- end of auto-generated comment: release notes by coderabbit.ai -->