### PR TITLE
[18.0][FIX] cetmix_tower_server Plan line conditions

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan_line.py
+++ b/cetmix_tower_server/models/cx_tower_plan_line.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2022 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools.safe_eval import safe_eval
 
 from .constants import PLAN_LINE_CONDITION_CHECK_FAILED
+
+_logger = logging.getLogger(__name__)
 
 
 class CxTowerPlanLine(models.Model):
@@ -241,7 +244,21 @@ class CxTowerPlanLine(models.Model):
             # For evaluate a string that contains an expression that mostly uses
             # Python constants, arithmetic expressions and the objects directly provided
             # in context we need use `safe_eval`
-            return safe_eval(condition)
+            # We catch all exceptions and return False to avoid raising an exception
+            try:
+                result = safe_eval(condition)
+            except Exception as e:
+                _logger.error(
+                    "Error evaluating condition '%s' for plan line '%s' "
+                    "in plan '%s' for server '%s'. Line is skipped. Error: %s",
+                    condition,
+                    self.name,
+                    self.plan_id.name,
+                    server.name,
+                    str(e),
+                )
+                result = False
+            return result
 
         return True  # Assume the line can be executed if no condition is specified
 

--- a/cetmix_tower_server/readme/newsfragments/5154.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5154.bugfix
@@ -1,0 +1,1 @@
+Handle malformed expressions in flight plan line conditions.

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from odoo import _, fields
 from odoo.exceptions import AccessError, ValidationError
+from odoo.tools.misc import mute_logger
 
 from ..models.constants import (
     ANOTHER_PLAN_RUNNING,
@@ -2594,3 +2595,45 @@ result = {
 
         # Final plan status must be custom exit code -1 from line 5 action
         self.assertEqual(plan_log.plan_status, -1)
+
+    def test_plan_line_condition_error(self):
+        """Test plan line condition error
+        First line is skipped because of condition error
+        Second line is executed successfully
+        """
+        # Create commands
+        command_success = self.Command.create(
+            {
+                "name": "Command -> Success",
+                "action": "python_code",
+                "code": "# Just return default values",
+            }
+        )
+
+        # Plan and lines
+        plan = self.Plan.create(
+            {
+                "name": "Test plan line condition error",
+            }
+        )
+
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": plan.id,
+                "command_id": command_success.id,
+                "condition": "=q",
+            },
+        )
+        self.plan_line.create(
+            {"sequence": 20, "plan_id": plan.id, "command_id": command_success.id}
+        )
+
+        with mute_logger("odoo.addons.cetmix_tower_server.models.cx_tower_plan_line"):
+            plan_log = self.server_test_1.run_flight_plan(plan)
+
+        # Must be 2 command logs
+        self.assertEqual(len(plan_log.command_log_ids), 2)
+        logs = plan_log.command_log_ids
+        self.assertTrue(logs[0].is_skipped)
+        self.assertTrue(logs[1].command_status == 0)


### PR DESCRIPTION
Before this commit a malformed expression in a plan line condition would raise an unhandled exception which would break the plan execution.

After this commit the line is skipped and the error is logged.

Forward port of https://github.com/cetmix/cetmix-tower/pull/451

Task: 5160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for malformed expressions in flight plan line conditions. Invalid condition expressions that previously caused execution failures are now handled gracefully. Plan lines with problematic conditions are automatically skipped, allowing overall execution to continue uninterrupted, improving system stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->