### PR TITLE
[17.0][IMP] cetmix_tower_server_queue: command finish

### DIFF
--- a/cetmix_tower_server_queue/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_queue/models/cx_tower_command_log.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import fields, models, tools
 
 from odoo.addons.cetmix_tower_server.models.constants import (
@@ -8,6 +10,8 @@ from odoo.addons.cetmix_tower_server.models.constants import (
     COMMAND_TIMED_OUT,
 )
 from odoo.addons.queue_job.job import CANCELLED
+
+_logger = logging.getLogger(__name__)
 
 
 class CxTowerCommandLog(models.Model):
@@ -34,24 +38,45 @@ class CxTowerCommandLog(models.Model):
     def finish(
         self, finish_date=None, status=None, response=None, error=None, **kwargs
     ):
-        if status == COMMAND_TIMED_OUT and self.queue_job_id:
-            self.queue_job_id.sudo()._change_job_state(CANCELLED, result=error)
+        """Finish the command log
 
-        # Do not update status if it was already stopped
-        if self.command_status == COMMAND_STOPPED and status != COMMAND_STOPPED:
-            return False
+        Args:
+            finish_date (Datetime, optional): Command finish date. Defaults to None.
+            status (Integer, optional): Command status. Defaults to None.
+            response (Text, optional): Command response. Defaults to None.
+            error (Text, optional): Command error. Defaults to None.
+        """
 
-        if status == COMMAND_STOPPED and self.queue_job_id:
-            return super().finish(finish_date, status, response, error, **kwargs)
+        # Filter out command logs that are already stopped
+        command_logs_to_process = self.filtered(
+            lambda log: log.command_status != COMMAND_STOPPED
+        )
+        if not command_logs_to_process:
+            return
 
-        # Avoid to finish the command log multiple times in the same time
+        # Avoid finishing the command log multiple times at the same time
         try:
             with self.env.cr.savepoint(), tools.mute_logger("odoo.sql_db"):
                 self.env.cr.execute(
-                    f"SELECT command_status FROM {self._table} WHERE id = %s FOR UPDATE NOWAIT",  # noqa: E501
-                    [self.id],
+                    f"SELECT command_status FROM {self._table} WHERE id IN %s FOR UPDATE NOWAIT",  # noqa: E501
+                    (tuple(command_logs_to_process.ids),),
                 )
-        except Exception:
-            return {}
+        except Exception as e:
+            _logger.error(
+                "Could not acquire lock on command logs %s, skipping finish: %s",
+                command_logs_to_process.ids,
+                e,
+            )
+            return
 
-        return super().finish(finish_date, status, response, error, **kwargs)
+        # Update the related queue job state if the command timed out
+        if status == COMMAND_TIMED_OUT:
+            for command_log in command_logs_to_process:
+                if command_log.queue_job_id:
+                    command_log.queue_job_id.sudo()._change_job_state(
+                        CANCELLED, result=error
+                    )
+
+        return super(CxTowerCommandLog, command_logs_to_process).finish(
+            finish_date, status, response, error, **kwargs
+        )

--- a/cetmix_tower_server_queue/models/cx_tower_command_log.py
+++ b/cetmix_tower_server_queue/models/cx_tower_command_log.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from psycopg2.errors import LockNotAvailable
+
 from odoo import fields, models, tools
 
 from odoo.addons.cetmix_tower_server.models.constants import (
@@ -54,29 +56,35 @@ class CxTowerCommandLog(models.Model):
         if not command_logs_to_process:
             return
 
-        # Avoid finishing the command log multiple times at the same time
-        try:
-            with self.env.cr.savepoint(), tools.mute_logger("odoo.sql_db"):
-                self.env.cr.execute(
-                    f"SELECT command_status FROM {self._table} WHERE id IN %s FOR UPDATE NOWAIT",  # noqa: E501
-                    (tuple(command_logs_to_process.ids),),
+        # Lock and process each record individually
+        locked_logs = self.browse()
+        for command_log in command_logs_to_process:
+            try:
+                with self.env.cr.savepoint(), tools.mute_logger("odoo.sql_db"):
+                    self.env.cr.execute(
+                        f"SELECT command_status FROM {self._table} WHERE id = %s FOR UPDATE NOWAIT",  # noqa: E501
+                        (command_log.id,),
+                    )
+                    locked_logs |= command_log
+            except LockNotAvailable as e:
+                _logger.warning(
+                    "Could not acquire lock on command log %s, skipping: %s",
+                    command_log.id,
+                    e,
                 )
-        except Exception as e:
-            _logger.error(
-                "Could not acquire lock on command logs %s, skipping finish: %s",
-                command_logs_to_process.ids,
-                e,
-            )
+                continue
+
+        if not locked_logs:
             return
 
         # Update the related queue job state if the command timed out
         if status == COMMAND_TIMED_OUT:
-            for command_log in command_logs_to_process:
+            for command_log in locked_logs:
                 if command_log.queue_job_id:
                     command_log.queue_job_id.sudo()._change_job_state(
                         CANCELLED, result=error
                     )
 
-        return super(CxTowerCommandLog, command_logs_to_process).finish(
+        return super(CxTowerCommandLog, locked_logs).finish(
             finish_date, status, response, error, **kwargs
         )

--- a/cetmix_tower_server_queue/models/cx_tower_server.py
+++ b/cetmix_tower_server_queue/models/cx_tower_server.py
@@ -57,11 +57,14 @@ class CxTowerServer(models.Model):
     ):
         # avoid executing command if plan was stopped
         log_record.invalidate_recordset(["plan_log_id"])
-        if log_record.plan_log_id:
-            log_record.plan_log_id.invalidate_recordset(["is_stopped"])
-        if log_record and log_record.plan_log_id and log_record.plan_log_id.is_stopped:
-            log_record.stop()
-            return
+        plan_log_id = log_record.plan_log_id
+        if plan_log_id:
+            plan_log_id.invalidate_recordset(["is_stopped"])
+
+            # If plan was stopped, stop the command
+            if plan_log_id.is_stopped:
+                log_record.stop()
+                return
 
         return self._command_runner(
             command=command,

--- a/cetmix_tower_server_queue/readme/newsfragments/5062.bugfix
+++ b/cetmix_tower_server_queue/readme/newsfragments/5062.bugfix
@@ -1,0 +1,1 @@
+Finish multiple commands at once.


### PR DESCRIPTION
Before this commit the 'finish()' method was written to handle only one command log at a time.
However in the parent class this method is designed to handele recordsets. This lead to errors when this method was triggered for multiple command logs. Eg when killing 'zombie' commands.
This commit fixes the issue by filtering out the command logs that are already stopped and making it recordset-friendly.
Forward port of https://github.com/cetmix/cetmix-tower/pull/418

Additional: `_queue_command_runner_wrapper()` function optimisation.

Task: 5071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finish multiple queued commands at once, improving throughput and reliability.
  * Improved handling of command timeouts and cancellations to reduce stuck jobs.
  * More robust lock handling so contention on one command doesn’t block others.
* **Documentation**
  * Added release note entry describing the multi-command finish fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->