### PR TITLE
[17.0] cetmix_tower_server Terminate flight plan

### DIFF
--- a/cetmix_tower_server/data/ir_actions_server.xml
+++ b/cetmix_tower_server/data/ir_actions_server.xml
@@ -23,11 +23,25 @@
         <field name="groups_id" eval="[(4, ref('cetmix_tower_server.group_user'))]" />
     </record>
 
+    <record id="action_stop_cx_tower_plan_log" model="ir.actions.server">
+        <field name="name">Stop Flight Plan</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="model_cx_tower_plan_log" />
+        <field name="binding_model_id" ref="model_cx_tower_plan_log" />
+        <field name="sequence">14</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_stop()</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('cetmix_tower_server.group_manager'))]"
+        />
+    </record>
+
     <record id="action_cx_cetmix_tower_partner" model="ir.actions.act_window">
-      <field name="name">Partners</field>
-      <field name="type">ir.actions.act_window</field>
-      <field name="res_model">res.partner</field>
-      <field name="view_mode">tree,form</field>
+        <field name="name">Partners</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">res.partner</field>
+        <field name="view_mode">tree,form</field>
     </record>
 
 </odoo>

--- a/cetmix_tower_server/models/cetmix_tower.py
+++ b/cetmix_tower_server/models/cetmix_tower.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 import time
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 from .constants import NOT_FOUND, SSH_CONNECTION_ERROR
+
+_logger = logging.getLogger(__name__)
 
 
 class CetmixTower(models.AbstractModel):
@@ -223,6 +226,12 @@ class CetmixTower(models.AbstractModel):
         # Try connecting multiple times
         for attempt in range(1, attempts + 1):
             try:
+                _logger.info(
+                    "Attempt %s of %s to connect to server %s",
+                    attempt,
+                    attempts,
+                    server_reference,
+                )
                 result = server.test_ssh_connection(
                     raise_on_error=True,
                     return_notification=False,

--- a/cetmix_tower_server/models/constants.py
+++ b/cetmix_tower_server/models/constants.py
@@ -37,6 +37,9 @@ COMMAND_TIMED_OUT_MESSAGE = _("Command timed out and was terminated")
 # Returned when the command is not compatible with the server
 COMMAND_NOT_COMPATIBLE_WITH_SERVER = -207
 
+# Returned when the command was stopped by user
+COMMAND_STOPPED = -208
+
 # -- Plan: -300 > -399
 
 # Returned when trying to execute another instance of a flightplan on the same server
@@ -57,6 +60,8 @@ PLAN_LINE_NOT_ASSIGNED = -304
 # Returned when any of the commands in the plan is not compatible with the server
 PLAN_NOT_COMPATIBLE_WITH_SERVER = -306
 
+# Returned when the flight plan was stopped by user
+PLAN_STOPPED = -308
 
 # -- File: -400 > -499
 

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -1,8 +1,12 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+import logging
 
-from .constants import GENERAL_ERROR
+from odoo import _, api, fields, models
+
+from .constants import COMMAND_STOPPED, GENERAL_ERROR
+
+_logger = logging.getLogger(__name__)
 
 
 class CxTowerCommandLog(models.Model):
@@ -67,6 +71,7 @@ class CxTowerCommandLog(models.Model):
         "-205 plan line condition check failed,\n"
         "-206 command timed out,\n"
         "-207 command is not compatible with server,\n"
+        "-208 command is stopped by user,\n"
         "503 if SSH connection error occurred",
     )
     command_response = fields.Text(string="Response")
@@ -163,6 +168,20 @@ class CxTowerCommandLog(models.Model):
         log_record = self.sudo().create(vals)
         return log_record
 
+    def stop(self):
+        """
+        Stop the command execution.
+        """
+        user_name = self.env.user.name
+        for log in self:
+            if not log.is_running:
+                continue
+
+            log.finish(
+                status=COMMAND_STOPPED,
+                error=_("Stopped by user %(user)s", user=user_name),
+            )
+
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs
     ):
@@ -185,6 +204,7 @@ class CxTowerCommandLog(models.Model):
             "command_response": response,
             "command_error": error,
         }
+
         # Apply kwargs and write
         vals.update(kwargs)
         self_with_sudo.write(vals)

--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -1,12 +1,8 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import logging
-
 from odoo import _, api, fields, models
 
 from .constants import COMMAND_STOPPED, GENERAL_ERROR
-
-_logger = logging.getLogger(__name__)
 
 
 class CxTowerCommandLog(models.Model):
@@ -181,6 +177,10 @@ class CxTowerCommandLog(models.Model):
                 status=COMMAND_STOPPED,
                 error=_("Stopped by user %(user)s", user=user_name),
             )
+
+            # Ensure flight plan log is stopped too
+            if log.plan_log_id and log.plan_log_id.is_running:
+                log.plan_log_id.stop()
 
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -211,7 +211,7 @@ class CxTowerPlanLog(models.Model):
         """
         user_name = self.env.user.name
         for log in self:
-            if not log.is_running or log.is_stopped:
+            if not log.is_running:
                 continue
 
             # Finish plan log

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
-from .constants import PLAN_IS_EMPTY
+from .constants import PLAN_IS_EMPTY, PLAN_STOPPED
 
 
 class CxTowerPlanLog(models.Model):
@@ -54,6 +54,9 @@ class CxTowerPlanLog(models.Model):
     is_running = fields.Boolean(
         help="Plan is being executed right now", compute="_compute_duration", store=True
     )
+    is_stopped = fields.Boolean(
+        string="Stopped", default=False, help="Flight plan was stopped by user"
+    )
     plan_line_executed_id = fields.Many2one(
         comodel_name="cx.tower.plan.line",
         help="Flight Plan line that is being currently executed",
@@ -68,7 +71,8 @@ class CxTowerPlanLog(models.Model):
         "-302 if plan is empty, \n"
         "-303 if plan reference is missing, \n"
         "-304 if plan line reference is missing, \n"
-        "-306 if plan is not compatible with server",
+        "-306 if plan is not compatible with server,\n"
+        "-308 if plan is stopped by user",
     )
     custom_message = fields.Text(
         help="Custom message to be displayed in the plan log",
@@ -201,6 +205,52 @@ class CxTowerPlanLog(models.Model):
 
         return plan_log
 
+    def stop(self):
+        """
+        Force stop this plan log (and currently running command if possible).
+        """
+        user_name = self.env.user.name
+        for log in self:
+            if not log.is_running or log.is_stopped:
+                continue
+
+            # Finish plan log
+            log.finish(
+                plan_status=PLAN_STOPPED,
+                custom_message=_("Stopped by user %(user)s", user=user_name),
+                is_stopped=True,
+            )
+
+            # Stop running command
+            running_cmd_logs = log.command_log_ids.filtered(lambda c: c.is_running)
+            running_cmd_logs.stop()
+
+    def action_stop(self):
+        """
+        Action to stop the running plans.
+        """
+        self.stop()
+
+        if len(self) > 1:  # more than one plan is running
+            title = _("Flight Plans Stopped")
+            message = ", ".join([plan.name for plan in self])
+        else:
+            title = _("Flight Plan Stopped")
+            message = self.name
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": title,
+                "message": message,
+                "sticky": False,
+                "next": {
+                    "type": "ir.actions.act_window_close",
+                },
+            },
+        }
+
     def finish(self, plan_status, **kwargs):
         """Finish plan execution
 
@@ -287,6 +337,10 @@ class CxTowerPlanLog(models.Model):
 
         """
         self.ensure_one()
+
+        # Prevent scheduling further actions if this log was stopped
+        if self.is_stopped:
+            return
 
         # Update plan log variable values from command log
         self.variable_values = command_log.variable_values

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1522,7 +1522,8 @@ class CxTowerServer(models.Model):
                 response = []
                 error = [e]
 
-        return self._parse_command_results(status, response, error, secrets, **kwargs)
+        result = self._parse_command_results(status, response, error, secrets, **kwargs)
+        return result
 
     def _run_python_code(
         self,
@@ -1749,7 +1750,11 @@ class CxTowerServer(models.Model):
             # For not to save an empty list `[]` in log
             error = None
 
-        return {"status": status, "response": response, "error": error}
+        return {
+            "status": status,
+            "response": response,
+            "error": error,
+        }
 
     def _check_zombie_commands(self):
         """

--- a/cetmix_tower_server/readme/newsfragments/3410.feature
+++ b/cetmix_tower_server/readme/newsfragments/3410.feature
@@ -1,0 +1,1 @@
+Terminate running flight plan manually

--- a/cetmix_tower_server/ssh/ssh.py
+++ b/cetmix_tower_server/ssh/ssh.py
@@ -251,6 +251,16 @@ class CommandExecutor:
     ) -> tuple[int, list[str], list[str]]:
         """
         Run a command on the remote server.
+
+        Args:
+            command (str): The command to execute.
+            sudo (Optional[str]): Sudo mode.
+
+        Returns:
+            tuple:
+                - exit_status (int)
+                - stdout (list[str])
+                - stderr (list[str])
         """
         ssh_client = self.connection.connect()
         use_sudo_with_password = sudo == "p" and self.connection.username != "root"
@@ -258,13 +268,17 @@ class CommandExecutor:
         if use_sudo_with_password and not self.connection.password:
             return 255, [], ["Sudo password not provided!"]
 
-        stdin, stdout, stderr = ssh_client.exec_command(command)
-        if use_sudo_with_password:
-            stdin.write(self.connection.password + "\n")
-            stdin.flush()
-
-        exit_status = stdout.channel.recv_exit_status()
-        return exit_status, stdout.readlines(), stderr.readlines()
+        try:
+            stdin, stdout, stderr = ssh_client.exec_command(command)
+            if use_sudo_with_password:
+                stdin.write(self.connection.password + "\n")
+                stdin.flush()
+            exit_status = stdout.channel.recv_exit_status()
+            response = stdout.readlines()
+            error = stderr.readlines()
+            return exit_status, response, error
+        except Exception as e:
+            return 255, [], [str(e)]
 
 
 class SSHManager:
@@ -356,3 +370,10 @@ class SSHManager:
             self.connection.host_key or "",
         )
         self.delete_cache(key)
+
+    @classmethod
+    def get_connection_cache(cls):
+        """
+        Get the connection cache.
+        """
+        return cls._connection_cache

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -11,6 +11,7 @@ from ..models.constants import (
     PLAN_IS_EMPTY,
     PLAN_LINE_CONDITION_CHECK_FAILED,
     PLAN_NOT_COMPATIBLE_WITH_SERVER,
+    PLAN_STOPPED,
 )
 from .common import TestTowerCommon
 
@@ -2061,3 +2062,50 @@ custom_values['random_var_reference'] = 'another_random_var_value'
 
         self.assertIn("/test_path", create_dir_logs[0].code)
         self.assertIn("/another_test_path", create_dir_logs[1].code)
+
+    def test_plan_stop_mid_execution(self):
+        """
+        Test that plan is correctly marked as stopped and
+        further commands are not executed.
+        """
+        plan = self._create_plan(
+            name="Test Plan Stop",
+            line_ids=[
+                (0, 0, {"command_id": self.command_create_dir.id, "sequence": 1}),
+                (0, 0, {"command_id": self.command_list_dir.id, "sequence": 2}),
+            ],
+        )
+        server = self.server_test_1
+
+        cx_tower_plan_line_obj = self.registry["cx.tower.plan.line"]
+        _run_super = cx_tower_plan_line_obj._run
+
+        # Save plan_log for control is_running
+        plan_log_holder = {}
+
+        def fake_run(self, server, plan_log, **kwargs):
+            # Save plan_log for control is_running
+            plan_log_holder["log"] = plan_log
+
+            # Call stop() after first command
+            if len(plan_log.command_log_ids) == 0:
+                plan_log.stop()
+                # After this call plan_log should be stopped,
+                # and finish_date should be filled
+            # Continue execution in standard way
+            return _run_super(self, server, plan_log, **kwargs)
+
+        with patch.object(cx_tower_plan_line_obj, "_run", new=fake_run):
+            plan_log = plan._run_single(server)
+
+        self.assertTrue(plan_log.is_stopped, "Plan should be stopped")
+        self.assertFalse(plan_log.is_running, "Plan should not be in running status")
+        self.assertEqual(
+            plan_log.plan_status, PLAN_STOPPED, "Status should be PLAN_STOPPED"
+        )
+        self.assertTrue(plan_log.finish_date, "Finish date should be filled")
+        self.assertLessEqual(
+            len(plan_log.command_log_ids),
+            1,
+            "There should be maximum one command in the log",
+        )

--- a/cetmix_tower_server/views/cx_tower_plan_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_log_view.xml
@@ -5,6 +5,17 @@
         <field name="model">cx.tower.plan.log</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button
+                        name="action_stop"
+                        string="Stop"
+                        type="object"
+                        class="oe_highlight"
+                        invisible="not is_running or is_stopped"
+                        confirm="Flight Plan will be terminated after executing the current command. Continue?"
+                        groups="cetmix_tower_server.group_manager"
+                    />
+                </header>
                 <sheet>
                     <widget
                         name="web_ribbon"
@@ -15,13 +26,19 @@
                     <widget
                         name="web_ribbon"
                         title="Finished"
-                        invisible="is_running or not is_running and plan_status != 0"
+                        invisible="is_running or is_stopped or not is_running and plan_status != 0"
+                    />
+                    <widget
+                        name="web_ribbon"
+                        title="Stopped"
+                        bg_color="bg-danger"
+                        invisible="not is_stopped"
                     />
                     <widget
                         name="web_ribbon"
                         title="Failed"
                         bg_color="bg-danger"
-                        invisible="is_running or not is_running and plan_status == 0"
+                        invisible="is_running or is_stopped or not is_running and plan_status == 0"
                     />
                     <group>
                         <group>
@@ -37,6 +54,7 @@
                                 invisible="not parent_flight_plan_log_id"
                             />
                             <field name="is_running" invisible="not is_running" />
+                            <field name="is_stopped" invisible="not is_stopped" />
                             <field
                                 name="plan_line_executed_id"
                                 invisible="not is_running"

--- a/cetmix_tower_server_queue/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_queue/models/cx_tower_command_log.py
@@ -1,9 +1,12 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import fields, models, tools
 
-from odoo.addons.cetmix_tower_server.models.constants import COMMAND_TIMED_OUT
+from odoo.addons.cetmix_tower_server.models.constants import (
+    COMMAND_STOPPED,
+    COMMAND_TIMED_OUT,
+)
 from odoo.addons.queue_job.job import CANCELLED
 
 
@@ -31,7 +34,24 @@ class CxTowerCommandLog(models.Model):
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs
     ):
-        res = super().finish(finish_date, status, response, error, **kwargs)
-        if self.queue_job_id and status == COMMAND_TIMED_OUT:
+        if status == COMMAND_TIMED_OUT and self.queue_job_id:
             self.queue_job_id.sudo()._change_job_state(CANCELLED, result=error)
-        return res
+
+        # Do not update status if it was already stopped
+        if self.command_status == COMMAND_STOPPED and status != COMMAND_STOPPED:
+            return False
+
+        if status == COMMAND_STOPPED and self.queue_job_id:
+            return super().finish(finish_date, status, response, error, **kwargs)
+
+        # Avoid to finish the command log multiple times in the same time
+        try:
+            with self.env.cr.savepoint(), tools.mute_logger("odoo.sql_db"):
+                self.env.cr.execute(
+                    f"SELECT command_status FROM {self._table} WHERE id = %s FOR UPDATE NOWAIT",  # noqa: E501
+                    [self.id],
+                )
+        except Exception:
+            return {}
+
+        return super().finish(finish_date, status, response, error, **kwargs)

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -57,7 +57,10 @@ class CxTowerServer(models.Model):
     ):
         # avoid executing command if plan was stopped
         log_record.invalidate_recordset(["plan_log_id"])
+        if log_record.plan_log_id:
+            log_record.plan_log_id.invalidate_recordset(["is_stopped"])
         if log_record and log_record.plan_log_id and log_record.plan_log_id.is_stopped:
+            log_record.stop()
             return
 
         return self._command_runner(

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -22,7 +22,7 @@ class CxTowerServer(models.Model):
         # preserve the order of execution of commands with action “Run flight plan”.
         # Use runner only if command log record is provided.
         if log_record and not log_record.plan_log_id.parent_flight_plan_log_id:
-            job = self.with_delay()._command_runner(
+            job = self.with_delay()._queue_command_runner_wrapper(
                 command=command,
                 log_record=log_record,
                 rendered_command_code=rendered_command_code,
@@ -44,3 +44,28 @@ class CxTowerServer(models.Model):
                 ssh_connection=ssh_connection,
                 **kwargs,
             )
+
+    def _queue_command_runner_wrapper(
+        self,
+        command,
+        log_record,
+        rendered_command_code,
+        sudo=None,
+        rendered_command_path=None,
+        ssh_connection=None,
+        **kwargs,
+    ):
+        # avoid executing command if plan was stopped
+        log_record.invalidate_recordset(["plan_log_id"])
+        if log_record and log_record.plan_log_id and log_record.plan_log_id.is_stopped:
+            return
+
+        return self._command_runner(
+            command=command,
+            log_record=log_record,
+            rendered_command_code=rendered_command_code,
+            sudo=sudo,
+            rendered_command_path=rendered_command_path,
+            ssh_connection=ssh_connection,
+            **kwargs,
+        )

--- a/cetmix_tower_server_queue/readme/newsfragments/3410.feature
+++ b/cetmix_tower_server_queue/readme/newsfragments/3410.feature
@@ -1,0 +1,1 @@
+Terminate running flight plan manually


### PR DESCRIPTION
Terminate a running flight plan. Important: flight plan will be terminated after the current running command is finished.

Forward port of https://github.com/cetmix/cetmix-tower/pull/350

Task: 5011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manager-only "Stop" button/action to terminate running flight plans with confirmation and on-screen notification.
  * New "Stopped" status/ribbon and visible indicator for user-terminated plans; stopping a plan also stops running commands.

* **Bug Fixes**
  * Prevents further scheduling/execution after a plan is stopped; cancels queued/running command jobs when stopped.

* **Tests**
  * Added test verifying mid-execution plan stop behavior and resulting statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->