### PR TITLE
[16.0][FIX] cetmix_tower_server: scheduled tasks

### DIFF
--- a/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
@@ -11,7 +11,6 @@ class CxTowerCustomVariableValueMixin(models.AbstractModel):
 
     variable_id = fields.Many2one(
         "cx.tower.variable",
-        readonly=True,
     )
     variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
     value_char = fields.Char(

--- a/cetmix_tower_server/readme/newsfragments/5105.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5105.bugfix
@@ -1,0 +1,1 @@
+Make variables selectable in scheduled tasks

--- a/cetmix_tower_server/security/cx_tower_scheduled_task_cv_security.xml
+++ b/cetmix_tower_server/security/cx_tower_scheduled_task_cv_security.xml
@@ -56,10 +56,6 @@
         <field name="name">Scheduled Task CV: root full access</field>
         <field name="model_id" ref="model_cx_tower_scheduled_task_cv" />
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_root'))]" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_unlink" eval="1" />
         <field name="domain_force">[(1, '=', 1)]</field>
     </record>
 </odoo>

--- a/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
+++ b/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
@@ -117,11 +117,7 @@
                                 </tree>
                             </field>
                         </page>
-                        <page
-                            name="configuration_values"
-                            string="Configuration Values"
-                            attrs="{'invisible': [('custom_variable_value_ids', '=', False)]}"
-                        >
+                        <page name="configuration_values" string="Configuration Values">
                             <field name="custom_variable_value_ids">
                                 <tree editable="bottom">
                                     <field name="variable_id" />

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -476,6 +476,9 @@ class CxTowerCommandRunWizardVariableValue(models.TransientModel):
     _name = "cx.tower.command.run.wizard.variable.value"
     _description = "Custom variable values for command run wizard"
 
+    variable_id = fields.Many2one(
+        readonly=True,
+    )
     wizard_id = fields.Many2one(
         "cx.tower.command.run.wizard",
         string="Wizard",

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
@@ -147,8 +147,3 @@ class CxTowerPlanRunWizardVariableValue(models.TransientModel):
         "cx.tower.plan.run.wizard",
         string="Wizard",
     )
-    # Override from mixin to make variable_id editable
-    variable_id = fields.Many2one(
-        "cx.tower.variable",
-        readonly=False,
-    )


### PR DESCRIPTION
Before this commit:

- Configuration values for scheduled tasks were not displayed if there were no values.
- Variable was not selectable in newly added configuration values.

After this commit:

- Configuration values for scheduled tasks are always displayed.
- Variable is selectable in newly added configuration values.

Task: 5105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variables are now selectable in scheduled tasks.

* **Bug Fixes**
  * Configuration Values section is now consistently visible in the interface.

* **Security**
  * Updated permissions for scheduled task management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->