### PR TITLE
[17.0][MIG] cetmix_tower_server custom values in flight plan

### DIFF
--- a/cetmix_tower_server/demo/demo_data.xml
+++ b/cetmix_tower_server/demo/demo_data.xml
@@ -254,6 +254,11 @@
             name="validation_message"
         >Must be lowercase and contain only letters and numbers!</field>
     </record>
+    <record id="variable_command_error" model="cx.tower.variable">
+        <field name="name">Command Error</field>
+        <field name="reference">command_error</field>
+        <field name="variable_type">s</field>
+    </record>
 
     <!-- ===============================================
     Variables Options for Odoo Version
@@ -450,6 +455,21 @@
         />
     </record>
 
+    <!-- Flight Plan #6 - Test skip command error -->
+    <record id="plan_test_skip_command_error" model="cx.tower.plan">
+        <field name="name">Test skip command error</field>
+        <field name="access_level">2</field>
+        <field name="on_error_action">e</field>
+        <field name="custom_exit_code">0</field>
+        <field name="note">
+This plan is used to test the skip command error flow.
+Expected result:
+- Command 4 skipped
+- Command 5 is run
+- Plan finishes with error
+        </field>
+    </record>
+
     <!-- ===============================================
     Commands
     ================================================ -->
@@ -563,6 +583,42 @@ else:
             name="tag_ids"
             eval="[(6, 0, [ref('cetmix_tower_server.tag_staging')])]"
         />
+    </record>
+
+    <!-- Command #8 - Success -->
+    <record id="command__success" model="cx.tower.command">
+        <field name="name">Command -&gt; Success</field>
+        <field name="action">python_code</field>
+        <field name="code"># Juse return deafult values</field>
+        <field name="access_level">2</field>
+    </record>
+
+    <!-- Command #9 - Error -->
+    <record id="command__error" model="cx.tower.command">
+        <field name="name">Command -&gt; Error</field>
+        <field name="action">python_code</field>
+        <field name="code">result = {"exit_code": -100, "message": "Error"}</field>
+        <field name="access_level">2</field>
+    </record>
+
+    <!-- Command #10 - After failed -->
+    <record id="command___after_failed" model="cx.tower.command">
+        <field name="name">Command -&gt; After failed</field>
+        <field name="action">python_code</field>
+        <field name="code"># Update the server name
+name = server.name + " --after-failed-- "
+server.write({"name":name})</field>
+        <field name="access_level">2</field>
+    </record>
+
+    <!-- Command #11 - The last one -->
+    <record id="command___the_last_one" model="cx.tower.command">
+        <field name="name">Command -&gt; The last one</field>
+        <field name="action">python_code</field>
+        <field name="code"># Update the server name
+name = server.name + " --last-one-- "
+server.write({"name":name})</field>
+        <field name="access_level">2</field>
     </record>
 
     <!-- ===============================================
@@ -701,6 +757,81 @@ else:
         <field name="sequence">20</field>
         <field name="plan_id" ref="plan_demo_5" />
         <field name="command_id" ref="command_download_file" />
+    </record>
+
+    <!-- ===============================================
+    Flight Plan Test Skip Command Error Lines
+    ================================================ -->
+    <record id="plan_test_skip_command_error_line_1" model="cx.tower.plan.line">
+        <field name="sequence">10</field>
+        <field name="plan_id" ref="plan_test_skip_command_error" />
+        <field name="command_id" ref="command__success" />
+    </record>
+    <record id="plan_test_skip_command_error_line_2" model="cx.tower.plan.line">
+        <field name="sequence">11</field>
+        <field name="plan_id" ref="plan_test_skip_command_error" />
+        <field name="command_id" ref="command__success" />
+    </record>
+    <record id="plan_test_skip_command_error_line_3" model="cx.tower.plan.line">
+        <field name="sequence">12</field>
+        <field name="plan_id" ref="plan_test_skip_command_error" />
+        <field name="command_id" ref="command__error" />
+    </record>
+    <record id="plan_test_skip_command_error_line_4" model="cx.tower.plan.line">
+        <field name="sequence">13</field>
+        <field name="plan_id" ref="plan_test_skip_command_error" />
+        <field name="command_id" ref="command___after_failed" />
+        <field name="condition">not {{ command_error }}</field>
+        <field name="variable_ids" eval="[(4, ref('variable_command_error'))]" />
+    </record>
+    <record id="plan_test_skip_command_error_line_5" model="cx.tower.plan.line">
+        <field name="sequence">14</field>
+        <field name="plan_id" ref="plan_test_skip_command_error" />
+        <field name="command_id" ref="command___the_last_one" />
+        <field name="condition">{{ command_error }}</field>
+        <field name="variable_ids" eval="[(4, ref('variable_command_error'))]" />
+    </record>
+
+    <!-- ===============================================
+    Flight Plan Test Skip Command Error Line Actions
+    ================================================ -->
+    <record
+        id="plan_test_skip_command_error_line_3_action_1"
+        model="cx.tower.plan.line.action"
+    >
+        <field name="line_id" ref="plan_test_skip_command_error_line_3" />
+        <field name="sequence">10</field>
+        <field name="condition">!=</field>
+        <field name="value_char">0</field>
+        <field name="action">n</field>
+        <field name="custom_exit_code">0</field>
+    </record>
+    <record
+        id="plan_test_skip_command_error_line_5_action_1"
+        model="cx.tower.plan.line.action"
+    >
+        <field name="line_id" ref="plan_test_skip_command_error_line_5" />
+        <field name="sequence">10</field>
+        <field name="condition">==</field>
+        <field name="value_char">0</field>
+        <field name="action">ec</field>
+        <field name="custom_exit_code">-1</field>
+    </record>
+
+    <!-- ===============================================
+    Flight Plan Test Skip Command Error Line Action Variable Values
+    ================================================ -->
+    <record
+        id="plan_test_skip_command_error_line_3_action_1_value_command_error"
+        model="cx.tower.variable.value"
+    >
+        <field name="variable_id" ref="variable_command_error" />
+        <field
+            name="plan_line_action_id"
+            ref="plan_test_skip_command_error_line_3_action_1"
+        />
+        <field name="sequence">10</field>
+        <field name="value_char">1</field>
     </record>
 
     <!-- ===============================================

--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -271,11 +271,10 @@ class CxTowerPlan(models.Model):
         # Default values
         exit_code = command_log.command_status
         server = command_log.server_id
-        server_variable_values = server.variable_value_ids
 
         # Check line condition
         variable_values = (
-            command_log.variable_values or command_log.plan_log_id.variable_values
+            command_log.variable_values or command_log.plan_log_id.variable_values or {}
         )
         if not current_line._is_executable_line(
             server, variable_values=variable_values
@@ -297,24 +296,17 @@ class CxTowerPlan(models.Model):
                 if action == "ec" and action_line.custom_exit_code:
                     exit_code = action_line.custom_exit_code
 
-                variable_value_obj = self.env["cx.tower.variable.value"]
+                # Apply action-defined values into the variable values context
                 for variable_value in action_line.variable_value_ids:
-                    variable = variable_value.variable_id
-                    server_variable_value = server_variable_values.filtered(
-                        lambda rec, variable=variable: rec.variable_id == variable,
-                    )
-                    if server_variable_value:
-                        # update exist server value
-                        server_variable_value.value_char = variable_value.value_char
-                    else:
-                        # create new value
-                        variable_value_obj.create(
-                            {
-                                "variable_id": variable.id,
-                                "value_char": variable_value.value_char,
-                                "server_id": server.id,
-                            }
-                        )
+                    ref = variable_value.variable_id.reference
+                    variable_values[ref] = variable_value.value_char
+
+                # Persist the updated custom values only in logs
+                # so they remain available within the current flight plan context
+                updated_values = dict(variable_values)
+                command_log.variable_values = updated_values
+                if command_log.plan_log_id:
+                    command_log.plan_log_id.variable_values = updated_values
 
                 return self._get_next_action_state(action, exit_code, current_line)
 
@@ -368,7 +360,11 @@ class CxTowerPlan(models.Model):
             if plan_line._is_executable_line(server, variable_values=variable_values):
                 plan_line._run(server, plan_log, variable_values=variable_values)
             else:
-                plan_line._skip(server, plan_log)
+                plan_line._skip(
+                    server,
+                    plan_log,
+                    log={"variable_values": dict(variable_values or {})},
+                )
 
         # Exit
         if action in ["e", "ec"]:

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -835,7 +835,7 @@ custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
 
     def test_plan_with_update_variables(self):
         """
-        Test plan with update server variables
+        Test plan updates custom (in-flight) values
         """
         # Add new variable to server
         self.VariableValue.create(
@@ -845,7 +845,7 @@ custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
                 "server_id": self.server_test_1.id,
             }
         )
-        # Create new variable value to action to update existing server variable
+        # Create new variable value on action
         self.VariableValue.create(
             {
                 "variable_id": self.variable_version.id,
@@ -853,7 +853,15 @@ custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
                 "plan_line_action_id": self.plan_line_1_action_1.id,
             }
         )
-        # Check that server contains server variable with value
+        # Add a new variable value on action for a variable absent on the server
+        self.VariableValue.create(
+            {
+                "variable_id": self.variable_os.id,
+                "value_char": "Ubuntu",
+                "plan_line_action_id": self.plan_line_1_action_1.id,
+            }
+        )
+        # Pre-run sanity: server holds initial value and no OS value
         exist_server_values = self.server_test_1.variable_value_ids.filtered(
             lambda rec: rec.variable_id == self.variable_version
         )
@@ -867,16 +875,6 @@ custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
             "14.0",
             "The server variable value should be '14.0'",
         )
-
-        # Add a new variable value to an action that does not exist on the server
-        self.VariableValue.create(
-            {
-                "variable_id": self.variable_os.id,
-                "value_char": "Ubuntu",
-                "plan_line_action_id": self.plan_line_1_action_1.id,
-            }
-        )
-        # Check that this field is not exist on server
         exist_server_values = self.server_test_1.variable_value_ids.filtered(
             lambda rec: rec.variable_id == self.variable_os
         )
@@ -885,33 +883,44 @@ custom_values['{cls.variable_url.reference}'] = 'https://www.cetmix.com'
         )
         # Run plan
         self.plan_1._run_single(self.server_test_1)
-        # Check that exists server values was updated
-        exist_server_values = self.server_test_1.variable_value_ids.filtered(
+        # After run: server values MUST remain unchanged
+        server_version_val = self.server_test_1.variable_value_ids.filtered(
             lambda rec: rec.variable_id == self.variable_version
         )
         self.assertEqual(
-            len(exist_server_values),
-            1,
-            "The server should have only one value for the variable",
+            server_version_val.value_char,
+            "14.0",
+            "Server variable value must remain unchanged",
         )
+        self.assertFalse(
+            self.server_test_1.variable_value_ids.filtered(
+                lambda rec: rec.variable_id == self.variable_os
+            ),
+            "Server must not receive new variable from action",
+        )
+
+        # But custom (in-flight) values MUST be updated in logs
+        plan_log = self.PlanLog.search(
+            [("server_id", "=", self.server_test_1.id)], order="id desc", limit=1
+        )
+        self.assertTrue(plan_log, "Plan log should exist after run")
         self.assertEqual(
-            exist_server_values.value_char,
+            plan_log.variable_values[self.variable_version.reference],
             "16.0",
-            "The server variable value should be updated value '16.0'",
-        )
-        # Check that new server value was added to server
-        exist_server_values = self.server_test_1.variable_value_ids.filtered(
-            lambda rec: rec.variable_id == self.variable_os
+            "Plan log must contain updated custom value",
         )
         self.assertEqual(
-            len(exist_server_values),
-            1,
-            "The server should have new value for the variable",
-        )
-        self.assertEqual(
-            exist_server_values.value_char,
+            plan_log.variable_values[self.variable_os.reference],
             "Ubuntu",
-            "The server variable value should be updated value 'Ubuntu'",
+            "Plan log must contain new custom value",
+        )
+
+        last_command_log = plan_log.command_log_ids and plan_log.command_log_ids[-1]
+        self.assertTrue(last_command_log, "Command log should exist after run")
+        self.assertEqual(
+            last_command_log.variable_values[self.variable_version.reference],
+            "16.0",
+            "Command log must contain updated custom value",
         )
 
     def test_plan_with_action_variables_for_condition(self):
@@ -2437,3 +2446,151 @@ result = {
             main_plan_log.plan_status,
             "Main plan should have the same error status as the SSH command",
         )
+
+    def test_skip_command_error_flow(self):
+        """Plan flow:
+        1) success, 2) success, 3) error -> sets command_error variable,
+        4) skipped if not var, 5) runs if var and exits -1.
+        """
+        # Create commands
+        command_success = self.Command.create(
+            {
+                "name": "Command -> Success",
+                "action": "python_code",
+                "code": "# Juse return deafult values",
+            }
+        )
+        command_error = self.Command.create(
+            {
+                "name": "Command -> Error",
+                "action": "python_code",
+                "code": "result = {'exit_code': -100, 'message': 'Error'}",
+            }
+        )
+        command_after_failed = self.Command.create(
+            {
+                "name": "Command -> After failed",
+                "action": "python_code",
+                "code": (
+                    "name = server.name + ' --after-failed-- '\n"
+                    "server.write({'name': name})"
+                ),
+            }
+        )
+        command_last_one = self.Command.create(
+            {
+                "name": "Command -> The last one",
+                "action": "python_code",
+                "code": (
+                    "name = server.name + ' --last-one-- '\n"
+                    "server.write({'name': name})"
+                ),
+            }
+        )
+
+        # Variable used in conditions
+        variable_command_error = self.Variable.create(
+            {
+                "name": "command_error",
+                "reference": "test_command_error",
+                "variable_type": "s",
+            }
+        )
+
+        # Plan and lines
+        plan = self.Plan.create(
+            {
+                "name": "Test skip command error",
+                "on_error_action": "e",
+                "custom_exit_code": 0,
+            }
+        )
+
+        self.plan_line.create(
+            {"sequence": 10, "plan_id": plan.id, "command_id": command_success.id}
+        )
+        self.plan_line.create(
+            {"sequence": 20, "plan_id": plan.id, "command_id": command_success.id}
+        )
+
+        line3 = self.plan_line.create(
+            {"sequence": 30, "plan_id": plan.id, "command_id": command_error.id}
+        )
+        action3 = self.plan_line_action.create(
+            {
+                "line_id": line3.id,
+                "sequence": 10,
+                "condition": "!=",
+                "value_char": "0",
+                "action": "n",
+            }
+        )
+
+        self.VariableValue.create(
+            {
+                "variable_id": variable_command_error.id,
+                "value_char": "1",
+                "plan_line_action_id": action3.id,
+            }
+        )
+
+        self.plan_line.create(
+            {
+                "sequence": 40,
+                "plan_id": plan.id,
+                "command_id": command_after_failed.id,
+                "condition": "not {{ test_command_error }}",
+                "variable_ids": [(6, 0, [variable_command_error.id])],
+            }
+        )
+
+        line5 = self.plan_line.create(
+            {
+                "sequence": 50,
+                "plan_id": plan.id,
+                "command_id": command_last_one.id,
+                "condition": "{{ test_command_error }}",
+                "variable_ids": [(6, 0, [variable_command_error.id])],
+            }
+        )
+        self.plan_line_action.create(
+            {
+                "line_id": line5.id,
+                "sequence": 10,
+                "condition": "==",
+                "value_char": "0",
+                "action": "ec",
+                "custom_exit_code": -1,
+            }
+        )
+
+        plan_log = self.server_test_1.run_flight_plan(plan)
+
+        self.assertEqual(len(plan_log.command_log_ids), 5)
+        logs = plan_log.command_log_ids
+        self.assertTrue(
+            all(
+                log.command_status == 0
+                for log in logs.filtered(lambda log: log.command_id == command_success)
+            )
+        )
+
+        error_log = logs.filtered(lambda log: log.command_id == command_error)
+        self.assertIn(variable_command_error.reference, error_log.variable_values)
+        self.assertTrue(error_log.command_status == GENERAL_ERROR)
+
+        self.assertTrue(
+            logs.filtered(lambda log: log.command_id == command_after_failed).mapped(
+                "command_status"
+            )[0]
+            == PLAN_LINE_CONDITION_CHECK_FAILED
+        )
+        self.assertTrue(
+            logs.filtered(lambda log: log.command_id == command_last_one).mapped(
+                "command_status"
+            )[0]
+            == 0
+        )
+
+        # Final plan status must be custom exit code -1 from line 5 action
+        self.assertEqual(plan_log.plan_status, -1)

--- a/cetmix_tower_server/views/cx_tower_plan_line_view_action_view.xml
+++ b/cetmix_tower_server/views/cx_tower_plan_line_view_action_view.xml
@@ -29,7 +29,8 @@
                         <field
                             name="variable_value_ids"
                             order="variable_reference"
-                            string="Set Variable Values"
+                            string="Set Custom Values"
+                            help="Custom values will be available in the current flight plan context only. They can be used in Python commands and line conditions"
                         >
                             <tree editable="bottom">
                                 <field name="sequence" widget="handle" />


### PR DESCRIPTION
Use in-plan custom values instead of  variables in flight plans. Forward port of https://github.com/cetmix/cetmix-tower/pull/405
Demo date: dedicated flight plan to test condition based flow.

Task: 5073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demonstration flight plan scenario for error handling and conditional command execution testing.
  * Custom variable values now function as flight-plan-scoped context for commands and line conditions.

* **Documentation**
  * Updated UI label and added help text clarifying that custom values are available within the current flight plan context only.

* **Tests**
  * Added comprehensive test coverage for error-handling flow validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->