### PR TITLE
[17.0][IMP] cetmix_tower_server_queue/cetmix_tower_yaml

### DIFF
--- a/cetmix_tower_server_queue/models/cx_tower_file.py
+++ b/cetmix_tower_server_queue/models/cx_tower_file.py
@@ -175,7 +175,7 @@ class CxTowerFile(models.Model):
                     "message": _(
                         "Unable to upload file '%(f)s'.\n"
                         "Upload operation is not supported for 'server' type files.",
-                        f=server_files[0].rendered_name,
+                        f=", ".join(server_files.mapped("rendered_name")),
                     ),
                     "sticky": False,
                 },

--- a/cetmix_tower_server_queue/tests/test_command.py
+++ b/cetmix_tower_server_queue/tests/test_command.py
@@ -74,9 +74,9 @@ class TestTowerCommand(TestTowerCommon):
             "Zombie command log should have queue job",
         )
 
-        job = self.env["queue.job"].search(
-            [("id", "=", zombie_command_logs.queue_job_id.id)]
-        )
+        job = zombie_command_logs.queue_job_id
+        self.assertTrue(job.exists(), "Zombie command job should exist")
+
         self.assertEqual(job.state, "pending", "Zombie command job should be pending")
 
         # run process to kill zombie command

--- a/cetmix_tower_server_queue/tests/test_command_log.py
+++ b/cetmix_tower_server_queue/tests/test_command_log.py
@@ -7,12 +7,6 @@ class TestTowerCommand(TestTowerCommon):
     Test cases for command log state on queue_job failure
     """
 
-    def setUp(self):
-        super().setUp()
-
-    # Should match models.queue_job.QUEUE_JOB_ERROR
-    QUEUE_JOB_ERROR = 601
-
     def test_command_log_state_on_job_fail(self):
         command = self.env["cx.tower.command"].create(
             {
@@ -38,6 +32,6 @@ class TestTowerCommand(TestTowerCommon):
         self.assertEqual(job.state, "failed", "Job should be in failed state")
         self.assertEqual(
             command_log.command_status,
-            self.QUEUE_JOB_ERROR,
+            self.env["queue.job"].QUEUE_JOB_ERROR,
             "Command log should be in failed state",
         )

--- a/cetmix_tower_yaml/i18n/cetmix_tower_yaml.pot
+++ b/cetmix_tower_yaml/i18n/cetmix_tower_yaml.pot
@@ -382,7 +382,7 @@ msgstr ""
 #: code:addons/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py:0
 #: code:addons/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py:0
 #, python-format
-msgid "File contains non-unicode characters or is empty"
+msgid "File is not a valid base64-encoded file"
 msgstr ""
 
 #. module: cetmix_tower_yaml

--- a/cetmix_tower_yaml/i18n/hr.po
+++ b/cetmix_tower_yaml/i18n/hr.po
@@ -268,8 +268,8 @@ msgstr "Naziv datoteke"
 #: code:addons/cetmix_tower_yaml/tests/test_yaml_import_wizard.py:0
 #: code:addons/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py:0
 #, python-format
-msgid "File contains non-unicode characters or is empty"
-msgstr "Datoteka sadrži ne-unicode znakove ili je prazna"
+msgid "File is not a valid base64-encoded file"
+msgstr "Datoteka nije ispravno base64 kodirana"
 
 #. module: cetmix_tower_yaml
 #: model_terms:ir.ui.view,arch_db:cetmix_tower_yaml.cx_tower_yaml_export_wiz_view_form

--- a/cetmix_tower_yaml/i18n/it.po
+++ b/cetmix_tower_yaml/i18n/it.po
@@ -388,8 +388,8 @@ msgstr "Nome file"
 #: code:addons/cetmix_tower_yaml/tests/test_yaml_import_wizard.py:0
 #: code:addons/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py:0
 #, python-format
-msgid "File contains non-unicode characters or is empty"
-msgstr "Il file contiene caratteri non unicode o è vuoto"
+msgid "File is not a valid base64-encoded file"
+msgstr "Il file non è un file codificato in base64 valido"
 
 #. module: cetmix_tower_yaml
 #: model:ir.model.fields,field_description:cetmix_tower_yaml.field_cx_tower_yaml_manifest_tmpl__file_prefix

--- a/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_manifest_template.py
@@ -87,7 +87,7 @@ class CxTowerYamlManifestTemplate(models.Model):
         """
         semver = re.compile(r"^\d+\.\d+\.\d+$")
         for rec in self:
-            if not semver.match(rec.version):
+            if rec.version and not semver.match(rec.version):
                 raise ValidationError(
                     _("Version must be in the Major.Minor.Patch format, e.g. 1.2.3")
                 )

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
-from builtins import UnicodeEncodeError
 
 import yaml
 

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -210,7 +210,7 @@ class TestTowerYamlImportWizUpload(TransactionCase):
             self.yaml_upload_wizard._extract_yaml_data()
         self.assertEqual(
             str(e.exception),
-            _("File contains non-unicode characters or is empty"),
+            _("File is empty"),
             "Exception message does not match",
         )
 

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_export_wiz.py
@@ -349,7 +349,6 @@ class CxTowerYamlExportWiz(models.TransientModel):
             "res_id": download_wizard.id,
             "target": "new",
             "view_mode": "form",
-            "view_type": "form",
         }
 
     def _get_model_record(self):

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -5,6 +5,7 @@
 import logging
 
 import yaml
+from markupsafe import escape
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -84,7 +85,7 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 continue
 
             # Build deterministic HTML list of secrets
-            items = "".join(f"<li>{name}</li>" for name in sorted(secret_list))
+            items = "".join(f"<li>{escape(name)}</li>" for name in sorted(secret_list))
             secrets_html = f"<ul>{items}</ul>"
 
             record.secret_list = _(
@@ -133,7 +134,7 @@ class CxTowerYamlImportWiz(models.TransientModel):
             raise ValidationError(_("YAML file doesn't contain any records"))
 
         # Cache models
-        models = {}
+        model_cache = {}
         odoo_record_ids = []
 
         # Process each record
@@ -148,12 +149,12 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 )
 
             # Get model from cache or create new one
-            model = models.get(model_name)
+            model = model_cache.get(model_name)
             if not model:
                 model = self.env[
                     f"cx.tower.{model_name.replace('_', '.')}"
                 ].with_context(skip_ssh_settings_check=(model_name == "server"))
-                models[model_name] = model
+                model_cache[model_name] = model
 
             # Get existing record by reference
             # NOTE: we don't validate models here because they are
@@ -163,8 +164,9 @@ class CxTowerYamlImportWiz(models.TransientModel):
             # Skip
             if self.if_record_exists == "skip" and odoo_record:
                 _logger.info(
-                    f"Skipping record '{record_reference}' in model '{model_name}'"
-                    " because it already exists"
+                    "Skipping record '%s' in model '%s'" " because it already exists",
+                    record_reference,
+                    model_name,
                 )
                 continue
 
@@ -227,8 +229,8 @@ class CxTowerYamlImportWiz(models.TransientModel):
             }
 
         # All records from the same model
-        elif len(models) == 1:
-            model = list(models.values())[0]
+        elif len(model_cache) == 1:
+            model = list(model_cache.values())[0]
             action = {
                 "name": _("Import result: %(model)s", model=model._description),
                 "type": "ir.actions.act_window",
@@ -247,7 +249,7 @@ class CxTowerYamlImportWiz(models.TransientModel):
         # Records from different models
         else:
             model_names = ", ".join(
-                f"'{model._description}'" for model in models.values()
+                f"'{model._description}'" for model in model_cache.values()
             )
             action = {
                 "type": "ir.actions.client",

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz_upload.py
@@ -43,7 +43,7 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
         }
 
     def _extract_yaml_data(self):
-        """Extract data form YAML file and validate them
+        """Extract data from YAML file and validate them
 
         Returns:
             decoded_file (Text): YAML code
@@ -59,12 +59,10 @@ class CxTowerYamlImportWizUpload(models.TransientModel):
             raw_bytes = b64decode(self.yaml_file or b"")
         except (TypeError, binascii.Error) as e:
             # Not a valid base-64 payload
-            raise ValidationError(
-                _("File contains non-unicode characters or is empty")
-            ) from e
+            raise ValidationError(_("File is not a valid base64-encoded file")) from e
 
         if not raw_bytes:
-            raise ValidationError(_("File contains non-unicode characters or is empty"))
+            raise ValidationError(_("File is empty"))
 
         try:
             decoded_file = raw_bytes.decode("utf-8")


### PR DESCRIPTION
Minor code improvements and translations updates based on the migration to 18.0 feedback.

 - Cetmix Tower YAML
 - Cetmix Tower Server Queue

Task: 5172

Same as https://github.com/cetmix/cetmix-tower/pull/458 for 16.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved error messages for YAML file upload validation to be more specific about base64 encoding requirements
  * Added HTML escaping for secret names in YAML imports
  * Version fields in YAML manifests now allow empty values without triggering validation errors
  * Enhanced error messages to display all affected server files instead of just the first one

* **Localization**
  * Updated Croatian and Italian translations for validation messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->