### PR TITLE
[16.0[FIX] cetmix_tower_server: SSH Client error handling

### DIFF
--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -574,8 +574,7 @@ class CxTowerServer(models.Model):
         except Exception as e:
             if raise_on_error:
                 raise ValidationError(_("SSH connection error %(err)s", err=e)) from e
-            else:
-                return False, e
+            return False, e
         return client
 
     def test_ssh_connection(
@@ -1508,12 +1507,23 @@ class CxTowerServer(models.Model):
         if not client:
             if raise_on_error:
                 raise ValidationError(_("SSH Client is not defined."))
-            else:
-                return {
-                    "status": SSH_CONNECTION_ERROR,
-                    "response": False,
-                    "error": _("SSH Client is not defined."),
-                }
+            return {
+                "status": SSH_CONNECTION_ERROR,
+                "response": False,
+                "error": _("SSH Client is not defined."),
+            }
+
+        # Client contains a result of _get_ssh_client()
+        # If it's a tuple, it means there was an error getting the client
+        if isinstance(client, tuple):
+            error = client[1]
+            if raise_on_error:
+                raise ValidationError(error)
+            return {
+                "status": SSH_CONNECTION_ERROR,
+                "response": False,
+                "error": error,
+            }
 
         # Parse inline secrets
         code_and_secrets = self.env["cx.tower.key"]._parse_code_and_return_key_values(
@@ -1557,10 +1567,9 @@ class CxTowerServer(models.Model):
             if raise_on_error:
                 _logger.error(f"SSH run command error: {e}")
                 raise ValidationError(_("SSH run command error %(err)s", err=e)) from e
-            else:
-                status = GENERAL_ERROR
-                response = []
-                error = [e]
+            status = GENERAL_ERROR
+            response = []
+            error = [e]
 
         result = self._parse_command_results(status, response, error, secrets, **kwargs)
         return result

--- a/cetmix_tower_server/readme/newsfragments/5109.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5109.bugfix
@@ -1,0 +1,1 @@
+Save correct error message in log when SSH connection fails.


### PR DESCRIPTION
Return error message from _get_ssh_client() if it's a tuple when running a command.

Task: 5109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved SSH connection error handling to ensure error messages are captured and logged correctly when connection failures occur, providing more reliable error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->