### PR TITLE
[16.0][FIX] cetmix_tower_server Flight plan line action

### DIFF
--- a/cetmix_tower_server/models/cx_tower_plan.py
+++ b/cetmix_tower_server/models/cx_tower_plan.py
@@ -292,7 +292,7 @@ class CxTowerPlan(models.Model):
             if expr_eval(conditional_expression):
                 action = action_line.action
                 # Use custom exit code if action requires it
-                if action == "ec" and action_line.custom_exit_code:
+                if action == "ec" and action_line.custom_exit_code is not None:
                     exit_code = action_line.custom_exit_code
 
                 # Apply action-defined values into the variable values context
@@ -315,6 +315,14 @@ class CxTowerPlan(models.Model):
     def _get_next_action_state(self, action, exit_code, current_line):
         """
         Determine the next action, exit code, and next line based on the current state.
+
+        Args:
+            action (Selection): Action to proceed
+            exit_code (Integer): Exit code
+            current_line (cx.tower.plan.line()): Current line
+
+        Returns:
+            action, exit_code, next_line (Selection, Integer, cx.tower.plan.line())
         """
         lines = current_line.plan_id.line_ids
         is_last_line = current_line == lines[-1]
@@ -332,7 +340,8 @@ class CxTowerPlan(models.Model):
         if action == "n" and not is_last_line:
             next_line = lines[indexOf(lines, current_line) + 1]
 
-        if is_last_line:
+        # Exit with command code if not exiting with custom code
+        if is_last_line and action != "ec":
             action = "e"
 
         return action, exit_code, next_line

--- a/cetmix_tower_server/readme/newsfragments/5120.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/5120.bugfix
@@ -1,0 +1,1 @@
+Last flight plan line post-run action was not triggered correctly.

--- a/cetmix_tower_server/tests/test_plan.py
+++ b/cetmix_tower_server/tests/test_plan.py
@@ -2691,3 +2691,58 @@ result = {
         self.assertEqual(logs[1].command_status, 0)
         # Custom values should be updated
         self.assertEqual(plan_log.variable_values, {"some_value": "1"})
+
+    def test_last_flight_plan_line_post_run_action_is_executed(self):
+        """
+        Test last flight plan line post run action is executed
+        """
+        # Create commands
+        command_error = self.Command.create(
+            {
+                "name": "Command -> Error",
+                "action": "python_code",
+                "code": "result = {'exit_code': -100, 'message': 'Error'}",
+            }
+        )
+
+        # Plan and lines
+        plan = self.Plan.create(
+            {
+                "name": "Test post run action",
+                "on_error_action": "e",
+                "custom_exit_code": 0,
+            }
+        )
+
+        line1 = self.plan_line.create(
+            {"sequence": 10, "plan_id": plan.id, "command_id": command_error.id}
+        )
+        self.plan_line_action.create(
+            {
+                "line_id": line1.id,
+                "sequence": 10,
+                "condition": "!=",
+                "value_char": "0",
+                "action": "n",
+            }
+        )
+        line2 = self.plan_line.create(
+            {"sequence": 20, "plan_id": plan.id, "command_id": command_error.id}
+        )
+        self.plan_line_action.create(
+            {
+                "line_id": line2.id,
+                "sequence": 10,
+                "condition": "!=",
+                "value_char": "0",
+                "action": "ec",
+                "custom_exit_code": 0,
+            }
+        )
+
+        plan_log = self.server_test_1.run_flight_plan(plan)
+
+        self.assertEqual(len(plan_log.command_log_ids), 2)
+
+        # Final plan status must be custom exit code 0
+        self.assertEqual(plan_log.plan_status, 0)


### PR DESCRIPTION
**Steps to reproduce the fixed bug**

- Create a flight plan where the last line has the following action:
  - Condition: `Exit code != 0`
  - Action: `Exit with custom exit code`
  - Custom exit code: 0
- Run the flight plan and ensure that the last command exits with code different from 0.

**Expected behavior after this commit**

The flight plan exits with the custom exit code 0 as defined in the action.

**Before this commit**

The flight plan exits with the command exit code.

Task: 5120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Final flight plan line post-run actions now trigger correctly.
  * Custom exit codes now accept 0 as a valid value and respect exit-on-last-line behavior.

* **Tests**
  * Added tests verifying post-run action execution on the final flight plan line and custom exit code behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->