### PR TITLE
[18.0][FIX] requirement paramiko<4.0.0

### DIFF
--- a/cetmix_tower_server/__manifest__.py
+++ b/cetmix_tower_server/__manifest__.py
@@ -13,7 +13,7 @@
     "application": False,
     "installable": True,
     "external_dependencies": {
-        "python": ["paramiko<4", "tldextract", "dnspython", "ansi2html"],
+        "python": ["paramiko<4.0.0", "tldextract", "dnspython", "ansi2html"],
     },
     "depends": [
         "mail",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ boto3
 dnspython
 giturlparse==0.12.0
 ovh
-paramiko<4
+paramiko<4.0.0
 pyyaml
 tldextract


### PR DESCRIPTION
- paramiko version 4 doesn't exist, only 4.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external dependency version constraints to tighten version specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->