### PR TITLE
[18.0][FIX] cetmix_tower_server: resolve secrets in files

### DIFF
--- a/cetmix_tower_server/models/cx_tower_file.py
+++ b/cetmix_tower_server/models/cx_tower_file.py
@@ -579,6 +579,23 @@ class CxTowerFile(models.Model):
         """
         self._process("delete", raise_error)
 
+    def _get_secret_parse_context(self):
+        """Build kwargs for secret resolution scoped to this file's server.
+
+        Mirrors the key context prepared in ``cx.tower.server`` command
+        runners so server- and partner-specific secrets resolve the same
+        way on file upload/download/delete as when running commands.
+
+        Returns:
+            dict: ``server_id`` and optionally ``partner_id`` for
+                ``cx.tower.key._parse_code``.
+        """
+        self.ensure_one()
+        key_vals = {"server_id": self.server_id.id}
+        if self.server_id.partner_id:
+            key_vals["partner_id"] = self.server_id.partner_id.id
+        return key_vals
+
     def _process_download(
         self,
         tower_key_obj,
@@ -605,7 +622,9 @@ class CxTowerFile(models.Model):
         """
         self.ensure_one()
         code = self.server_id.download_file(
-            tower_key_obj._parse_code(self.full_server_path),
+            tower_key_obj._parse_code(
+                self.full_server_path, **self._get_secret_parse_context()
+            ),
         )
         if self.file_type == "text" and b"\x00" in code:
             return {
@@ -705,17 +724,22 @@ class CxTowerFile(models.Model):
                     if res:
                         return res
                 elif action == "upload":
+                    key_ctx = file._get_secret_parse_context()
                     if file.file_type == "binary":
                         file_content = b64decode(file.file)
                     else:
-                        file_content = tower_key_obj._parse_code(file.rendered_code)
+                        file_content = tower_key_obj._parse_code(
+                            file.rendered_code, **key_ctx
+                        )
                     file.server_id.upload_file(
                         file_content,
-                        tower_key_obj._parse_code(file.full_server_path),
+                        tower_key_obj._parse_code(file.full_server_path, **key_ctx),
                     )
                 elif action == "delete":
                     file.server_id.delete_file(
-                        tower_key_obj._parse_code(file.full_server_path)
+                        tower_key_obj._parse_code(
+                            file.full_server_path, **file._get_secret_parse_context()
+                        )
                     )
                 else:
                     return False

--- a/cetmix_tower_server/readme/newsfragments/5574.bugfix.md
+++ b/cetmix_tower_server/readme/newsfragments/5574.bugfix.md
@@ -1,0 +1,1 @@
+Fix rendering of server-only secrets when uploading files.

--- a/cetmix_tower_server/tests/test_file.py
+++ b/cetmix_tower_server/tests/test_file.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from odoo import exceptions
 from odoo.exceptions import AccessError
 
@@ -191,6 +193,46 @@ class TestTowerFile(TestTowerCommon):
         """
         self.file.action_push_to_server()
         self.assertEqual(self.file.server_response, "ok")
+
+    def test_upload_file_with_server_only_secret(self):
+        """Server-only secrets must resolve when uploading a file."""
+        secret = self.Key.create(
+            {
+                "name": "Server Only Secret",
+                "reference": "SERVER_ONLY_SECRET",
+                "key_type": "s",
+            }
+        )
+        self.KeyValue.create(
+            {
+                "key_id": secret.id,
+                "secret_value": "server_secret_value",
+                "server_id": self.server_test_1.id,
+            }
+        )
+        file_record = self.File.create(
+            {
+                "name": "secret.txt",
+                "source": "tower",
+                "server_id": self.server_test_1.id,
+                "server_dir": "/tmp",
+                "code": "password=#!cxtower.secret.SERVER_ONLY_SECRET!#",
+            }
+        )
+
+        uploaded = {}
+
+        def capture_upload(server_self, data, remote_path, from_path=False):
+            uploaded["data"] = data
+            uploaded["path"] = remote_path
+            return MagicMock()
+
+        with patch.object(type(self.server_test_1), "upload_file", new=capture_upload):
+            file_record.upload(raise_error=True)
+
+        self.assertEqual(file_record.server_response, "ok")
+        self.assertEqual(uploaded["data"], "password=server_secret_value")
+        self.assertNotIn("None", uploaded["data"])
 
     def test_delete_file(self):
         """


### PR DESCRIPTION
File upload, download and delete called _parse_code without the server/partner key context that command runners pass. Server-scoped secrets therefore failed to resolve and could end up as None in the uploaded content or remote path.

Pass the same parse context so secrets resolve consistently.

Task 5574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected file uploads so server-only secrets are properly resolved in rendered file content.
  - Improved secret handling for file uploads, downloads, and deletions using the appropriate server and partner context.
  - Prevented unresolved secret references from appearing as “None” in uploaded files.

- **Tests**
  - Added regression coverage for uploads containing server-only secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->