### PR TITLE
[18.0][FIX] cetmix_tower_server: drop re.template, removed in Python 3.13

### DIFF
--- a/cetmix_tower_server/models/cx_tower_command.py
+++ b/cetmix_tower_server/models/cx_tower_command.py
@@ -39,23 +39,27 @@ hashlib = wrap_module(
         "new",
     ],
 )
-re = wrap_module(
-    __import__("re"),
-    [
-        "match",
-        "fullmatch",
-        "search",
-        "sub",
-        "subn",
-        "split",
-        "findall",
-        "finditer",
-        "compile",
-        "template",
-        "escape",
-        "error",
-    ],
-)
+_re_module = __import__("re")
+_re_attributes = [
+    "match",
+    "fullmatch",
+    "search",
+    "sub",
+    "subn",
+    "split",
+    "findall",
+    "finditer",
+    "compile",
+    "escape",
+    "error",
+]
+# `re.template` was deprecated in Python 3.11 and removed in 3.13. Keep
+# exposing it where the interpreter still provides it, so commands relying on
+# it keep working, without breaking the import on newer Pythons.
+if hasattr(_re_module, "template"):
+    _re_attributes.append("template")
+
+re = wrap_module(_re_module, _re_attributes)
 hmac = wrap_module(
     __import__("hmac"),
     ["new", "compare_digest"],

--- a/cetmix_tower_server/models/cx_tower_variable.py
+++ b/cetmix_tower_server/models/cx_tower_variable.py
@@ -13,23 +13,27 @@ _lt = LazyTranslate(__name__, default_lang="en_US")
 
 _logger = logging.getLogger(__name__)
 
-re = wrap_module(
-    __import__("re"),
-    [
-        "match",
-        "fullmatch",
-        "search",
-        "sub",
-        "subn",
-        "split",
-        "findall",
-        "finditer",
-        "compile",
-        "template",
-        "escape",
-        "error",
-    ],
-)
+_re_module = __import__("re")
+_re_attributes = [
+    "match",
+    "fullmatch",
+    "search",
+    "sub",
+    "subn",
+    "split",
+    "findall",
+    "finditer",
+    "compile",
+    "escape",
+    "error",
+]
+# `re.template` was deprecated in Python 3.11 and removed in 3.13. Keep
+# exposing it where the interpreter still provides it, so commands relying on
+# it keep working, without breaking the import on newer Pythons.
+if hasattr(_re_module, "template"):
+    _re_attributes.append("template")
+
+re = wrap_module(_re_module, _re_attributes)
 
 # Maximum recursion depth for variable value rendering
 # to prevent infinite loops

--- a/cetmix_tower_server/readme/newsfragments/3973.bugfix
+++ b/cetmix_tower_server/readme/newsfragments/3973.bugfix
@@ -1,0 +1,1 @@
+Remove the deprecated 'template' method from the 're' lib import


### PR DESCRIPTION
## Problem

`cx_tower_variable.py` and `cx_tower_command.py` both wrap the `re` module for `safe_eval` and whitelist **`re.template`**. That function was deprecated in Python 3.11 and **removed in 3.13**, so on 3.13+ neither module can be imported:

```
File ".../cetmix_tower_server/models/cx_tower_variable.py", line 16, in <module>
    re = wrap_module(
File ".../odoo/tools/safe_eval.py", line 471, in __init__
    target = getattr(module, attrib)
AttributeError: module 're' has no attribute 'template'. Did you mean: 'replace'?
```

The failure is at **import** time, so `-i cetmix_tower` aborts part-way through loading the module graph and leaves the database half-initialised. There is no partial degradation — the module simply cannot install.

## Reproduce

Install `cetmix_tower` on Odoo 18.0 running on Python 3.13 or newer. Encountered on Ubuntu 26.04 / Python 3.14 while setting up a control plane.

This affects any host on Python 3.13+ — Ubuntu 25.10 onward, Debian trixie onward — so it becomes more common over time, not less.

## Fix

Remove `"template"` from both `wrap_module()` whitelists. Two lines.

`re.template` was undocumented and deprecated for two releases, so this takes away nothing anyone can be relying on: on 3.13+ it cannot be called at all, and Odoo's own `safe_eval` does not expose it either.

If you would rather keep it available on older interpreters, the alternative is to build the list conditionally:

```python
_RE_ATTRS = ["match", "fullmatch", ..., "escape", "error"]
if hasattr(_re, "template"):
    _RE_ATTRS.append("template")
```

Happy to switch to that if you prefer it.

## Scope

I checked **every** `wrap_module()` call in the repo against Python 3.14, resolving each wrapped module and asserting each whitelisted attribute exists. `re.template` in these two files is the only one affected — `requests`, `json`, `hashlib`, `hmac`, `urllib.parse`, `tldextract` and the `dns.*` wrappers all resolve cleanly.

No version bump included, since the post-merge bot appears to handle that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Python versions by handling the unavailable `re.template` feature safely.
  * Preserved supported regular-expression functionality, including `re.template` where available.
  * Fixed command evaluation and variable validation imports that could fail on Python versions without `re.template`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->