### PR TITLE
[18.0][FIX] cetmix_tower_server forward port fixes from 17.0

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -13,9 +13,13 @@
     "application": False,
     "installable": True,
     "external_dependencies": {
-        "python": ["paramiko<4", "tldextract", "dnspython"],
+        "python": ["paramiko<4", "tldextract", "dnspython", "ansi2html"],
     },
-    "depends": ["mail", "rpc_helper", "web_notify"],
+    "depends": [
+        "mail",
+        "rpc_helper",
+        "web_notify",
+    ],
     "data": [
         "security/cetmix_tower_server_groups.xml",
         "security/ir.model.access.csv",

--- a/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_custom_variable_value_mixin.py
@@ -13,7 +13,6 @@ class CxTowerCustomVariableValueMixin(models.AbstractModel):
 
     variable_id = fields.Many2one(
         "cx.tower.variable",
-        readonly=True,
     )
     variable_type = fields.Selection(related="variable_id.variable_type", readonly=True)
     value_char = fields.Char(

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1520,6 +1520,18 @@ class CxTowerServer(models.Model):
                 "error": _("SSH Client is not defined."),
             }
 
+        # Client contains a result of _get_ssh_client()
+        # If it's a tuple, it means there was an error getting the client
+        if isinstance(client, tuple):
+            error = client[1]
+            if raise_on_error:
+                raise ValidationError(error)
+            return {
+                "status": SSH_CONNECTION_ERROR,
+                "response": False,
+                "error": error,
+            }
+
         # Parse inline secrets
         code_and_secrets = self.env["cx.tower.key"]._parse_code_and_return_key_values(
             command_code, **kwargs.get("key", {})

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -151,7 +151,9 @@ class CxTowerServerLog(models.Model):
             self.file_id.download(raise_error=False)
             return self.file_id.code
         if self.file_id.source == "tower":
-            self.file_id.action_get_current_server_code()
+            result = self.file_id.action_get_current_server_code()
+            if isinstance(result, dict):
+                return
             return self.file_id.code_on_server
 
     def _get_log_from_command(self):

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -1,9 +1,13 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
 from ansi2html import Ansi2HTMLConverter
 
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError
+
+_logger = logging.getLogger(__name__)
 
 html_converter = Ansi2HTMLConverter(inline=True)
 
@@ -74,9 +78,15 @@ class CxTowerServerLog(models.Model):
     @api.depends("log_text")
     def _compute_log_html(self):
         for record in self:
-            record.log_html = (
-                html_converter.convert(record.log_text) if record.log_text else False
-            )
+            if record.log_text:
+                try:
+                    record.log_html = html_converter.convert(record.log_text)
+                # We catch all exceptions to avoid breaking the log display
+                except Exception as e:
+                    _logger.error("Error converting log text to HTML: %s", e)
+                    record.log_html = False
+            else:
+                record.log_html = False
 
     def copy(self, default=None):
         return super(

--- a/cetmix_tower_server/models/cx_tower_server_log.py
+++ b/cetmix_tower_server/models/cx_tower_server_log.py
@@ -1,7 +1,11 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, fields, models
+from ansi2html import Ansi2HTMLConverter
+
+from odoo import _, api, fields, models
 from odoo.exceptions import AccessError
+
+html_converter = Ansi2HTMLConverter(inline=True)
 
 
 class CxTowerServerLog(models.Model):
@@ -44,6 +48,7 @@ class CxTowerServerLog(models.Model):
         help="File that will be executed to get the log data",
     )
     log_text = fields.Text(readonly=True, copy=False)
+    log_html = fields.Html(compute="_compute_log_html")
 
     # --- Server template related
     server_template_id = fields.Many2one("cx.tower.server.template", ondelete="cascade")
@@ -65,6 +70,13 @@ class CxTowerServerLog(models.Model):
             ("command", "Command"),
             ("file", "File"),
         ]
+
+    @api.depends("log_text")
+    def _compute_log_html(self):
+        for record in self:
+            record.log_html = (
+                html_converter.convert(record.log_text) if record.log_text else False
+            )
 
     def copy(self, default=None):
         return super(

--- a/cetmix_tower_server/readme/newsfragments/5105.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5105.bugfix
@@ -1,0 +1,1 @@
+Make variables selectable in scheduled tasks

--- a/cetmix_tower_server/readme/newsfragments/5109.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5109.bugfix
@@ -1,0 +1,1 @@
+Save correct error message in log when SSH connection fails.

--- a/cetmix_tower_server/security/cx_tower_scheduled_task_cv_security.xml
+++ b/cetmix_tower_server/security/cx_tower_scheduled_task_cv_security.xml
@@ -56,10 +56,6 @@
         <field name="name">Scheduled Task CV: root full access</field>
         <field name="model_id" ref="model_cx_tower_scheduled_task_cv" />
         <field name="groups" eval="[(4, ref('cetmix_tower_server.group_root'))]" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_unlink" eval="1" />
         <field name="domain_force">[(1, '=', 1)]</field>
     </record>
 </odoo>

--- a/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
+++ b/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
@@ -110,11 +110,7 @@
                                 </list>
                             </field>
                         </page>
-                        <page
-                            name="configuration_values"
-                            string="Configuration Values"
-                            invisible="not custom_variable_value_ids"
-                        >
+                        <page name="configuration_values" string="Configuration Values">
                             <field name="custom_variable_value_ids">
                                 <list editable="bottom">
                                     <field name="variable_id" />

--- a/cetmix_tower_server/views/cx_tower_server_log_view.xml
+++ b/cetmix_tower_server/views/cx_tower_server_log_view.xml
@@ -56,7 +56,7 @@
                             groups="cetmix_tower_server.group_manager"
                         />
                     </group>
-                    <field name="log_text" />
+                    <field name="log_html" />
                 </sheet>
             </form>
         </field>

--- a/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_command_run_wizard.py
@@ -476,6 +476,9 @@ class CxTowerCommandRunWizardVariableValue(models.TransientModel):
     _name = "cx.tower.command.run.wizard.variable.value"
     _description = "Custom variable values for command run wizard"
 
+    variable_id = fields.Many2one(
+        readonly=True,
+    )
     wizard_id = fields.Many2one(
         "cx.tower.command.run.wizard",
         string="Wizard",

--- a/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
+++ b/cetmix_tower_server/wizards/cx_tower_plan_run_wizard.py
@@ -147,8 +147,3 @@ class CxTowerPlanRunWizardVariableValue(models.TransientModel):
         "cx.tower.plan.run.wizard",
         string="Wizard",
     )
-    # Override from mixin to make variable_id editable
-    variable_id = fields.Many2one(
-        "cx.tower.variable",
-        readonly=False,
-    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+ansi2html
 dnspython
 giturlparse==0.12.0
 paramiko<4


### PR DESCRIPTION
Forward port of https://github.com/cetmix/cetmix-tower/pull/435

## Forward port

- Fix custom values in scheduled tasks https://github.com/cetmix/cetmix-tower/pull/433
- Fix SSH client error https://github.com/cetmix/cetmix-tower/pull/434

## Server logs

- Fix: file logs were not updated when "Update" button is clicked
- Fix: 'null' symbol in logs was causing Postgres error when saving log value in text field
- Feature: use the [ansi2html](https://github.com/pycontribs/ansi2html/) library to display coloured formatted logs 🥳 

Task: 5112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server logs now render as HTML for improved readability.
  * Configuration values page in scheduled tasks is always visible.
  * Command run wizards show variable reference fields for clearer context.

* **Bug Fixes**
  * SSH connection failures now record the correct detailed error message.
  * Variable reference fields are writable to ease task configuration.
  * Scheduled task root permissions tightened.

* **Chores**
  * Added ansi2html dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->