### PR TITLE
[17.0][MIG] cetmix_tower_yaml: forward port from 16.0

### DIFF
--- a/cetmix_tower_yaml/readme/newsfragments/5010.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/5010.feature
@@ -1,0 +1,1 @@
+Improve the way secrets are listed in the YAML import widget.

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -520,6 +520,37 @@ records:
         self.assertIn("Secret 1", secret_list, "Key is not in the list")
         self.assertIn("Secret 2", secret_list, "Key is not in the list")
 
+    def test_extract_secret_names_with_key_id(self):
+        """Test extract secret names when secrets are nested under key_id"""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: test_model
+  reference: rec_1
+  name: Test Record
+  secret_ids:
+    - key_id:
+        reference: secret_1
+        name: Nested Secret 1
+    - key_id:
+        reference: secret_2
+        name: Nested Secret 2
+  ssh_key_id:
+    name: SSH Key Nested
+"""
+        secret_list = self.env["cx.tower.yaml.import.wiz"]._extract_secret_names(
+            yaml.safe_load(yaml_code)
+        )
+
+        # We expect 3 secrets total:
+        # - SSH Key Nested (from ssh_key_id)
+        # - Nested Secret 1
+        # - Nested Secret 2
+        self.assertCountEqual(
+            secret_list,
+            ["Nested Secret 1", "Nested Secret 2", "SSH Key Nested"],
+            "Unexpected secrets extracted for nested structure",
+        )
+
     def test_create_records_different_models(self):
         """Test create records with different models"""
 

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -32,13 +32,13 @@ class CxTowerYamlImportWiz(models.TransientModel):
         required=True,
         help="What to do if record with the same reference already exists",
     )
-    secret_list = fields.Char(
-        readonly=True,
-        help="List of secrets present in the YAML file",
+    secret_list = fields.Html(
+        help="List of secrets present in the YAML file (formatted as HTML list)",
         compute="_compute_secret_list",
     )
-    preview_code = fields.Boolean()
-
+    preview_code = fields.Boolean(
+        help="Toggle to show or hide YAML code preview",
+    )
     manifest_name = fields.Char(
         readonly=True, compute="_compute_yaml_data", string="Snippet Name"
     )
@@ -77,20 +77,25 @@ class CxTowerYamlImportWiz(models.TransientModel):
     def _compute_secret_list(self):
         """Compute list of secrets present in the YAML file"""
         for record in self:
-            secret_list = self._extract_secret_names(yaml.safe_load(record.yaml_code))
-            if secret_list:
-                record.secret_list = _(
-                    "After import, please check and provide secret values"
-                    " if needed for the following secrets: %(secrets)s",
-                    secrets=", ".join(secret_list),
-                )
-            else:
+            yaml_data = yaml.safe_load(record.yaml_code or "{}")
+            secret_list = self._extract_secret_names(yaml_data)
+            if not secret_list:
                 record.secret_list = False
+                continue
+
+            # Build deterministic HTML list of secrets
+            items = "".join(f"<li>{name}</li>" for name in sorted(secret_list))
+            secrets_html = f"<ul>{items}</ul>"
+
+            record.secret_list = _(
+                "Following secrets are used in the code:<br/>%(secrets)s",
+                secrets=secrets_html,
+            )
 
     @api.depends("yaml_code")
     def _compute_yaml_data(self):
         for record in self:
-            data = yaml.safe_load(record.yaml_code)
+            data = yaml.safe_load(record.yaml_code or "{}")
 
             manifest = data.get("manifest", {}) if isinstance(data, dict) else {}
             authors = manifest.get("author")
@@ -265,11 +270,9 @@ class CxTowerYamlImportWiz(models.TransientModel):
     def _extract_secret_names(self, data: dict) -> list:
         """Extract names of secrets from YAML data.
 
-        Args:
-            data (dict): YAML data.
-
-        Returns:
-            list: List of unique secret names.
+        Supports both formats:
+        - secret_ids -> [{name: ...}]
+        - secret_ids -> [{key_id: {name: ...}}]
         """
         secret_names = set()
 
@@ -278,9 +281,21 @@ class CxTowerYamlImportWiz(models.TransientModel):
             if isinstance(node, dict):
                 if "secret_ids" in node and isinstance(node["secret_ids"], list):
                     for item in node["secret_ids"]:
-                        if isinstance(item, dict) and "name" in item:
-                            secret_names.add(item["name"])
+                        if not isinstance(item, dict):
+                            continue
 
+                        # Format 1: direct name
+                        if "name" in item:
+                            secret_names.add(item["name"])
+                        # Format 2: nested key_id -> name
+                        elif (
+                            "key_id" in item
+                            and isinstance(item["key_id"], dict)
+                            and "name" in item["key_id"]
+                        ):
+                            secret_names.add(item["key_id"]["name"])
+
+                # Handle single ssh_key_id
                 if "ssh_key_id" in node and isinstance(node["ssh_key_id"], dict):
                     if "name" in node["ssh_key_id"]:
                         secret_names.add(node["ssh_key_id"]["name"])

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
@@ -9,7 +9,22 @@
                 <group>
                     <field name="if_record_exists" />
                 </group>
-                <group invisible="not manifest_name">
+                <div
+                    class="alert alert-info"
+                    role="alert"
+                    attrs="{'invisible': [('secret_list', '=', False)]}"
+                >
+                    <field name="secret_list" nolabel="1" />
+                </div>
+
+                <group>
+                    <field name="preview_code" widget="boolean_toggle" />
+                </group>
+                <group
+                    attrs="{'invisible': [
+                        ('manifest_name', '=', False),
+                    ]}"
+                >
                     <group string="Information">
                         <field name="manifest_name" string="Name" />
                         <field name="manifest_summary" string="Summary" />
@@ -34,27 +49,38 @@
                             invisible="not manifest_currency"
                         />
                     </group>
-                    <notebook>
-                        <page string="Description" invisible="not manifest_description">
-                            <field
-                                name="manifest_description"
-                                widget="text"
-                                nolabel="1"
-                                colspan="4"
-                            />
-                        </page>
-                        <page
-                            string="License text"
-                            invisible="not manifest_license_text"
-                        >
-                            <field
-                                name="manifest_license_text"
-                                widget="text"
-                                nolabel="1"
-                                colspan="4"
-                            />
-                        </page>
-                        <page string="Preview code">
+                </group>
+
+                <notebook>
+                    <page
+                        string="Description"
+                        attrs="{'invisible':[('manifest_description','=',False)]}"
+                    >
+                        <field
+                            name="manifest_description"
+                            widget="text"
+                            nolabel="1"
+                            colspan="4"
+                        />
+                    </page>
+
+                    <page
+                        string="License text"
+                        attrs="{'invisible':[('manifest_license_text','=',False)]}"
+                    >
+                        <field
+                            name="manifest_license_text"
+                            widget="text"
+                            nolabel="1"
+                            colspan="4"
+                        />
+                    </page>
+
+                    <page
+                        string="Code preview"
+                        attrs="{'invisible': [('preview_code', '=', False)]}"
+                    >
+                        <group>
                             <field
                                 name="yaml_code"
                                 widget="ace"
@@ -63,10 +89,9 @@
                                 nolabel="1"
                                 colspan="4"
                             />
-                        </page>
-                    </notebook>
-
-                </group>
+                        </group>
+                    </page>
+                </notebook>
 
                 <div
                     class="alert alert-warning"
@@ -74,9 +99,11 @@
                     invisible="if_record_exists != 'create'"
                     style="margin-bottom:0px;"
                 >
-                <p>
-                    <strong
-                        >Important:</strong> To maintain data consistency, the following model records will always be updated if they exist in Odoo:
+                    <p>
+                        <strong
+                        >Important:</strong> To maintain data consistency, the following
+                        model records will always be updated if they exist in Odoo:
+                    </p>
                     <ul>
                         <li>Variables</li>
                         <li>Variable Options</li>
@@ -84,9 +111,11 @@
                         <li>Tags</li>
                         <li>OSs</li>
                     </ul>
-                    To create new entities instead of updating existing ones, remove or modify the <code
+                    <p>
+                        To create new entities instead of updating existing ones, remove or modify
+                        the <code
                         >reference</code> field in the YAML code for those entities.
-                </p>
+                    </p>
                 </div>
                 <div
                     class="alert alert-warning"
@@ -98,9 +127,6 @@
                         Existing record will be updated with the new data. Related records, present in the YAML code, will be updated too.
                         If any of those related records doesn't exist, it will be created automatically.
                     </p>
-                </div>
-                <div class="alert alert-info" role="alert" invisible="not secret_list">
-                    <field name="secret_list" invisible="not secret_list" />
                 </div>
                 <footer>
                     <button

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.xml
@@ -9,22 +9,15 @@
                 <group>
                     <field name="if_record_exists" />
                 </group>
-                <div
-                    class="alert alert-info"
-                    role="alert"
-                    attrs="{'invisible': [('secret_list', '=', False)]}"
-                >
+                <div class="alert alert-info" role="alert" invisible="not secret_list">
                     <field name="secret_list" nolabel="1" />
                 </div>
 
                 <group>
                     <field name="preview_code" widget="boolean_toggle" />
                 </group>
-                <group
-                    attrs="{'invisible': [
-                        ('manifest_name', '=', False),
-                    ]}"
-                >
+
+                <group invisible="not manifest_name">
                     <group string="Information">
                         <field name="manifest_name" string="Name" />
                         <field name="manifest_summary" string="Summary" />
@@ -52,10 +45,7 @@
                 </group>
 
                 <notebook>
-                    <page
-                        string="Description"
-                        attrs="{'invisible':[('manifest_description','=',False)]}"
-                    >
+                    <page string="Description" invisible="not manifest_description">
                         <field
                             name="manifest_description"
                             widget="text"
@@ -64,10 +54,7 @@
                         />
                     </page>
 
-                    <page
-                        string="License text"
-                        attrs="{'invisible':[('manifest_license_text','=',False)]}"
-                    >
+                    <page string="License text" invisible="not manifest_license_text">
                         <field
                             name="manifest_license_text"
                             widget="text"
@@ -76,10 +63,7 @@
                         />
                     </page>
 
-                    <page
-                        string="Code preview"
-                        attrs="{'invisible': [('preview_code', '=', False)]}"
-                    >
+                    <page string="Code preview" invisible="not preview_code">
                         <group>
                             <field
                                 name="yaml_code"


### PR DESCRIPTION
Forward port the following PR:

[[16.0][IMP] cetmix_tower_yaml: move secrets above YAML and add preview toggle](https://github.com/cetmix/cetmix-tower/pull/409/commits/1e4f1bd76f86edc1193ff3418a637d0cb9869a73)

Task: 5055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secrets are displayed as a deterministic, formatted HTML list, now detecting nested secret entries (including SSH key entries).
  * Added a toggleable code preview to show or hide the YAML editor.

* **UI / Layout**
  * Reorganized the import form into Description, License, and Code Preview pages.
  * Added a top informational alert for secrets and refined warning wording/formatting; removed the bottom alert.

* **Tests**
  * Added a test verifying extraction of nested secret names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->