### PR TITLE
[16.0][IMP] cetmix_tower_server: Key parsing

### DIFF
--- a/cetmix_tower_server/models/cx_tower_key.py
+++ b/cetmix_tower_server/models/cx_tower_key.py
@@ -160,21 +160,25 @@ class CxTowerKey(models.Model):
         for key_string in key_strings:
             # Replace key including key terminator
             key_value = self._parse_key_string(key_string, **kwargs)
-            if key_value:
-                if pythonic_mode:
-                    # save key value as string in pythonic mode
-                    key_value = f'"{key_value}"'
-                    # Escape newline characters to ensure the key value remains
-                    # a valid single-line string. This prevents syntax errors
-                    # when the string is used in contexts where unescaped
-                    # newlines would break Python syntax or evaluation logic.
-                    key_value = key_value.replace("\n", "\\n")
+            if pythonic_mode and key_value:
+                # save key value as string in pythonic mode
+                key_value = f'"{key_value}"'
+                # Escape newline characters to ensure the key value remains
+                # a valid single-line string. This prevents syntax errors
+                # when the string is used in contexts where unescaped
+                # newlines would break Python syntax or evaluation logic.
+                key_value = key_value.replace("\n", "\\n")
 
-                code = code.replace(key_string, key_value)
+            # Save key value if not saved yet
+            if key_value and key_value not in key_values:
+                key_values.append(key_value)
 
-                # Save key value if not saved yet
-                if key_value not in key_values:
-                    key_values.append(key_value)
+            # Handle False and None values
+            if not key_value:
+                key_value = str(key_value)
+
+            # Replace key with value
+            code = code.replace(key_string, key_value)
 
         return {"code": code, "key_values": key_values}
 

--- a/cetmix_tower_server/readme/newsfragments/5134.feature
+++ b/cetmix_tower_server/readme/newsfragments/5134.feature
@@ -1,0 +1,1 @@
+Parse empty or missing key values as 'None' instead of leaving key reference as is.

--- a/cetmix_tower_server/tests/test_key.py
+++ b/cetmix_tower_server/tests/test_key.py
@@ -340,9 +340,7 @@ class TestTowerKey(TestTowerCommon):
 
         # 3 - Key not found
         code = "Don't mess with #!cxtower.secret.DOGE_LIKE!# He will make you cry"
-        code_parsed_expected = (
-            "Don't mess with #!cxtower.secret.DOGE_LIKE!# He will make you cry"
-        )
+        code_parsed_expected = "Don't mess with None He will make you cry"
         expected_key_values = []
         check_parsed_code(code, code_parsed_expected, expected_key_values)
 


### PR DESCRIPTION
NB: this is actually not a bug but an expected behaviour. However it turns out that it creates issues.

Before this commit:
-------------------

`if x == #!cxtower.secret.postgres_password!#`
where "Postgres Password" is not defined is parsed as

`if x == #!cxtower.secret.postgres_password!#`

This breaks Python code execution and leads to error.

After this commit:
-------------------
`if x == #!cxtower.secret.postgres_password!#`

where "Postgres Password" is not defined is parsed as

`if x == None`

This ensures that the code is executed correctly.

Task: 5134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or missing key references are now replaced with the string "None" instead of leaving the reference intact.
  * Parsing now consistently substitutes processed values (including falsy values) so placeholders are reliably resolved.

* **Documentation**
  * Added a release note explaining the new behavior for empty/missing keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->