### PR TITLE
[16.0][FIX] cetmix_tower_server Skipped commands in plan

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_log.py
+++ b/cetmix_tower_server/models/cx_tower_plan_log.py
@@ -193,7 +193,11 @@ class CxTowerPlanLog(models.Model):
             else:
                 if self._context.get("no_command_log"):
                     continue
-                line._skip(server, plan_log)
+                line._skip(
+                    server,
+                    plan_log,
+                    log={"variable_values": dict(variable_values or {})},
+                )
                 break
         else:
             plan_log.finish(plan_status=PLAN_IS_EMPTY)
@@ -416,6 +420,7 @@ class CxTowerPlanLog(models.Model):
             return
 
         # Update plan log variable values from command log
+        # Overwrite with command log values (last command's values take precedence)
         self.variable_values = command_log.variable_values
 
         # Get next line to execute

--- a/cetmix_tower_server/readme/newsfragments/5129.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5129.bugfix
@@ -1,0 +1,1 @@
+Custom values in flight plan are lost in a skipped command and are not available after it.


### PR DESCRIPTION
Before this commit:

Custom flight plan configuration values were lost in a skipped command and were not available after it.

After this commit:

Custom flight plan configuration values are available after a skipped command.

Task: 5129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where custom variable values in flight plans were lost when a command was skipped, preventing them from being available for subsequent steps.
  * Skipping a command now preserves/logs the current variable values, and the last command’s values correctly take precedence for following execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->