### PR TITLE
[16.0][FIX] cetmix_tower_server, cetmix_tower_server_queue Stop plans and commands

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command_log.py
+++ b/cetmix_tower_server/models/cx_tower_command_log.py
@@ -1,12 +1,8 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import logging
-
 from odoo import _, api, fields, models
 
 from .constants import COMMAND_STOPPED, GENERAL_ERROR
-
-_logger = logging.getLogger(__name__)
 
 
 class CxTowerCommandLog(models.Model):
@@ -181,6 +177,10 @@ class CxTowerCommandLog(models.Model):
                 status=COMMAND_STOPPED,
                 error=_("Stopped by user %(user)s", user=user_name),
             )
+
+            # Ensure flight plan log is stopped too
+            if log.plan_log_id and log.plan_log_id.is_running:
+                log.plan_log_id.stop()
 
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs

--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -206,7 +206,7 @@ class CxTowerPlanLog(models.Model):
         """
         user_name = self.env.user.name
         for log in self:
-            if not log.is_running or log.is_stopped:
+            if not log.is_running:
                 continue
 
             # Finish plan log

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -57,8 +57,14 @@ class CxTowerServer(models.Model):
     ):
         # avoid executing command if plan was stopped
         log_record.invalidate_recordset(["plan_log_id"])
-        if log_record and log_record.plan_log_id and log_record.plan_log_id.is_stopped:
-            return
+        plan_log_id = log_record.plan_log_id
+        if plan_log_id:
+            plan_log_id.invalidate_recordset(["is_stopped"])
+
+            # If plan was stopped, stop the command
+            if plan_log_id.is_stopped:
+                log_record.stop()
+                return
 
         return self._command_runner(
             command=command,


### PR DESCRIPTION
Fix edge case scenario handling in the command/flight plan termination flow.

Task: 5044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping a command now also ensures its related flight plan log is stopped to keep logs synchronized.
  * Refined stop handling to reduce inconsistent or duplicate finish actions on logs.
  * Command execution will now halt early when tied to a flight plan that has already been stopped; commands without a plan continue as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->