### PR TITLE
[17.0][FIX] cetmix_tower_git Project->Server link

### DIFF
--- a/cetmix_tower_git/models/cx_tower_git_project.py
+++ b/cetmix_tower_git/models/cx_tower_git_project.py
@@ -34,15 +34,14 @@ class CxTowerGitProject(models.Model):
     # IMPORTANT: This field may contain duplicates because of the relation nature!
     server_ids = fields.Many2many(
         comodel_name="cx.tower.server",
-        relation="cx_tower_git_project_rel",
-        column1="git_project_id",
-        column2="server_id",
-        string="Servers",
+        relation="cx_tower_git_project_server_rel",
         readonly=True,
         copy=False,
-        help="Servers are added automatically based on the files linked to the project."
-        "\nIMPORTANT: This field may contain duplicates"
-        " because of the relation nature!",
+        compute="_compute_server_ids",
+        store=True,
+        context={"active_test": False},
+        help="Servers are added automatically based on the files"
+        " linked to the project.",
     )
     source_ids = fields.One2many(
         comodel_name="cx.tower.git.source",
@@ -148,6 +147,22 @@ class CxTowerGitProject(models.Model):
         Default project format.
         """
         return "git_aggregator"
+
+    @api.depends("git_project_rel_ids", "git_project_rel_ids.server_id")
+    def _compute_server_ids(self):
+        """Compute server ids for git projects.
+
+        Why? Because a git project can be linked to multiple files
+        on the same server.
+        So we need to use a set to avoid duplicates so every server
+        is listed only once.
+        """
+        for project in self:
+            project.server_ids = (
+                list(set(project.git_project_rel_ids.server_id.ids))
+                if project.git_project_rel_ids
+                else False
+            )
 
     @api.depends(
         "git_project_rel_ids.server_id",

--- a/cetmix_tower_git/readme/newsfragments/5214.bugfix
+++ b/cetmix_tower_git/readme/newsfragments/5214.bugfix
@@ -1,0 +1,1 @@
+Link server to git project only once.

--- a/cetmix_tower_git/views/cx_tower_git_project_views.xml
+++ b/cetmix_tower_git/views/cx_tower_git_project_views.xml
@@ -8,7 +8,11 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
-                <field name="server_ids" widget="many2many_tags" />
+                <field
+                    name="server_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color'}"
+                />
                 <field name="active" widget="boolean_toggle" />
             </tree>
         </field>
@@ -45,6 +49,7 @@
                                 name="server_ids"
                                 widget="many2many_tags"
                                 invisible="not server_ids"
+                                options="{'color_field': 'color'}"
                             />
                             <field
                                 name="file_template_ids"


### PR DESCRIPTION
Forward port of https://github.com/cetmix/cetmix-tower/pull/470

In some cases a git project could be linked to different files on the same server.
Before this commit this lead to a situation where the same server was listed multiple times in the git project.
This broke the 'many2many_tags' widget in the git project form view causing weird UI behavior and errors in the console.

This commit fixes the issue ensuring that the same server is listed only once in the git project.

Task: 5214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved duplicate server entries in git projects; servers are now linked only once and managed automatically based on file relationships.

* **UI/UX Improvements**
  * Enhanced server display in git project views with color-coded tags for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->