### PR TITLE
[18.0][IMP] cetmix_tower_server Python code and Vault

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -527,6 +527,7 @@ class CxTowerCommand(models.Model):
         """
         return {}
 
+    @api.model
     def _get_python_command_eval_context(self, server=None, **kwargs):
         """
         Get the evaluation context for the python command.
@@ -548,3 +549,13 @@ class CxTowerCommand(models.Model):
 
         eval_context["custom_values"] = kwargs.get("variable_values") or {}
         return eval_context
+
+    def _get_banned_python_code_keywords(self):
+        """
+        Get the banned python code keywords for the python command.
+        Extend this method to add banned keywords to the list.
+
+        Returns:
+            list: Banned python code keywords.
+        """
+        return ["_set_secret_values(", "_get_secret_value(", "_get_secret_values("]

--- a/cetmix_tower_server/models/cx_tower_server.py
+++ b/cetmix_tower_server/models/cx_tower_server.py
@@ -1627,6 +1627,20 @@ class CxTowerServer(models.Model):
                 command_code, pythonic_mode=True, **kwargs.get("key", {})
             )
 
+            # Check if code contains banned keywords
+            banned_keywords = self.env[
+                "cx.tower.command"
+            ]._get_banned_python_code_keywords()
+            for banned_keyword in banned_keywords:
+                if banned_keyword in code:
+                    raise ValidationError(
+                        _(
+                            "Following keyword is not allowed in Python code:"
+                            " '%(banned_keyword)s'",
+                            banned_keyword=banned_keyword,
+                        )
+                    )
+
             # Get the evaluation context for the python command
             eval_context = self.env[
                 "cx.tower.command"
@@ -1654,9 +1668,8 @@ class CxTowerServer(models.Model):
                 raise ValidationError(
                     _("Python code running error: %(err)s", err=e)
                 ) from e
-            else:
-                status = PYTHON_COMMAND_ERROR
-                error = [e]
+            status = PYTHON_COMMAND_ERROR
+            error = [e]
 
         result = self._parse_command_results(status, response, error, secrets, **kwargs)
         result["variable_values"] = kwargs.get("variable_values", {})

--- a/cetmix_tower_server/models/cx_tower_vault_mixin.py
+++ b/cetmix_tower_server/models/cx_tower_vault_mixin.py
@@ -400,3 +400,17 @@ class CxTowerVaultMixin(models.AbstractModel):
         set_clause = ", ".join(f"{field} = NULL" for field in self.SECRET_FIELDS)
         query = f"UPDATE {self._table} SET {set_clause} WHERE id in %s"
         self.env.cr.execute(query, (tuple(self.ids),))
+
+    def _is_secret_value_set(self, field_name):
+        """
+        Check if a secret value is set for a specific field for a single record.
+        This method is preferable to _get_secret_value because it doesn't require
+        to expose the secret value to the caller.
+
+        Args:
+            field_name (str): Name of the secret field to check
+
+        Returns:
+            bool: True if the secret value is set, False otherwise
+        """
+        return self._get_secret_value(field_name) is not None

--- a/cetmix_tower_server/readme/newsfragments/5253.feature
+++ b/cetmix_tower_server/readme/newsfragments/5253.feature
@@ -1,0 +1,1 @@
+Blacklist filter for Python commands, value checker for Vault.

--- a/cetmix_tower_server/tests/test_command.py
+++ b/cetmix_tower_server/tests/test_command.py
@@ -1475,6 +1475,27 @@ else:
             "The error response must be contain text - error",
         )
 
+    def test_run_python_code_banned_keywords(self):
+        """
+        Test that _run_python_code raises ValidationError when code contains
+        banned keywords (e.g. _set_secret_values, _get_secret_value,
+        _get_secret_values).
+        """
+        banned_keywords = self.Command._get_banned_python_code_keywords()
+        for banned_keyword in banned_keywords:
+            with self.subTest(banned_keyword=banned_keyword):
+                code = f"""
+result = {{"exit_code": 0, "message": "ok"}}
+# Banned: {banned_keyword}
+"""
+                with self.assertRaises(ValidationError) as cm:
+                    self.server_test_1._run_python_code(code, raise_on_error=True)
+                self.assertIn(
+                    banned_keyword,
+                    str(cm.exception),
+                    "ValidationError must mention the banned keyword",
+                )
+
     def test_run_python_code(self):
         """
         Test python execution code

--- a/cetmix_tower_server/tests/test_vault_mixin.py
+++ b/cetmix_tower_server/tests/test_vault_mixin.py
@@ -504,3 +504,31 @@ class TestVaultMixin(TestTowerCommon):
             all_secret_values,
             "Server 3 should not be in secret values since it has no secret fields",
         )
+
+    def test_is_secret_value_set(self):
+        """Test _is_secret_value_set returns True/False for host_key correctly."""
+        server = self.Server.create(
+            {
+                "name": "Is Secret Set Test Server",
+                "ip_v4_address": "localhost",
+                "ssh_username": "admin",
+                "ssh_password": "password",
+                "ssh_auth_mode": "p",
+                "os_id": self.os_debian_10.id,
+                "host_key": "test_host_key_value",
+                "skip_host_key": False,
+            }
+        )
+
+        self.assertTrue(
+            server._is_secret_value_set("host_key"),
+            "host_key should be considered set when value exists in vault",
+        )
+
+        server.write({"host_key": False})
+        server = self.Server.browse(server.id)
+
+        self.assertFalse(
+            server._is_secret_value_set("host_key"),
+            "host_key should be considered not set when cleared",
+        )


### PR DESCRIPTION
- Blacklist filter for Python commands. Catch banned keywords in Python code before execution.
- Value checker for Vault. Allows to check if a secret value is set for a specific field for a single record without exposing the secret value.

Forward port of https://github.com/cetmix/cetmix-tower/pull/473

Task: 5259