### PR TITLE
[16.0][IMP] cetmix_tower_yaml Import

### DIFF
--- a/cetmix_tower_yaml/models/__init__.py
+++ b/cetmix_tower_yaml/models/__init__.py
@@ -15,6 +15,7 @@ from . import cx_tower_key_value
 from . import cx_tower_server_log
 from . import cx_tower_shortcut
 from . import cx_tower_scheduled_task
+from . import cx_tower_scheduled_task_cv
 from . import cx_tower_file
 from . import cx_tower_server
 from . import cx_tower_yaml_manifest_template

--- a/cetmix_tower_yaml/models/cx_tower_command.py
+++ b/cetmix_tower_yaml/models/cx_tower_command.py
@@ -19,13 +19,25 @@ class CxTowerCommand(models.Model):
             "tag_ids",
             "path",
             "file_template_id",
+            "if_file_exists",
+            "disconnect_file",
             "flight_plan_id",
+            "jet_template_id",
+            "jet_action_id",
+            "waypoint_template_id",
+            "fly_here",
             "code",
+            "no_split_for_sudo",
             "server_status",
             "variable_ids",
             "secret_ids",
-            "no_split_for_sudo",
-            "if_file_exists",
-            "disconnect_file",
         ]
         return res
+
+    def _get_deferred_m2o_import_fields(self):
+        """Return m2o command fields resolved after the main import pass."""
+        return {
+            "jet_template_id": "cx.tower.jet.template",
+            "jet_action_id": "cx.tower.jet.action",
+            "waypoint_template_id": "cx.tower.jet.waypoint.template",
+        }

--- a/cetmix_tower_yaml/models/cx_tower_jet_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_jet_template.py
@@ -30,3 +30,13 @@ class CxTowerJetTemplate(models.Model):
             "scheduled_task_ids",
         ]
         return res
+
+    def _get_deferred_x2m_import_fields(self):
+        """Return x2m child records resolved after the main import pass."""
+        return {
+            "template_requires_ids": {
+                "child_model": "cx.tower.jet.template.dependency",
+                "deferred_field": "template_required_id",
+                "target_model": "cx.tower.jet.template",
+            }
+        }

--- a/cetmix_tower_yaml/models/cx_tower_jet_waypoint_template.py
+++ b/cetmix_tower_yaml/models/cx_tower_jet_waypoint_template.py
@@ -16,6 +16,7 @@ class CxTowerJetWaypointTemplate(models.Model):
             "name",
             "sequence",
             "access_level",
+            "jet_template_id",
             "plan_create_id",
             "plan_arrive_id",
             "plan_leave_id",
@@ -23,3 +24,9 @@ class CxTowerJetWaypointTemplate(models.Model):
             "note",
         ]
         return res
+
+    def _get_deferred_m2o_import_fields(self):
+        """Return m2o waypoint-template fields resolved after import."""
+        return {
+            "jet_template_id": "cx.tower.jet.template",
+        }

--- a/cetmix_tower_yaml/models/cx_tower_plan.py
+++ b/cetmix_tower_yaml/models/cx_tower_plan.py
@@ -21,3 +21,20 @@ class CxTowerPlan(models.Model):
             "line_ids",
         ]
         return res
+
+    def _get_deferred_x2m_import_fields(self):
+        """Defer plan lines whose command is not resolvable during nested import.
+
+        Deep YAML (e.g. a command's waypoint inlines a jet template whose plans
+        reference that same command) creates a forward reference: plan lines are
+        prepared before the command exists in the database. Queue those lines
+        and create them after the main import pass when ``command_id`` can be
+        resolved.
+        """
+        return {
+            "line_ids": {
+                "child_model": "cx.tower.plan.line",
+                "deferred_field": "command_id",
+                "target_model": "cx.tower.command",
+            }
+        }

--- a/cetmix_tower_yaml/models/cx_tower_scheduled_task.py
+++ b/cetmix_tower_yaml/models/cx_tower_scheduled_task.py
@@ -19,5 +19,24 @@ class CxTowerScheduledTask(models.Model):
             "interval_type",
             "next_call",
             "last_call",
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+            "custom_variable_value_ids",
         ]
         return res
+
+    def _get_deferred_x2m_import_fields(self):
+        """Return scheduled-task child records resolved after import."""
+        return {
+            "custom_variable_value_ids": {
+                "child_model": "cx.tower.scheduled.task.cv",
+                "deferred_field": "variable_value_id",
+                "target_model": "cx.tower.variable.value",
+                "skip_empty": True,
+            }
+        }

--- a/cetmix_tower_yaml/models/cx_tower_scheduled_task_cv.py
+++ b/cetmix_tower_yaml/models/cx_tower_scheduled_task_cv.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class CxTowerScheduledTaskCv(models.Model):
+    _name = "cx.tower.scheduled.task.cv"
+    _inherit = [
+        "cx.tower.scheduled.task.cv",
+        "cx.tower.yaml.mixin",
+        "cx.tower.reference.mixin",
+    ]
+
+    def _get_fields_for_yaml(self):
+        res = super()._get_fields_for_yaml()
+        res += ["variable_value_id"]
+        return res
+
+    def _post_process_yaml_dict_values(self, values):
+        """Populate required child fields from the linked variable value."""
+        res = super()._post_process_yaml_dict_values(values)
+        variable_value_id = res.get("variable_value_id")
+        if variable_value_id:
+            variable_value = self.env["cx.tower.variable.value"].browse(
+                variable_value_id
+            )
+            if variable_value.exists():
+                res.update(
+                    {
+                        "name": variable_value.name,
+                        "variable_id": variable_value.variable_id.id,
+                        "option_id": variable_value.option_id.id or False,
+                        "value_char": variable_value.value_char,
+                    }
+                )
+        return res

--- a/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/models/cx_tower_yaml_mixin.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import copy
 import logging
 
 import yaml
@@ -9,6 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, ValidationError
 
 _logger = logging.getLogger(__name__)
+DEFERRED_M2O_IMPORT = object()
 
 
 class CustomDumper(yaml.Dumper):
@@ -76,14 +78,18 @@ class CxTowerYamlMixin(models.AbstractModel):
 
     def _compute_yaml_code(self):
         """Compute YAML code based on model record data"""
-
         # This is used for the file name.
         # Eg cx.tower.command record will have 'command_' prefix.
         for record in self:
+            # Use a shared collector from context when one is provided (e.g. by
+            # the export wizard for cross-record deduplication); otherwise use a
+            # fresh per-record collector so that each record's yaml_code is
+            # deterministic regardless of which sibling records are batched.
+            collector = record._context.get("yaml_collector") or YamlExportCollector()
             # We are reading field list for each record
             # because list of fields can differ from record to record
             record.yaml_code = self._convert_dict_to_yaml(
-                record._prepare_record_for_yaml()
+                record.with_context(yaml_collector=collector)._prepare_record_for_yaml()
             )
 
     def _inverse_yaml_code(self):
@@ -206,6 +212,167 @@ class CxTowerYamlMixin(models.AbstractModel):
             "cx.tower.key",
         ]
 
+    def _get_deferred_m2o_import_fields(self):
+        """Map m2o fields that should be resolved after the main import pass.
+
+        Returns:
+            dict: Field name to expected target model mapping.
+        """
+        return {}
+
+    def _get_deferred_x2m_import_fields(self):
+        """Map x2m child records that should be created after the main import pass.
+
+        Returns:
+            dict: Parent field name to deferred child spec mapping.
+        """
+        return {}
+
+    def _has_meaningful_yaml_value(self, value):
+        """Return whether a YAML value contains meaningful payload."""
+        if value is False or value is None or value == "":
+            return False
+        if isinstance(value, dict):
+            if set(value.keys()) == {"reference"}:
+                return bool(value.get("reference"))
+            return any(
+                self._has_meaningful_yaml_value(item)
+                for key, item in value.items()
+                if key != "reference"
+            )
+        if isinstance(value, list):
+            return any(self._has_meaningful_yaml_value(item) for item in value)
+        return True
+
+    def _get_reference_only_yaml_relation_reference(self, value):
+        """Return reference for reference-only YAML relation values.
+
+        Args:
+            value (str | dict): YAML relation value.
+
+        Returns:
+            str | bool: Reference if the value is reference-only, otherwise False.
+        """
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict) and set(value.keys()) == {"reference"}:
+            return value.get("reference") or False
+        return False
+
+    def _queue_deferred_m2o_import(self, field, comodel, value):
+        """Queue unresolved m2o relation for the deferred import pass.
+
+        Args:
+            field (str): Owner field name.
+            comodel (BaseModel): Related model.
+            value (str | dict): YAML relation value.
+
+        Returns:
+            bool: True when the relation was queued for deferred resolution.
+        """
+        queue = self._context.get("yaml_deferred_m2o_queue")
+        if queue is None:
+            return False
+
+        deferred_fields = self._get_deferred_m2o_import_fields()
+        expected_model = deferred_fields.get(field)
+        if not expected_model or expected_model != comodel._name:
+            return False
+
+        target_reference = self._get_reference_only_yaml_relation_reference(value)
+        if not target_reference or comodel.get_by_reference(target_reference):
+            return False
+
+        record_reference = self._context.get("yaml_import_record_reference")
+        if not record_reference:
+            return False
+
+        queue.append(
+            {
+                "record_model": self._name,
+                "record_reference": record_reference,
+                "field_name": field,
+                "target_model": comodel._name,
+                "target_reference": target_reference,
+            }
+        )
+        return True
+
+    def _queue_deferred_x2m_import(self, field, comodel, value):
+        """Queue unresolved x2m child record for the deferred import pass.
+
+        Args:
+            field (str): Owner x2m field name.
+            comodel (BaseModel): Related child model.
+            value (dict): YAML child record value.
+
+        Returns:
+            bool: True when the child was queued for deferred creation or
+                  should be skipped (e.g., empty value with skip_empty=True).
+        """
+        queue = self._context.get("yaml_deferred_x2m_queue")
+        if queue is None or not isinstance(value, dict):
+            return False
+
+        deferred_fields = self._get_deferred_x2m_import_fields()
+        spec = deferred_fields.get(field) or {}
+        if spec.get("child_model") != comodel._name:
+            return False
+
+        if spec.get("skip_empty") and not self._has_meaningful_yaml_value(value):
+            return True
+
+        deferred_field = spec.get("deferred_field")
+        if not deferred_field:
+            return False
+
+        target_model = spec.get("target_model")
+        target_value = value.get(deferred_field)
+        target_reference = self._get_reference_only_yaml_relation_reference(
+            target_value
+        )
+        if not target_model or not target_reference:
+            return False
+
+        target_record = self.env[target_model].get_by_reference(target_reference)
+        if target_record:
+            return False
+
+        record_reference = self._context.get("yaml_import_record_reference")
+        if not record_reference:
+            return False
+
+        queue.append(
+            {
+                "record_model": self._name,
+                "record_reference": record_reference,
+                "field_name": field,
+                "child_model": comodel._name,
+                "deferred_field": deferred_field,
+                "target_model": target_model,
+                "target_reference": target_reference,
+                "values": copy.deepcopy(value),
+            }
+        )
+        return True
+
+    def _get_yaml_duplicate_reference_dict(self, ref, values):
+        """Return the stub emitted when a record has already been serialized.
+
+        The collector deduplicates by (model, reference); subsequent occurrences
+        are collapsed to a reference-only dict. Import must never attempt to create
+        from this stub — it must resolve the record by reference instead.
+
+        Args:
+            ref (str): Record reference.
+            values (dict): Raw values (unused; kept for signature compatibility
+                in case subclasses need them).
+
+        Returns:
+            dict: ``{"reference": ref}`` only.
+        """
+        return {"reference": ref}
+
     def _post_process_record_values(self, values):
         """Post process record values
             before converting them to YAML
@@ -226,7 +393,10 @@ class CxTowerYamlMixin(models.AbstractModel):
         collector_key = (self._name, ref) if ref else None
 
         if collector and collector_key and collector.is_added(collector_key):
-            return {"reference": ref}
+            return self._get_yaml_duplicate_reference_dict(ref, values)
+
+        if collector and collector_key:
+            collector.add(collector_key)
 
         # We don't need id because we are not using it
         values.pop("id", None)
@@ -274,9 +444,6 @@ class CxTowerYamlMixin(models.AbstractModel):
                     )._process_relation_field_value(key, value, record_mode=True)
                     new_values.update({key: processed_value})
 
-        if collector and collector_key:
-            collector.add(collector_key)
-
         return new_values
 
     def _post_process_yaml_dict_values(self, values):
@@ -312,16 +479,20 @@ class CxTowerYamlMixin(models.AbstractModel):
         filtered_values = {k: v for k, v in values.items() if k in supported_keys}
 
         # Post process m2o fields
-        for key, value in filtered_values.items():
+        for key, value in list(filtered_values.items()):
             # IMPORTANT: Odoo naming patterns must be followed for related fields.
             # This is why we are checking for the field name ending here.
             # Further checks for the field type are done
             # in _process_relation_field_value()
             if key.endswith("_id") or key.endswith("_ids"):
                 processed_value = self.with_context(
-                    explode_related_record=True
+                    explode_related_record=True,
+                    yaml_import_record_reference=filtered_values.get("reference"),
                 )._process_relation_field_value(key, value, record_mode=False)
-                filtered_values.update({key: processed_value})
+                if processed_value is DEFERRED_M2O_IMPORT:
+                    filtered_values.pop(key, None)
+                else:
+                    filtered_values.update({key: processed_value})
 
         return filtered_values
 
@@ -362,21 +533,22 @@ class CxTowerYamlMixin(models.AbstractModel):
         # Step 3: process value based on the field type
         if field_type == "many2one":
             return self._process_m2o_value(
-                comodel, value, explode_related_record, record_mode
+                field, comodel, value, explode_related_record, record_mode
             )
         if field_type in ["one2many", "many2many"]:
             return self._process_x2m_values(
-                comodel, field_type, value, explode_related_record, record_mode
+                field, comodel, field_type, value, explode_related_record, record_mode
             )
 
         # Step 4: fall back if field type is not supported
         return False
 
     def _process_m2o_value(
-        self, comodel, value, explode_related_record, record_mode=False
+        self, field, comodel, value, explode_related_record, record_mode=False
     ):
         """Post process many2one value
         Args:
+            field (Char): Field the value belongs to
             comodel (BaseClass): Model the value belongs to
             value (Char): Value to process
             explode_related_record (Bool): If True return entire record dict
@@ -410,6 +582,8 @@ class CxTowerYamlMixin(models.AbstractModel):
         # -- (YAML -> Record)
         # Step 1: Process value in normal mode
         record = False
+        if self._queue_deferred_m2o_import(field, comodel, value):
+            return DEFERRED_M2O_IMPORT
 
         # If the value is a string, it is treated as a reference
         if isinstance(value, str):
@@ -418,10 +592,13 @@ class CxTowerYamlMixin(models.AbstractModel):
         # If the value is a dictionary, extract the reference from it
         elif isinstance(value, dict):
             reference = value.get("reference")
+            if self._get_reference_only_yaml_relation_reference(value):
+                record = False
+            else:
+                record = self._update_or_create_related_record(
+                    comodel, reference, value, create_immediately=True
+                )
 
-            record = self._update_or_create_related_record(
-                comodel, reference, value, create_immediately=True
-            )
         else:
             return False
 
@@ -432,10 +609,17 @@ class CxTowerYamlMixin(models.AbstractModel):
         return record.id if record else False
 
     def _process_x2m_values(
-        self, comodel, field_type, values, explode_related_record, record_mode=False
+        self,
+        field,
+        comodel,
+        field_type,
+        values,
+        explode_related_record,
+        record_mode=False,
     ):
         """Post process many2many value
         Args:
+            field (Char): Field the value belongs to
             comodel (BaseClass): Model the value belongs to
             field_type (Char): Field type
             values (list()): Values to process
@@ -485,6 +669,8 @@ class CxTowerYamlMixin(models.AbstractModel):
 
             # If the value is a dictionary, extract the reference from it
             elif isinstance(value, dict):
+                if self._queue_deferred_x2m_import(field, comodel, value):
+                    continue
                 reference = value.get("reference")
                 record = self._update_or_create_related_record(
                     comodel,
@@ -542,6 +728,17 @@ class CxTowerYamlMixin(models.AbstractModel):
 
             # If the record does not exist, create a new one
             else:
+                if set(values.keys()) == {"reference"}:
+                    _logger.warning(
+                        "Attempted to import a record for model '%s' "
+                        "with reference "
+                        "'%s', but only the 'reference' field was provided. "
+                        "Creation will be skipped until the target record "
+                        "exists.",
+                        model._name,
+                        reference,
+                    )
+                    return False
                 if create_immediately:
                     record = model.with_context(from_yaml=True).create(
                         model._post_process_yaml_dict_values(values)
@@ -552,20 +749,20 @@ class CxTowerYamlMixin(models.AbstractModel):
 
         # If there's no reference but value is a dict, create a new record
         else:
-            if create_immediately:
-                # Only 'reference' provided, no other data: do not create,
-                # just log warning
-                if set(values.keys()) == {"reference"}:
-                    _logger.warning(
-                        "Attempted to import a record for model '%s' with reference "
-                        "'%s', but only the 'reference' field was provided. "
-                        "It is possible that this record has already been imported. "
-                        "Creation will be skipped.",
-                        model._name,
-                        reference,
-                    )
-                    return False
+            # Only 'reference' provided, no other data: do not create,
+            # just log warning
+            if set(values.keys()) == {"reference"}:
+                _logger.warning(
+                    "Attempted to import a record for model '%s' with reference "
+                    "'%s', but only the 'reference' field was provided. "
+                    "It is possible that this record has already been imported. "
+                    "Creation will be skipped.",
+                    model._name,
+                    reference,
+                )
+                return False
 
+            if create_immediately:
                 record = model.with_context(from_yaml=True).create(
                     model._post_process_yaml_dict_values(values)
                 )

--- a/cetmix_tower_yaml/readme/newsfragments/5323.feature
+++ b/cetmix_tower_yaml/readme/newsfragments/5323.feature
@@ -1,0 +1,1 @@
+Deferred import of related records.

--- a/cetmix_tower_yaml/tests/test_command.py
+++ b/cetmix_tower_yaml/tests/test_command.py
@@ -27,16 +27,20 @@ os_ids: false
 tag_ids: false
 path: false
 file_template_id: false
+if_file_exists: skip
+disconnect_file: false
 flight_plan_id: false
+jet_template_id: false
+jet_action_id: false
+waypoint_template_id: false
+fly_here: false
 code: |-
   cd /home/{{ tower.server.ssh_username }} \\
   && ls -lha
+no_split_for_sudo: false
 server_status: false
 variable_ids: false
 secret_ids: false
-no_split_for_sudo: false
-if_file_exists: skip
-disconnect_file: false
 """
 
         # YAML content translated into Python dict
@@ -265,14 +269,18 @@ os_ids: false
 tag_ids: false
 path: false
 file_template_id: my_custom_test_template
+if_file_exists: skip
+disconnect_file: false
 flight_plan_id: false
+jet_template_id: false
+jet_action_id: false
+waypoint_template_id: false
+fly_here: false
 code: false
+no_split_for_sudo: false
 server_status: false
 variable_ids: false
 secret_ids: false
-no_split_for_sudo: false
-if_file_exists: skip
-disconnect_file: false
 """
         # Add file template
         file_template = self.env["cx.tower.file.template"].create(
@@ -330,14 +338,18 @@ file_template_id:
   code: false
   variable_ids: false
   secret_ids: false
+if_file_exists: skip
+disconnect_file: false
 flight_plan_id: false
+jet_template_id: false
+jet_action_id: false
+waypoint_template_id: false
+fly_here: false
 code: false
+no_split_for_sudo: false
 server_status: false
 variable_ids: false
 secret_ids: false
-no_split_for_sudo: false
-if_file_exists: skip
-disconnect_file: false
 """
         command_with_template.invalidate_recordset(["yaml_code"])
         self.assertEqual(

--- a/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
+++ b/cetmix_tower_yaml/tests/test_tower_yaml_mixin.py
@@ -13,9 +13,30 @@ class TestTowerYamlMixin(TransactionCase):
         super().setUpClass(*args, **kwargs)
         cls.Users = cls.env["res.users"].with_context(no_reset_password=True)
         cls.YamlMixin = cls.env["cx.tower.yaml.mixin"]
+        cls.Command = cls.env["cx.tower.command"]
+        cls.JetTemplate = cls.env["cx.tower.jet.template"]
+        cls.ScheduledTask = cls.env["cx.tower.scheduled.task"]
         TowerTag = cls.env["cx.tower.tag"]
         cls.tag_doge = TowerTag.create({"name": "Doge", "reference": "doge"})
         cls.tag_pepe = TowerTag.create({"name": "Pepe", "reference": "pepe"})
+        cls.jet_state_running = cls.env["cx.tower.jet.state"].get_by_reference(
+            "running"
+        )
+        cls.command_for_schedule = cls.Command.create(
+            {"name": "Command for schedule", "action": "ssh_command"}
+        )
+        cls.jet_template_existing = cls.env["cx.tower.jet.template"].create(
+            {"name": "Existing Jet Template", "reference": "existing_jet_template"}
+        )
+        cls.waypoint_template_existing = cls.env[
+            "cx.tower.jet.waypoint.template"
+        ].create(
+            {
+                "name": "Existing Waypoint Template",
+                "reference": "existing_waypoint_template",
+                "jet_template_id": cls.jet_template_existing.id,
+            }
+        )
 
     def test_convert_dict_to_yaml(self):
         # -- 1 --
@@ -183,6 +204,227 @@ class TestTowerYamlMixin(TransactionCase):
 
         # Restore original method
         self.YamlMixin._revert_method("_get_fields_for_yaml")
+
+    def test_post_process_yaml_dict_values_defers_command_template_links(self):
+        """Reference-only unresolved command template links must be deferred."""
+        deferred_queue = []
+        values = {
+            "reference": "command_deferred_links",
+            "name": "Command Deferred Links",
+            "action": "jet_action",
+            "jet_template_id": "future_jet_template",
+            "waypoint_template_id": {"reference": "future_waypoint_template"},
+        }
+
+        result_values = self.Command.with_context(
+            yaml_deferred_m2o_queue=deferred_queue
+        )._post_process_yaml_dict_values(values)
+
+        self.assertNotIn(
+            "jet_template_id",
+            result_values,
+            "Deferred jet template link must be omitted from first-pass values",
+        )
+        self.assertNotIn(
+            "waypoint_template_id",
+            result_values,
+            "Deferred waypoint template link must be omitted from first-pass values",
+        )
+        self.assertEqual(len(deferred_queue), 2, "Two deferred items must be queued")
+        self.assertEqual(
+            deferred_queue[0]["record_reference"],
+            values["reference"],
+            "Deferred queue must preserve command reference",
+        )
+        self.assertEqual(
+            deferred_queue[0]["field_name"],
+            "jet_template_id",
+            "Deferred queue must preserve the deferred field name",
+        )
+        self.assertEqual(
+            deferred_queue[1]["field_name"],
+            "waypoint_template_id",
+            "Deferred queue must preserve each deferred field separately",
+        )
+
+    def test_post_process_yaml_dict_values_resolves_existing_command_template_links(
+        self
+    ):
+        """Already existing command template links must be resolved immediately."""
+        deferred_queue = []
+        values = {
+            "reference": "command_immediate_links",
+            "name": "Command Immediate Links",
+            "action": "create_waypoint",
+            "jet_template_id": self.jet_template_existing.reference,
+            "waypoint_template_id": {
+                "reference": self.waypoint_template_existing.reference
+            },
+        }
+
+        result_values = self.Command.with_context(
+            yaml_deferred_m2o_queue=deferred_queue
+        )._post_process_yaml_dict_values(values)
+
+        self.assertEqual(
+            result_values["jet_template_id"],
+            self.jet_template_existing.id,
+            "Existing jet template must resolve during the first import pass",
+        )
+        self.assertEqual(
+            result_values["waypoint_template_id"],
+            self.waypoint_template_existing.id,
+            "Existing waypoint template must resolve during the first import pass",
+        )
+        self.assertFalse(
+            deferred_queue,
+            "No deferred items must be queued when targets already exist",
+        )
+
+    def test_post_process_yaml_dict_values_defers_template_dependency_children(self):
+        """Unresolved template dependency children must be deferred."""
+        deferred_queue = []
+        values = {
+            "reference": "owner_template_deferred_dependency",
+            "name": "Owner Template Deferred Dependency",
+            "template_requires_ids": [
+                {
+                    "reference": False,
+                    "template_required_id": {
+                        "reference": "future_template_dependency_target"
+                    },
+                    "state_required_id": {
+                        "reference": self.jet_state_running.reference
+                    },
+                }
+            ],
+        }
+
+        result_values = self.JetTemplate.with_context(
+            yaml_deferred_x2m_queue=deferred_queue
+        )._post_process_yaml_dict_values(values)
+
+        self.assertEqual(
+            result_values.get("template_requires_ids"),
+            [],
+            "Deferred dependency child must be removed from first-pass create values",
+        )
+        self.assertEqual(
+            len(deferred_queue),
+            1,
+            "One dependency child must be queued for deferred creation",
+        )
+        self.assertEqual(
+            deferred_queue[0]["field_name"],
+            "template_requires_ids",
+            "Deferred queue must preserve the parent x2m field name",
+        )
+        self.assertEqual(
+            deferred_queue[0]["target_reference"],
+            "future_template_dependency_target",
+            "Deferred queue must preserve the missing dependency target reference",
+        )
+
+    def test_post_process_yaml_dict_values_skips_empty_scheduled_task_custom_values(
+        self
+    ):
+        """Placeholder scheduled-task custom values must be skipped."""
+        deferred_queue = []
+        scheduled_task_values = {
+            "reference": "scheduled_task_skip_empty_child",
+            "name": "Scheduled Task Skip Empty Child",
+            "action": "command",
+            "command_id": self.command_for_schedule.reference,
+            "interval_number": 1,
+            "interval_type": "days",
+            "next_call": "2026-03-27 00:00:00",
+            "custom_variable_value_ids": [{"reference": False}],
+        }
+
+        result_values = self.ScheduledTask.with_context(
+            yaml_deferred_x2m_queue=deferred_queue
+        )._post_process_yaml_dict_values(scheduled_task_values)
+
+        self.assertEqual(
+            result_values.get("custom_variable_value_ids"),
+            [],
+            "Placeholder child rows must be removed from scheduled task import values",
+        )
+        self.assertFalse(
+            deferred_queue,
+            "Empty placeholder rows must be skipped rather than deferred",
+        )
+
+    def test_post_process_yaml_dict_values_defers_scheduled_task_custom_values(self):
+        """Unresolved scheduled-task custom values must be deferred."""
+        deferred_queue = []
+        scheduled_task_values = {
+            "reference": "scheduled_task_deferred_custom_value",
+            "name": "Scheduled Task Deferred Custom Value",
+            "action": "command",
+            "command_id": self.command_for_schedule.reference,
+            "interval_number": 1,
+            "interval_type": "days",
+            "next_call": "2026-03-27 00:00:00",
+            "custom_variable_value_ids": [
+                {
+                    "reference": False,
+                    "variable_value_id": {"reference": "future_variable_value_ref"},
+                }
+            ],
+        }
+
+        result_values = self.ScheduledTask.with_context(
+            yaml_deferred_x2m_queue=deferred_queue
+        )._post_process_yaml_dict_values(scheduled_task_values)
+
+        self.assertEqual(
+            result_values.get("custom_variable_value_ids"),
+            [],
+            "Deferred scheduled-task child rows must be removed from first-pass values",
+        )
+        self.assertEqual(
+            len(deferred_queue),
+            1,
+            "One scheduled-task custom value row must be queued for deferred creation",
+        )
+        self.assertEqual(
+            deferred_queue[0]["field_name"],
+            "custom_variable_value_ids",
+            "Deferred queue must preserve the scheduled-task child field name",
+        )
+        self.assertEqual(
+            deferred_queue[0]["target_reference"],
+            "future_variable_value_ref",
+            "Deferred queue must preserve the missing variable value reference",
+        )
+
+    def test_process_relation_field_value_reference_only_dict_no_placeholder_create(
+        self
+    ):
+        """Reference-only dict must not create placeholder m2o records."""
+        command = self.Command.create(
+            {
+                "name": "Command reference-only dict",
+                "action": "file_using_template",
+            }
+        )
+        missing_reference = "missing_file_template_reference_only"
+
+        result = command._process_relation_field_value(
+            field="file_template_id",
+            value={"reference": missing_reference},
+            record_mode=False,
+        )
+
+        self.assertFalse(
+            result,
+            "Reference-only dict must stay unresolved instead of creating a record",
+        )
+        self.assertFalse(
+            self.env["cx.tower.file.template"].get_by_reference(missing_reference),
+            "Reference-only dict must not create a placeholder related record",
+        )
 
     def test_process_relation_field_value_no_explode(self):
         """Test non exploded related field values.

--- a/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_export_wizard.py
@@ -103,11 +103,12 @@ records:
   allow_parallel_run: false
   note: false
   path: false
-  code: echo 'Test Command From Yaml'
-  server_status: false
-  no_split_for_sudo: false
   if_file_exists: skip
   disconnect_file: false
+  fly_here: false
+  code: echo 'Test Command From Yaml'
+  no_split_for_sudo: false
+  server_status: false
 - cetmix_tower_model: command
   access_level: manager
   reference: test_command_from_yaml_2
@@ -116,11 +117,12 @@ records:
   allow_parallel_run: false
   note: false
   path: false
-  code: echo 'Test Command From Yaml 2'
-  server_status: false
-  no_split_for_sudo: false
   if_file_exists: skip
   disconnect_file: false
+  fly_here: false
+  code: echo 'Test Command From Yaml 2'
+  no_split_for_sudo: false
+  server_status: false
 """
 
         # -- 1 --

--- a/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
+++ b/cetmix_tower_yaml/tests/test_yaml_import_wizard.py
@@ -131,6 +131,15 @@ class TestTowerYamlImportWizUpload(TransactionCase):
         )
         cls.import_wizard.if_record_exists = "update"
 
+    def _create_import_wizard(self, yaml_code, if_record_exists="create"):
+        """Create import wizard for ad-hoc YAML payload."""
+        return self.env["cx.tower.yaml.import.wiz"].create(
+            {
+                "yaml_code": yaml_code,
+                "if_record_exists": if_record_exists,
+            }
+        )
+
     def test_extract_yaml_data(self):
         """Test extract YAML data from file"""
 
@@ -634,6 +643,302 @@ records:
         # Check tag
         self.assertTrue(
             self.Tag.get_by_reference("such_much_tag"), "Tag must be created"
+        )
+
+    def test_action_import_yaml_defers_command_template_links(self):
+        """Forward references for command template links must resolve after import."""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: command
+  reference: deferred_jet_command
+  name: Deferred Jet Command
+  action: jet_action
+  jet_template_id: deferred_jet_template
+- cetmix_tower_model: command
+  reference: deferred_waypoint_command
+  name: Deferred Waypoint Command
+  action: create_waypoint
+  waypoint_template_id:
+    reference: deferred_waypoint_template
+- cetmix_tower_model: jet_template
+  reference: deferred_jet_template
+  name: Deferred Jet Template
+- cetmix_tower_model: jet_waypoint_template
+  reference: deferred_waypoint_template
+  name: Deferred Waypoint Template
+  jet_template_id: deferred_jet_template
+"""
+        wiz = self._create_import_wizard(yaml_code)
+
+        wiz.action_import_yaml()
+
+        deferred_jet_command = self.Command.get_by_reference("deferred_jet_command")
+        deferred_waypoint_command = self.Command.get_by_reference(
+            "deferred_waypoint_command"
+        )
+        deferred_jet_template = self.env["cx.tower.jet.template"].get_by_reference(
+            "deferred_jet_template"
+        )
+        deferred_waypoint_template = self.env[
+            "cx.tower.jet.waypoint.template"
+        ].get_by_reference("deferred_waypoint_template")
+
+        self.assertTrue(
+            deferred_jet_command,
+            "Jet action command must be created during YAML import",
+        )
+        self.assertEqual(
+            deferred_jet_command.jet_template_id,
+            deferred_jet_template,
+            "Deferred jet template link must be written after the main import pass",
+        )
+        self.assertTrue(
+            deferred_waypoint_command,
+            "Waypoint command must be created during YAML import",
+        )
+        self.assertEqual(
+            deferred_waypoint_command.waypoint_template_id,
+            deferred_waypoint_template,
+            "Deferred waypoint template link must be written "
+            "after the main import pass",
+        )
+        self.assertEqual(
+            deferred_waypoint_template.jet_template_id,
+            deferred_jet_template,
+            "Waypoint template must keep its deferred jet template link after import",
+        )
+
+    def test_action_import_yaml_defers_plan_line_command_forward_ref(self):
+        """Plan lines may reference a command still being created (deep YAML cycle)."""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: command
+  reference: yaml_defer_plan_circ_cmd
+  name: YAML defer plan circ command
+  action: create_waypoint
+  allow_parallel_run: false
+  note: false
+  path: false
+  if_file_exists: skip
+  disconnect_file: false
+  fly_here: false
+  waypoint_template_id:
+    reference: yaml_defer_plan_circ_wp
+    name: YAML defer circ waypoint
+    sequence: 10
+    access_level: manager
+    note: false
+    jet_template_id:
+      reference: yaml_defer_plan_circ_jet
+      name: YAML defer circ jet
+      note: false
+      limit_per_server: 0
+      show_in_create_wizard: false
+      action_ids:
+      - reference: yaml_defer_plan_circ_action
+        name: YAML defer circ action
+        note: false
+        priority: 10
+        access_level: manager
+        state_from_id:
+          reference: stopped
+        state_transit_id:
+          reference: building
+        state_to_id:
+          reference: stopped
+        plan_id:
+          reference: yaml_defer_plan_circ_plan
+          name: YAML defer circ plan
+          access_level: manager
+          allow_parallel_run: false
+          color: 0
+          note: false
+          on_error_action: e
+          custom_exit_code: 0
+          line_ids:
+          - reference: yaml_defer_plan_circ_line
+            sequence: 10
+            condition: false
+            use_sudo: false
+            path: false
+            command_id:
+              reference: yaml_defer_plan_circ_cmd
+            is_make_copy: false
+"""
+        wiz = self._create_import_wizard(yaml_code)
+        wiz.action_import_yaml()
+
+        command = self.Command.get_by_reference("yaml_defer_plan_circ_cmd")
+        plan = self.FlightPlan.get_by_reference("yaml_defer_plan_circ_plan")
+        self.assertTrue(command, "Command must be created")
+        self.assertTrue(plan, "Plan must be created")
+        self.assertEqual(
+            len(plan.line_ids),
+            1,
+            "Deferred plan line must be created after the command exists",
+        )
+        self.assertEqual(
+            plan.line_ids.command_id,
+            command,
+            "Plan line command_id must resolve to the enclosing command",
+        )
+
+    def test_action_import_yaml_defers_template_dependency_children(self):
+        """Forward references inside template dependency children must resolve."""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: jet_template
+  reference: owner_template_with_dependency
+  name: Owner Template With Dependency
+  template_requires_ids:
+  - reference: false
+    template_required_id:
+      reference: future_template_dependency
+    state_required_id:
+      reference: running
+- cetmix_tower_model: jet_template
+  reference: future_template_dependency
+  name: Future Template Dependency
+"""
+        wiz = self._create_import_wizard(yaml_code)
+
+        wiz.action_import_yaml()
+
+        owner_template = self.env["cx.tower.jet.template"].get_by_reference(
+            "owner_template_with_dependency"
+        )
+        future_template = self.env["cx.tower.jet.template"].get_by_reference(
+            "future_template_dependency"
+        )
+
+        self.assertTrue(owner_template, "Owner template must be created")
+        self.assertTrue(
+            owner_template.template_requires_ids,
+            "Deferred dependency child must be created after the main import pass",
+        )
+        self.assertEqual(
+            owner_template.template_requires_ids.template_required_id,
+            future_template,
+            "Deferred dependency child must resolve the required template",
+        )
+        self.assertEqual(
+            owner_template.template_requires_ids.state_required_id.reference,
+            "running",
+            "Deferred dependency child must preserve its required state",
+        )
+
+    def test_action_import_yaml_defers_scheduled_task_custom_values(self):
+        """Forward references inside scheduled-task custom values must resolve."""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: scheduled_task
+  reference: deferred_scheduled_task
+  name: Deferred Scheduled Task
+  action: command
+  command_id:
+    reference: test_yaml_command
+  interval_number: 1
+  interval_type: days
+  next_call: 2026-03-27 00:00:00
+  custom_variable_value_ids:
+  - reference: false
+    variable_value_id:
+      reference: deferred_scheduled_task_variable_value
+- cetmix_tower_model: variable_value
+  reference: deferred_scheduled_task_variable_value
+  variable_id:
+    reference: yaml_test
+  value_char: Deferred Value
+"""
+        wiz = self._create_import_wizard(yaml_code)
+
+        wiz.action_import_yaml()
+
+        scheduled_task = self.env["cx.tower.scheduled.task"].get_by_reference(
+            "deferred_scheduled_task"
+        )
+        variable_value = self.env["cx.tower.variable.value"].get_by_reference(
+            "deferred_scheduled_task_variable_value"
+        )
+
+        self.assertTrue(scheduled_task, "Scheduled task must be created")
+        self.assertEqual(
+            len(scheduled_task.custom_variable_value_ids),
+            1,
+            "Deferred scheduled-task custom value must be created after import",
+        )
+        self.assertEqual(
+            scheduled_task.custom_variable_value_ids.variable_value_id,
+            variable_value,
+            "Deferred scheduled-task custom value must resolve variable_value_id",
+        )
+        self.assertEqual(
+            scheduled_task.custom_variable_value_ids.variable_id,
+            variable_value.variable_id,
+            "Deferred scheduled-task custom value must restore variable_id",
+        )
+        self.assertEqual(
+            scheduled_task.custom_variable_value_ids.value_char,
+            variable_value.value_char,
+            "Deferred scheduled-task custom value must restore value_char",
+        )
+
+    def test_action_import_yaml_aggregates_missing_deferred_links(self):
+        """Missing deferred command template links must fail with one clear error."""
+        yaml_code = """cetmix_tower_yaml_version: 1
+records:
+- cetmix_tower_model: command
+  reference: command_missing_jet_template
+  name: Command Missing Jet Template
+  action: jet_action
+  jet_template_id: missing_jet_template
+- cetmix_tower_model: command
+  reference: command_missing_waypoint_template
+  name: Command Missing Waypoint Template
+  action: create_waypoint
+  waypoint_template_id:
+    reference: missing_waypoint_template
+- cetmix_tower_model: command
+  reference: command_valid_deferred_template
+  name: Command Valid Deferred Template
+  action: jet_action
+  jet_template_id: valid_deferred_jet_template
+- cetmix_tower_model: jet_template
+  reference: valid_deferred_jet_template
+  name: Valid Deferred Jet Template
+"""
+        wiz = self._create_import_wizard(yaml_code)
+
+        with self.assertRaises(ValidationError) as err:
+            wiz.action_import_yaml()
+
+        error_message = str(err.exception)
+        self.assertIn(
+            "Deferred relation resolution failed",
+            error_message,
+            "Import must raise one aggregated deferred-resolution error",
+        )
+        self.assertIn(
+            "Record cx.tower.command 'command_missing_jet_template': "
+            "field 'jet_template_id'",
+            error_message,
+            "Error must include unresolved jet template links",
+        )
+        self.assertIn(
+            "cx.tower.jet.template 'missing_jet_template'",
+            error_message,
+            "Error must include missing jet template reference",
+        )
+        self.assertIn(
+            "Record cx.tower.command 'command_missing_waypoint_template': "
+            "field 'waypoint_template_id'",
+            error_message,
+            "Error must include unresolved waypoint template links",
+        )
+        self.assertIn(
+            "cx.tower.jet.waypoint.template 'missing_waypoint_template'",
+            error_message,
+            "Error must include missing waypoint template reference",
         )
 
     def test_yaml_import_server_without_password(self):

--- a/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
+++ b/cetmix_tower_yaml/wizards/cx_tower_yaml_import_wiz.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2024 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-
+import copy
 import logging
 
 import yaml
@@ -122,6 +122,152 @@ class CxTowerYamlImportWiz(models.TransientModel):
                 }
             )
 
+    def _get_import_model(self, model_name, model_cache):
+        """Return cached model configured for YAML import."""
+        model = model_cache.get(model_name)
+        if model is None:
+            model = self.env[f"cx.tower.{model_name.replace('_', '.')}"].with_context(
+                skip_ssh_settings_check=(model_name == "server")
+            )
+            model_cache[model_name] = model
+        return model
+
+    def _get_import_model_context(
+        self,
+        deferred_m2o_queue,
+        deferred_x2m_queue,
+        force_create_related_record,
+    ):
+        """Build context used while converting YAML values to record values."""
+        return {
+            "yaml_deferred_m2o_queue": deferred_m2o_queue,
+            "yaml_deferred_x2m_queue": deferred_x2m_queue,
+            "force_create_related_record": force_create_related_record,
+        }
+
+    def _format_deferred_resolution_error(self, item):
+        """Format one unresolved deferred relation entry."""
+        return _(
+            "Record %(record_model)s '%(record_reference)s': field "
+            "'%(field)s' could not resolve "
+            "%(target_model)s '%(target_reference)s'",
+            record_model=item["record_model"],
+            record_reference=item["record_reference"],
+            field=item["field_name"],
+            target_model=item["target_model"],
+            target_reference=item["target_reference"],
+        )
+
+    def _apply_deferred_m2o_imports(self, deferred_queue):
+        """Resolve queued m2o imports after the main import pass."""
+        unresolved = []
+        for item in deferred_queue:
+            record_id = item.get("record_id")
+            if record_id:
+                record = self.env[item["record_model"]].browse(record_id).exists()
+            else:
+                record = self.env[item["record_model"]].get_by_reference(
+                    item["record_reference"]
+                )
+            target = self.env[item["target_model"]].get_by_reference(
+                item["target_reference"]
+            )
+            if not record or not target:
+                unresolved.append(item)
+                continue
+            record.with_context(from_yaml=True).write({item["field_name"]: target.id})
+
+        if unresolved:
+            details = "\n".join(
+                self._format_deferred_resolution_error(item) for item in unresolved
+            )
+            raise ValidationError(
+                _("Deferred relation resolution failed:\n%(details)s", details=details)
+            )
+
+    def _format_deferred_x2m_resolution_error(self, item):
+        """Format one unresolved deferred x2m child entry."""
+        return _(
+            "Record '%(record)s': field '%(field)s' could not resolve "
+            "%(target_model)s '%(target_reference)s'",
+            record=item["record_reference"],
+            field=item["field_name"],
+            target_model=item["target_model"],
+            target_reference=item["target_reference"],
+        )
+
+    def _apply_deferred_x2m_imports(self, deferred_queue):
+        """Create queued x2m child records after the main import pass."""
+        unresolved = []
+        for item in deferred_queue:
+            owner_model = self.env[item["record_model"]]
+            record_id = item.get("record_id")
+            if record_id:
+                owner_record = owner_model.browse(record_id).exists()
+            else:
+                owner_record = owner_model.get_by_reference(item["record_reference"])
+            target_record = self.env[item["target_model"]].get_by_reference(
+                item["target_reference"]
+            )
+            if not owner_record or not target_record:
+                unresolved.append(item)
+                continue
+
+            owner_field = owner_model._fields[item["field_name"]]
+            inverse_name = owner_field.inverse_name
+            child_model = self.env[item["child_model"]]
+            child_values = child_model.with_context(
+                yaml_deferred_m2o_queue=[],
+                yaml_deferred_x2m_queue=[],
+                force_create_related_record=False,
+            )._post_process_yaml_dict_values(copy.deepcopy(item["values"]))
+            child_values[inverse_name] = owner_record.id
+            if not child_values.get(item["deferred_field"]):
+                unresolved.append(item)
+                continue
+
+            # Guard against creating a duplicate child when the same
+            # (owner, target) pair was already inserted — e.g. because a
+            # duplicate YAML entry queued the same item twice, or the child
+            # was created by a first-pass write after the queue was built.
+            existing = child_model.search(
+                [
+                    (inverse_name, "=", owner_record.id),
+                    (item["deferred_field"], "=", child_values[item["deferred_field"]]),
+                ],
+                limit=1,
+            )
+            if existing:
+                continue
+
+            child_model.with_context(from_yaml=True).create(child_values)
+
+        if unresolved:
+            details = "\n".join(
+                self._format_deferred_x2m_resolution_error(item) for item in unresolved
+            )
+            raise ValidationError(
+                _("Deferred relation resolution failed:\n%(details)s", details=details)
+            )
+
+    def _tag_deferred_queue_items(self, queue, start, record_id, owner_model_name):
+        """Stamp deferred queue items that belong to *owner_model_name*.
+
+        Nested imports queue deferred relations for inner models (e.g. plan lines)
+        while creating a top-level record (e.g. jet template). Only items whose
+        ``record_model`` matches the record that was just created must receive
+        ``record_id``; others keep reference-based resolution in the apply pass.
+
+        Args:
+            queue (list): The deferred import queue (m2o or x2m).
+            start (int): Index of the first item belonging to the current batch.
+            record_id (int): Database ID of the newly created/updated owner record.
+            owner_model_name (str): Technical name of the model *record_id* belongs to.
+        """
+        for item in queue[start:]:
+            if item["record_model"] == owner_model_name:
+                item["record_id"] = record_id
+
     def action_import_yaml(self):
         """Process YAML data and create records in Odoo"""
 
@@ -136,83 +282,116 @@ class CxTowerYamlImportWiz(models.TransientModel):
         # Cache models
         model_cache = {}
         odoo_record_ids = []
+        deferred_m2o_queue = []
+        deferred_x2m_queue = []
 
-        # Process each record
-        for record in records:
-            record_reference = record.get("reference")
-            if not record_reference:
-                raise ValidationError(_("Record reference is missing"))
-            model_name = record.get("cetmix_tower_model")
-            if not model_name:
-                raise ValidationError(
-                    _("Record model is missing for record %s", record_reference)
-                )
+        with self.env.cr.savepoint():
+            # Process each record
+            for record in records:
+                m2o_start = len(deferred_m2o_queue)
+                x2m_start = len(deferred_x2m_queue)
+                record_reference = record.get("reference")
+                if not record_reference:
+                    raise ValidationError(_("Record reference is missing"))
+                model_name = record.get("cetmix_tower_model")
+                if not model_name:
+                    raise ValidationError(
+                        _("Record model is missing for record %s", record_reference)
+                    )
 
-            # Get model from cache or create new one
-            model = model_cache.get(model_name)
-            if not model:
-                model = self.env[
-                    f"cx.tower.{model_name.replace('_', '.')}"
-                ].with_context(skip_ssh_settings_check=(model_name == "server"))
-                model_cache[model_name] = model
+                # Get model from cache or create new one
+                model = self._get_import_model(model_name, model_cache)
 
-            # Get existing record by reference
-            # NOTE: we don't validate models here because they are
-            # already validated in the file upload wizard.
-            odoo_record = model.get_by_reference(record_reference)
+                # Get existing record by reference
+                # NOTE: we don't validate models here because they are
+                # already validated in the file upload wizard.
+                odoo_record = model.get_by_reference(record_reference)
 
-            # Skip
-            if self.if_record_exists == "skip" and odoo_record:
-                _logger.info(
-                    "Skipping record '%s' in model '%s'" " because it already exists",
-                    record_reference,
-                    model_name,
-                )
-                continue
+                # Skip
+                if self.if_record_exists == "skip" and odoo_record:
+                    _logger.info(
+                        "Skipping record '%s' in model '%s' because it already exists",
+                        record_reference,
+                        model_name,
+                    )
+                    continue
 
-            # Update existing record
-            elif self.if_record_exists == "update" and odoo_record:
+                # Update existing record
+                if self.if_record_exists == "update" and odoo_record:
+                    try:
+                        record_values = model.with_context(
+                            **self._get_import_model_context(
+                                deferred_m2o_queue,
+                                deferred_x2m_queue,
+                                force_create_related_record=False,
+                            )
+                        )._post_process_yaml_dict_values(record)
+                        odoo_record.with_context(from_yaml=True).write(record_values)
+                        odoo_record_ids.append(odoo_record.id)
+                    except Exception as e:
+                        raise ValidationError(
+                            _(
+                                "Error updating record %(reference)s: %(error)s",
+                                reference=record_reference,
+                                error=e,
+                            )
+                        ) from e
+                    self._tag_deferred_queue_items(
+                        deferred_m2o_queue,
+                        m2o_start,
+                        odoo_record.id,
+                        model._name,
+                    )
+                    self._tag_deferred_queue_items(
+                        deferred_x2m_queue,
+                        x2m_start,
+                        odoo_record.id,
+                        model._name,
+                    )
+                    _logger.info(
+                        "Updated record '%s' in model '%s'",
+                        record_reference,
+                        model_name,
+                    )
+                    continue
+
+                # Or create a new record
+                record_values = model.with_context(
+                    **self._get_import_model_context(
+                        deferred_m2o_queue,
+                        deferred_x2m_queue,
+                        force_create_related_record=self.if_record_exists == "create",
+                    )
+                )._post_process_yaml_dict_values(record)
                 try:
-                    record_values = model.with_context(
-                        force_create_related_record=False,
-                    )._post_process_yaml_dict_values(record)
-                    odoo_record.with_context(
-                        from_yaml=True,
-                    ).write(record_values)
+                    odoo_record = model.with_context(from_yaml=True).create(
+                        record_values
+                    )
                     odoo_record_ids.append(odoo_record.id)
                 except Exception as e:
                     raise ValidationError(
                         _(
-                            "Error updating record %(reference)s: %(error)s",
+                            "Error creating record '%(reference)s' in model"
+                            " '%(model)s': %(error)s",
                             reference=record_reference,
+                            model=model_name,
                             error=e,
                         )
                     ) from e
-                _logger.info(
-                    f"Updated record '{record_reference}' in model '{model_name}'"
+                self._tag_deferred_queue_items(
+                    deferred_m2o_queue, m2o_start, odoo_record.id, model._name
                 )
-                continue
+                self._tag_deferred_queue_items(
+                    deferred_x2m_queue, x2m_start, odoo_record.id, model._name
+                )
+                _logger.info(
+                    "Created record '%s' in model '%s'",
+                    record_reference,
+                    model_name,
+                )
 
-            # Or create a new record
-            record_values = model.with_context(
-                force_create_related_record=self.if_record_exists == "create",
-            )._post_process_yaml_dict_values(record)
-            try:
-                odoo_record = model.with_context(
-                    from_yaml=True,
-                ).create(record_values)
-                odoo_record_ids.append(odoo_record.id)
-            except Exception as e:
-                raise ValidationError(
-                    _(
-                        "Error creating record '%(reference)s' in model"
-                        " '%(model)s': %(error)s",
-                        reference=record_reference,
-                        model=model_name,
-                        error=e,
-                    )
-                ) from e
-            _logger.info(f"Created record '{record_reference}' in model '{model_name}'")
+            self._apply_deferred_m2o_imports(deferred_m2o_queue)
+            self._apply_deferred_x2m_imports(deferred_x2m_queue)
 
         # No records were created or updated
         if not odoo_record_ids:


### PR DESCRIPTION
Handle the import of commands with types "Trigger jet action" and "Create waypoint".
Implement deferred import of related records to ensure referred is created before being referred.

Task 5323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred relation resolution for YAML import/export; expanded YAML fields for commands, jet templates, waypoint templates, and scheduled tasks; improved export ordering and post-processing; new YAML-backed scheduled-task child model and enhanced import wizard with aggregated deferred-resolution reporting.

* **Bug Fixes**
  * Jet template reference on waypoint templates made optional.

* **Tests**
  * Added and extended tests covering deferred resolution, import/export behavior, and aggregated error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->