### PR TITLE
[16.0][FIX] cetmix_tower_git Project->Server link

### DIFF
--- a/cetmix_tower_git/models/cx_tower_git_project.py
+++ b/cetmix_tower_git/models/cx_tower_git_project.py
@@ -34,15 +34,14 @@ class CxTowerGitProject(models.Model):
     # IMPORTANT: This field may contain duplicates because of the relation nature!
     server_ids = fields.Many2many(
         comodel_name="cx.tower.server",
-        relation="cx_tower_git_project_rel",
-        column1="git_project_id",
-        column2="server_id",
-        string="Servers",
+        relation="cx_tower_git_project_server_rel",
         readonly=True,
         copy=False,
-        help="Servers are added automatically based on the files linked to the project."
-        "\nIMPORTANT: This field may contain duplicates"
-        " because of the relation nature!",
+        compute="_compute_server_ids",
+        store=True,
+        context={"active_test": False},
+        help="Servers are added automatically based on the files"
+        " linked to the project.",
     )
     source_ids = fields.One2many(
         comodel_name="cx.tower.git.source",
@@ -151,6 +150,22 @@ class CxTowerGitProject(models.Model):
         Default project format.
         """
         return "git_aggregator"
+
+    @api.depends("git_project_rel_ids", "git_project_rel_ids.server_id")
+    def _compute_server_ids(self):
+        """Compute server ids for git projects.
+
+        Why? Because a git project can be linked to multiple files
+        on the same server.
+        So we need to use a set to avoid duplicates so every server
+        is listed only once.
+        """
+        for project in self:
+            project.server_ids = (
+                list(set(project.git_project_rel_ids.server_id.ids))
+                if project.git_project_rel_ids
+                else False
+            )
 
     @api.depends(
         "git_project_rel_ids.server_id",

--- a/cetmix_tower_git/readme/newsfragments/5214.bugfix
+++ b/cetmix_tower_git/readme/newsfragments/5214.bugfix
@@ -1,0 +1,1 @@
+Link server to git project only once.

--- a/cetmix_tower_git/views/cx_tower_git_project_views.xml
+++ b/cetmix_tower_git/views/cx_tower_git_project_views.xml
@@ -8,7 +8,11 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
-                <field name="server_ids" widget="many2many_tags" />
+                <field
+                    name="server_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color'}"
+                />
                 <field name="active" widget="boolean_toggle" />
             </tree>
         </field>
@@ -44,6 +48,7 @@
                             <field
                                 name="server_ids"
                                 widget="many2many_tags"
+                                options="{'color_field': 'color'}"
                                 attrs="{'invisible': [('server_ids', '=', [])]}"
                             />
                             <field


### PR DESCRIPTION
In some cases a git project could be linked to different files on the same server.
Before this commit this lead to a situation where the same server was listed multiple times in the git project.
This broke the 'many2many_tags' widget in the git project form view causing weird UI behavior and errors in the console.

This commit fixes the issue ensuring that the same server is listed only once in the git project.

Task: 5214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Servers are no longer duplicated on a git project — links are deduplicated so each server appears only once.

* **New Features**
  * Server lists in project views now support color-coding for clearer visual distinction.
  * Servers are now populated automatically from related project items; help text updated to reflect this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->