### PR TITLE
[16.0][FIX] cetmix_tower_server: Custom values is plan

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -546,5 +546,5 @@ class CxTowerCommand(models.Model):
         imports.update(self._get_python_command_libraries())
         eval_context = {key: value["import"] for key, value in imports.items()}
 
-        eval_context["custom_values"] = kwargs.get("variable_values", {})
+        eval_context["custom_values"] = kwargs.get("variable_values") or {}
         return eval_context

--- a/cetmix_tower_server/readme/newsfragments/5175.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5175.bugfix
@@ -1,0 +1,1 @@
+Ensure custom values can be updated even if not provided initially.

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -2637,3 +2637,57 @@ result = {
         logs = plan_log.command_log_ids
         self.assertTrue(logs[0].is_skipped)
         self.assertTrue(logs[1].command_status == 0)
+
+    def test_custom_values_not_defined_but_updated(self):
+        """Test custom values not defined but updated
+        First command is executed successfully
+        Second command is executed successfully and updates custom values
+        """
+        # Create commands
+        command_1 = self.Command.create(
+            {
+                "name": "Command -> Success",
+                "action": "python_code",
+                "code": "# Just return default values",
+            }
+        )
+        command_2 = self.Command.create(
+            {
+                "name": "Command -> Success",
+                "action": "python_code",
+                "code": "custom_values.update({'some_value': '1'})",
+            }
+        )
+
+        # Plan and lines
+        plan = self.Plan.create(
+            {
+                "name": "Test custom values not defined but updated",
+            }
+        )
+
+        self.plan_line.create(
+            {
+                "sequence": 10,
+                "plan_id": plan.id,
+                "command_id": command_1.id,
+            },
+        )
+
+        self.plan_line.create(
+            {
+                "sequence": 20,
+                "plan_id": plan.id,
+                "command_id": command_2.id,
+            },
+        )
+        plan_log = self.server_test_1.run_flight_plan(plan)
+
+        # Must be 2 command logs
+        self.assertEqual(len(plan_log.command_log_ids), 2)
+        logs = plan_log.command_log_ids
+        # Both commands should be successful
+        self.assertEqual(logs[0].command_status, 0)
+        self.assertEqual(logs[1].command_status, 0)
+        # Custom values should be updated
+        self.assertEqual(plan_log.variable_values, {"some_value": "1"})


### PR DESCRIPTION
Before this commit when custom values were not provided at the flight plan run but updated later, the following python code command `custom_values.update({'some_var': 'some value'})` failed with the following error:
 `Error <class 'AttributeError'>: "'bool' object has no attribute 'update'"...`

This commit fixes the issue by putting empty dictionary as default value for custom values.

Task: 5175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing custom values from being updated when they were not initially provided (ensures empty/absent values are handled).

* **Tests**
  * Added test coverage verifying custom values can be set and propagated through execution when not defined initially.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->