### PR TITLE
[16.0][IMP] cetmix_tower_server: scheduled tasks

### DIFF
--- a/cetmix_tower_server/models/cx_tower_scheduled_task.py
+++ b/cetmix_tower_server/models/cx_tower_scheduled_task.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class CxTowerScheduledTask(models.Model):
             ("minutes", "Minutes"),
             ("hours", "Hours"),
             ("days", "Days"),
+            ("dow", "Days of Week"),
             ("weeks", "Weeks"),
             ("months", "Months"),
         ],
@@ -57,6 +59,15 @@ class CxTowerScheduledTask(models.Model):
     last_call = fields.Datetime(
         string="Last Execution Date", help="Previous time the task ran successfully."
     )
+    # Days of week
+    monday = fields.Boolean(default=False)
+    tuesday = fields.Boolean(default=False)
+    wednesday = fields.Boolean(default=False)
+    thursday = fields.Boolean(default=False)
+    friday = fields.Boolean(default=False)
+    saturday = fields.Boolean(default=False)
+    sunday = fields.Boolean(default=False)
+
     custom_variable_value_ids = fields.One2many(
         "cx.tower.scheduled.task.cv",
         "scheduled_task_id",
@@ -82,6 +93,39 @@ class CxTowerScheduledTask(models.Model):
         ),
     ]
 
+    @api.constrains(
+        "interval_type",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    )
+    def _check_days_of_week(self):
+        """
+        Check if at least one day of week is selected
+        """
+        for task in self:
+            if task.interval_type == "dow" and not any(
+                [
+                    task.monday,
+                    task.tuesday,
+                    task.wednesday,
+                    task.thursday,
+                    task.friday,
+                    task.saturday,
+                    task.sunday,
+                ]
+            ):
+                raise ValidationError(
+                    _(
+                        "At least one day of week must be selected for the task '%s'.",
+                        task.display_name,
+                    )
+                )
+
     @api.depends("interval_number", "interval_type")
     def _compute_warning_message(self):
         """
@@ -105,6 +149,9 @@ class CxTowerScheduledTask(models.Model):
         cron_next = self._get_next_call(cron, now)
 
         for task in self:
+            if task.interval_type == "dow":
+                task.warning_message = False
+                continue
             task_next = self._get_next_call(task, now)
             if task_next < cron_next:
                 task.warning_message = _(
@@ -205,7 +252,7 @@ class CxTowerScheduledTask(models.Model):
                 task.write(
                     {
                         "last_call": finished_at,
-                        "next_call": self._get_next_call(task, finished_at),
+                        "next_call": self._get_next_call(task, task.next_call),
                         "is_running": False,
                     }
                 )
@@ -232,7 +279,13 @@ class CxTowerScheduledTask(models.Model):
     def _get_next_call(self, task, from_date):
         """
         Calculate next_call datetime
+
+        task: cx.tower.scheduled.task
+        from_date: datetime
         """
+        if task.interval_type == "dow":
+            return self._get_next_call_dow(task, from_date)
+
         num = task.interval_number or 1
         intervals = {
             "minutes": timedelta(minutes=num),
@@ -242,6 +295,73 @@ class CxTowerScheduledTask(models.Model):
             "months": relativedelta(months=num),
         }
         return from_date + intervals.get(task.interval_type, timedelta())
+
+    def _get_task_selected_days(self, task):
+        """
+        Get list of selected weekday numbers for a task
+
+        task: cx.tower.scheduled.task
+        Returns: list of weekday numbers (0=Monday, 6=Sunday)
+        """
+        selected_days = []
+        if task.monday:
+            selected_days.append(0)
+        if task.tuesday:
+            selected_days.append(1)
+        if task.wednesday:
+            selected_days.append(2)
+        if task.thursday:
+            selected_days.append(3)
+        if task.friday:
+            selected_days.append(4)
+        if task.saturday:
+            selected_days.append(5)
+        if task.sunday:
+            selected_days.append(6)
+        return selected_days
+
+    def _get_next_call_dow(self, task, from_date):
+        """
+        Calculate next_call datetime for days of week interval type
+
+        task: cx.tower.scheduled.task
+        from_date: datetime
+        """
+        # Days of week: find next selected day at the same time
+        # weekday() returns 0=Monday, 6=Sunday
+        selected_days = self._get_task_selected_days(task)
+        if not selected_days:
+            raise ValidationError(
+                _(
+                    "At least one day of week must be selected for the task '%s'.",
+                    task.display_name,
+                )
+            )
+        current_weekday = from_date.weekday()
+
+        # Find next selected day (starting from tomorrow to get next occurrence)
+        # Check days in current week first (after today)
+        next_day = None
+        for day in selected_days:
+            if day > current_weekday:
+                next_day = day
+                break
+
+        # If no day found in current week, take first day of next week
+        if next_day is None:
+            next_day = min(selected_days)
+            days_ahead = (7 - current_weekday) + next_day
+        else:
+            days_ahead = next_day - current_weekday
+
+        # Create new datetime with same time, on the next selected day
+        next_date = from_date + timedelta(days=days_ahead)
+        return next_date.replace(
+            hour=from_date.hour,
+            minute=from_date.minute,
+            second=from_date.second,
+            microsecond=from_date.microsecond,
+        )
 
     def _run_command(self):
         """Run command on selected servers."""

--- a/cetmix_tower_server/readme/newsfragments/5190.feature
+++ b/cetmix_tower_server/readme/newsfragments/5190.feature
@@ -1,0 +1,1 @@
+Scheduled tasks: allow to select specific days of week.

--- a/cetmix_tower_server/tests/test_scheduled_task.py
+++ b/cetmix_tower_server/tests/test_scheduled_task.py
@@ -1,12 +1,14 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from datetime import datetime
+
 from odoo import fields
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 
 from .common import TestTowerCommon
 
 
-class TestCxTowerScheduledTask(TestTowerCommon):
+class TestTowerScheduledTask(TestTowerCommon):
     """Test the cx.tower.scheduled.task model."""
 
     @classmethod
@@ -286,3 +288,152 @@ class TestCxTowerScheduledTask(TestTowerCommon):
             task.with_user(self.root).unlink()
         except AccessError:
             self.fail("Root should be able to write/unlink any scheduled task.")
+
+    def test_get_next_call_dow_wednesday(self):
+        """Test _get_next_call_dow when today is Wednesday.
+        Task runs Monday, Wednesday, Friday -> should return Friday."""
+        # Create task with Monday, Wednesday, Friday selected
+        task = self.ScheduledTask.create(
+            {
+                "name": "Test DOW Task",
+                "action": "command",
+                "command_id": self.command_list_dir.id,
+                "interval_type": "dow",
+                "monday": True,
+                "wednesday": True,
+                "friday": True,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+            }
+        )
+
+        # Create a Wednesday datetime (2024-01-03 is a Wednesday)
+        # Set time to 10:30:45
+        wednesday_date = datetime(2024, 1, 3, 10, 30, 45)
+
+        # Calculate next call
+        next_call = task._get_next_call_dow(task, wednesday_date)
+
+        # Should be Friday (2 days ahead) at the same time
+        expected_friday = datetime(2024, 1, 5, 10, 30, 45)
+        self.assertEqual(
+            next_call,
+            expected_friday,
+            "Next call from Wednesday should be Friday at the same time.",
+        )
+
+    def test_get_next_call_dow_friday(self):
+        """Test _get_next_call_dow when today is Friday.
+        Task runs Monday, Wednesday, Friday -> should return Monday (next week)."""
+        # Create task with Monday, Wednesday, Friday selected
+        task = self.ScheduledTask.create(
+            {
+                "name": "Test DOW Task",
+                "action": "command",
+                "command_id": self.command_list_dir.id,
+                "interval_type": "dow",
+                "monday": True,
+                "wednesday": True,
+                "friday": True,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+            }
+        )
+
+        # Create a Friday datetime (2024-01-05 is a Friday)
+        # Set time to 14:15:30
+        friday_date = datetime(2024, 1, 5, 14, 15, 30)
+
+        # Calculate next call
+        next_call = task._get_next_call_dow(task, friday_date)
+
+        # Should be Monday next week (3 days ahead) at the same time
+        expected_monday = datetime(2024, 1, 8, 14, 15, 30)
+        self.assertEqual(
+            next_call,
+            expected_monday,
+            "Next call from Friday should be Monday next week at the same time.",
+        )
+
+    def test_check_days_of_week_constraint(self):
+        """
+        Test _check_days_of_week constraint:
+        no days selected should raise ValidationError.
+        """
+        # Try to create a task with interval_type="dow" but no days selected
+        with self.assertRaises(ValidationError) as context:
+            self.ScheduledTask.create(
+                {
+                    "name": "Test DOW Task No Days",
+                    "action": "command",
+                    "command_id": self.command_list_dir.id,
+                    "interval_type": "dow",
+                    "monday": False,
+                    "tuesday": False,
+                    "wednesday": False,
+                    "thursday": False,
+                    "friday": False,
+                    "saturday": False,
+                    "sunday": False,
+                    "server_ids": [(6, 0, [self.server_test_1.id])],
+                }
+            )
+        self.assertIn(
+            "At least one day of week must be selected",
+            str(context.exception),
+            "ValidationError should mention that at " "least one day must be selected.",
+        )
+
+        # Try to update an existing task to have no days selected
+        task = self.ScheduledTask.create(
+            {
+                "name": "Test DOW Task",
+                "action": "command",
+                "command_id": self.command_list_dir.id,
+                "interval_type": "dow",
+                "monday": True,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+            }
+        )
+        with self.assertRaises(ValidationError):
+            task.write(
+                {
+                    "monday": False,
+                    "tuesday": False,
+                    "wednesday": False,
+                    "thursday": False,
+                    "friday": False,
+                    "saturday": False,
+                    "sunday": False,
+                }
+            )
+
+    def test_get_next_call_dow_single_day_monday(self):
+        """Test _get_next_call_dow edge case: only Monday selected,
+        current day is Monday.
+        Should wrap to next week's Monday."""
+        # Create task with only Monday selected
+        task = self.ScheduledTask.create(
+            {
+                "name": "Test DOW Task Single Day",
+                "action": "command",
+                "command_id": self.command_list_dir.id,
+                "interval_type": "dow",
+                "monday": True,
+                "server_ids": [(6, 0, [self.server_test_1.id])],
+            }
+        )
+
+        # Create a Monday datetime (2024-01-01 is a Monday)
+        # Set time to 09:00:00
+        monday_date = datetime(2024, 1, 1, 9, 0, 0)
+
+        # Calculate next call
+        next_call = task._get_next_call_dow(task, monday_date)
+
+        # Should be Monday next week (7 days ahead) at the same time
+        expected_next_monday = datetime(2024, 1, 8, 9, 0, 0)
+        self.assertEqual(
+            next_call,
+            expected_next_monday,
+            "Next call from Monday (only day selected) should be"
+            " next Monday at the same time.",
+        )

--- a/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
+++ b/cetmix_tower_server/views/cx_tower_scheduled_task_view.xml
@@ -106,6 +106,30 @@
                                 attrs="{'invisible': [('is_running', '=', True)]}"
                             />
                             <field name="next_call" />
+                            <label
+                                for="monday"
+                                string="Days of Week"
+                                attrs="{'invisible': [('interval_type', '!=', 'dow')]}"
+                            />
+                            <div
+                                class="o_row"
+                                attrs="{'invisible': [('interval_type', '!=', 'dow')]}"
+                            >
+                                <span class="o_form_label">Mo</span>
+                                <field name="monday" />
+                                <span class="o_form_label">Tu</span>
+                                <field name="tuesday" />
+                                <span class="o_form_label">We</span>
+                                <field name="wednesday" />
+                                <span class="o_form_label">Th</span>
+                                <field name="thursday" />
+                                <span class="o_form_label">Fr</span>
+                                <field name="friday" />
+                                <span class="o_form_label">Sa</span>
+                                <field name="saturday" />
+                                <span class="o_form_label">Su</span>
+                                <field name="sunday" />
+                            </div>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
- Allow to select specific days of week for scheduled tasks.
- Preserve the original time of the scheduled task when computing the next run. Eg if a daily task is scheduled to run at 10:00, it will run at 10:00 the next day even if it was actually run at 10:03. Before this change, the task would run at 10:03 the next day. This lead to the time drift of the scheduled task.

Task: 5190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "Days of Week" scheduling: pick one or more weekdays (Mon–Sun) in the schedule form; next-run respects selected days and preserves task time.
* **Bug Fixes**
  * Prevent saving a weekday schedule without at least one day selected.
  * Next-run calculation updated to use the task's scheduled next run for subsequent scheduling.
* **Tests**
  * New unit tests cover weekday scheduling and validation.
* **Documentation**
  * Release note entry added announcing weekday scheduling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->